### PR TITLE
Add entry-level diagram support using mermaidjs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,11 @@ When you open a pull request, you will get a preview of your changes (useful if 
 
 If the spellchecker is rejecting words that are valid (such as technology terms), double check the spelling and capitalisation, then add the word to ``.github/workflows/styles/Docs/accept.txt``.
 
+Diagrams
+~~~~~~~~
+
+Diagrams use `sphinxcontrib-mermaid <https://github.com/mgaitan/sphinxcontrib-mermaid>`_ and `mermaid.js <https://mermaid-js.github.io/mermaid/#/>`_ syntax.
+
 License
 -------
 

--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,8 @@ author = 'Aiven Team'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_panels"
+    'sphinx_panels',
+    'sphinxcontrib.mermaid'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,7 +1,17 @@
 Overview
 ========
 
-The API is excellent
+The Aiven API allows you to communicate with our servers from any client.
+
+.. mermaid::
+
+    sequenceDiagram
+        participant Client
+        participant Server
+
+        Client->>Server: Request
+        Server->>Client: Response
+
 
 .. toctree::
     :glob:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-autobuild
 sphinx-panels
+sphinxcontrib-mermaid


### PR DESCRIPTION
Add the https://github.com/mgaitan/sphinxcontrib-mermaid extension and a sample diagram on the API page to try the feature.