### PR TITLE
Move navigation to a single file

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,25 @@
+root: index
+options:
+  maxdepth: 1
+
+entries:
+  # --------- GLOBAL -----------
+  - file: docs/products/index
+
+  # CLI
+  - file: docs/cli
+
+  # API
+  - file: docs/api/index
+    title: Aiven API
+    entries:
+      - glob: docs/api/*
+
+  # -------- PRODUCT-SPECIFIC --------
+  - file: docs/products/kafka/index
+
+
+  # -------- AUXILIARY
+  - file: docs/community
+
+

--- a/conf.py
+++ b/conf.py
@@ -29,7 +29,8 @@ author = 'Aiven Team'
 # ones.
 extensions = [
     'sphinx_panels',
-    'sphinxcontrib.mermaid'
+    'sphinxcontrib.mermaid',
+    'sphinx_external_toc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -42,9 +42,3 @@ Aiven's API and Postman
 
 If you prefer an even more friendly tool, we have a blog post about `using Postman with Aiven's API <https://aiven.io/blog/your-first-aiven-api-call>`_ including how to import a Postman collection and spin up Aiven services with Postman.
 
-.. toctree::
-    :glob:
-    :hidden:
-    :maxdepth: 1
-
-    *

--- a/index.rst
+++ b/index.rst
@@ -69,18 +69,6 @@ Aiven offers everything you'd expect but here are some highlights:
 
 * Database **forking**. Create a fork of your database to test out migrations, upgrades, or anything else you'd like to try in a safe space before you go ahead.
 
-.. toctree::
-    :hidden:
-    :titlesonly:
-    :maxdepth: 2
-
-    Aiven Developer<self>
-    API<docs/api/index>
-    CLI<docs/cli>
-    docs/products/index
-    docs/products/kafka/index
-
-    docs/community
 
 .. |icon-postgres| image:: images/icon-pg.svg
    :width: 36px

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx
 sphinx-autobuild
 sphinx-panels
 sphinxcontrib-mermaid
+sphinx-external-toc


### PR DESCRIPTION
The `toctree` notation in sphinx can be pretty difficult to work with, so instead we'll use the external table of contents pattern and simply maintain everything in `_toc.yml`, so that it is easy to see and understand in one place.