### PR TITLE
Make code snippets copyable

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -29,6 +29,7 @@ extensions = [
     'sphinx_panels',
     'sphinxcontrib.mermaid',
     'sphinx_external_toc',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sphinx-autobuild==2021.3.14
 sphinx-panels==0.5.2
 sphinxcontrib-mermaid==0.6.3
 sphinx-external-toc==0.1.0
+sphinx-copybutton==0.4.0
 beautifulsoup4==4.9.3
 elasticsearch==7.13.1
 requests==2.25.1


### PR DESCRIPTION
# What changed, and why it matters

Add the [Sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton) plugin so that all code snippets become copyable
