### PR TITLE
Move postgres reference items into a group, fix CSS to support this

### DIFF
--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -394,43 +394,23 @@ code.literal {
   padding: 0.75rem 1.25rem;
 }
 
-#howto > .toctree-wrapper > ul > li.toctree-l1,
-#concepts > .toctree-wrapper > ul > li.toctree-l1 {
+.toctree-wrapper > ul > li.toctree-l1 {
   list-style: none !important;
   margin: 12px;
   font-weight: bold;
   font-size: 18px;
 }
 
-#howto > .toctree-wrapper > ul > .toctree-l1 > ul > .toctree-l2,
-#concepts > .toctree-wrapper > ul > .toctree-l1 > ul > .toctree-l2,
-#concepts
-  > .toctree-wrapper
-  > ul
-  > .toctree-l1
-  > ul
-  > .toctree-l2
-  > ul
-  > .toctree-l3 {
+.toctree-wrapper > ul > .toctree-l1 > ul > .toctree-l2,
+.toctree-wrapper > ul > .toctree-l1 > ul > .toctree-l2 > ul > .toctree-l3 {
   list-style: none !important;
   font-size: 16px;
   font-weight: 300;
 }
 
-#howto > .toctree-wrapper > ul > .toctree-l1 > a.reference:hover,
-#concepts > .toctree-wrapper > ul > .toctree-l1 > a.reference:hover {
+.toctree-wrapper > ul > .toctree-l1 > a.reference:hover,
+.toctree-wrapper > ul > .toctree-l1 > ul > .toctree-l2 > a.reference:hover {
   color: var(--linkActive);
   text-decoration-color: var(--linkActive) !important;
 }
 
-#howto,
-#concepts
-  > .toctree-wrapper
-  > ul
-  > .toctree-l1
-  > ul
-  > .toctree-l2
-  > a.reference:hover {
-  color: var(--linkActive);
-  text-decoration-color: var(--linkActive) !important;
-}

--- a/_toc.yml
+++ b/_toc.yml
@@ -26,11 +26,10 @@ entries:
         title: HowTo
         entries:
           - glob: docs/products/postgresql/howto/*
-      - file: docs/products/postgresql/reference/list-of-advanced-params
-      - file: docs/products/postgresql/reference/list-of-extensions
-      - file: docs/products/postgresql/reference/pg-connection-limits
-      - file: docs/products/postgresql/reference/terminology
-      - file: docs/products/postgresql/reference/pg-metrics
+      - file: docs/products/postgresql/reference
+        title: Reference
+        entries:
+          - glob: docs/products/postgresql/reference/*
 
   - file: docs/products/m3db/index
     title: M3DB

--- a/docs/products/postgresql/reference.rst
+++ b/docs/products/postgresql/reference.rst
@@ -1,0 +1,7 @@
+Reference
+=========
+
+References for PostgreSQL:
+
+.. tableofcontents::
+


### PR DESCRIPTION
# What changed, and why it matters

Now that we have a number of PostgreSQL reference articles, the nav is getting harder to manage. Nest the reference in its own section, and make the CSS styling on the listing pages (Concept, HowTo) more generic to cover this page too.