### PR TITLE
Add the Vale task (make spell) to make.bat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,22 @@ Start the HTML version with::
 
 Your preview should be at http://localhost:8000 (if anything doesn't seem to re-render well, the navigation seems particularly unreliable, try ``make clean`` and then ``make livehtml`` again).
 
+Windows users
+-------------
+
+Replace all `make` commands with `./make` - this uses the `make.bat` file instead of `Makefile` but the functionality should be equivalent.
+
 Making changes
 --------------
 
 Please make changes! Even small fixes are very welcome. The content is in the ``docs/`` folder, in `ReStructuredText <https://docutils.sourceforge.io/rst.html>`_.
 
-When you open a pull request, you will get a preview of your changes (useful if you or someone you want to show the work to does not have the tool set up locally). The process also runs some spelling and link checking tasks. You can also run those locally:
+When you open a pull request, you will get a preview of your changes (useful if you or someone you want to show the work to does not have the tool set up locally). The process also runs some spelling and link checking tasksi so please check the output of the build if it fails.
+
+Running build tasks locally
+---------------------------
+
+To run the spell check locally, you will need to have [Vale](https://github.com/errata-ai/vale) installed on your computer and available on your path.
 
 * Check links: ``make linkcheck``
 * Check spelling: ``make spell``

--- a/make.bat
+++ b/make.bat
@@ -16,6 +16,11 @@ if "%1" == "livehtml" (
 	sphinx-autobuild %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %2
 )
 
+if "%1" == "spell" (
+	vale %SOURCEDIR%/index.rst
+	vale %SOURCEDIR%/docs
+)
+
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.


### PR DESCRIPTION
# What changed, and why it matters

The `make.bat` file is the makefile alternative for Windows users, and it was missing the `make spell` feature. This pull request adds the feature and also updates the README to include instructions on using `make.bat` for Windows users, and to make the external Vale dependency clearer.

