### PR TITLE
Add timestamps from git history dates to footer

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -78,6 +78,10 @@
               {{ _('Show Source') }}
             </a>
           {%- endif %}
+          {%- if gitstamp %}
+            |
+            Last updated on {{ gitstamp }}
+          {%- endif %}
         </div>
         {% endblock footer %}
       </footer>

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -80,7 +80,7 @@
           {%- endif %}
           {%- if gitstamp %}
             |
-            Last updated on {{ gitstamp }}
+            Last updated: {{ gitstamp }}
           {%- endif %}
         </div>
         {% endblock footer %}

--- a/conf.py
+++ b/conf.py
@@ -42,7 +42,7 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*']
 
 
-gitstamp_fmt = "%b %d, %Y"
+gitstamp_fmt = "%B %Y"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -30,6 +30,7 @@ extensions = [
     'sphinxcontrib.mermaid',
     'sphinx_external_toc',
     'sphinx_copybutton',
+    'sphinx_gitstamp',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -39,6 +40,9 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*']
+
+
+gitstamp_fmt = "%b %d, %Y"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ sphinx-panels==0.5.2
 sphinxcontrib-mermaid==0.6.3
 sphinx-external-toc==0.1.0
 sphinx-copybutton==0.4.0
+sphinx_gitstamp== 0.3.1
 beautifulsoup4==4.9.3
 elasticsearch==7.13.1
 requests==2.25.1


### PR DESCRIPTION
# What changed, and why it matters

Introduces a plugin `sphinx_gitstamp` that uses the git history to add the correct last updated date to each page footer, to help users understand the freshness of the information.


