### PR TITLE
Move to a nested structure for PostgreSQL HowTo content

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -15,6 +15,7 @@ hardcoded
 [Hh]ostname
 jq
 [Nn]amespace
+npm
 parallelization
 pgAdmin
 PgBouncer

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -15,6 +15,7 @@ hardcoded
 [Hh]ostname
 jq
 [Nn]amespace
+NodeJS
 npm
 parallelization
 pgAdmin

--- a/_toc.yml
+++ b/_toc.yml
@@ -25,7 +25,34 @@ entries:
       - file: docs/products/postgresql/howto
         title: HowTo
         entries:
-          - glob: docs/products/postgresql/howto/*
+          - file: docs/products/postgresql/howto/list-code-samples
+            entries:
+              - file: docs/products/postgresql/howto/connect-go
+              - file: docs/products/postgresql/howto/connect-node
+              - file: docs/products/postgresql/howto/connect-php
+              - file: docs/products/postgresql/howto/connect-python
+          - file: docs/products/postgresql/howto/list-dba-tasks
+            entries:
+              - file: docs/products/postgresql/howto/upgrade
+              - file: docs/products/postgresql/howto/manage-extensions
+              - file: docs/products/postgresql/howto/create-manual-backups
+              - file: docs/products/postgresql/howto/restore-backup
+              - file: docs/products/postgresql/howto/migrate-cloud-region
+              - file: docs/products/postgresql/howto/claim-public-schema-ownership
+              - file: docs/products/postgresql/howto/manage-pool
+              - file: docs/products/postgresql/howto/pgbouncer-stats
+          - file: docs/products/postgresql/howto/list-replication-migration
+            entries:
+              - file: docs/products/postgresql/howto/create-read-replica
+              - file: docs/products/postgresql/howto/setup-logical-replication
+              - file: docs/products/postgresql/howto/migrate-aiven-db-migrate
+              - file: docs/products/postgresql/howto/migrate-pg-dump-restore
+          - file: docs/products/postgresql/howto/list-integrations
+            entries:
+              - file: docs/products/postgresql/howto/connect-psql
+              - file: docs/products/postgresql/howto/connect-pgadmin
+              - file: docs/products/postgresql/howto/visualize-grafana
+              - file: docs/products/postgresql/howto/report-metrics-grafana
       - file: docs/products/postgresql/reference
         title: Reference
         entries:

--- a/code/products/postgresql/connect.js
+++ b/code/products/postgresql/connect.js
@@ -1,0 +1,26 @@
+
+const fs = require('fs');
+const pg = require('pg');
+
+const config = {
+    connectionString: POSTGRESQL_URI
+    ssl: {
+        rejectUnauthorized: false,
+    },
+};
+
+const client = new pg.Client(config);
+client.connect(function (err) {
+    if (err)
+        throw err;
+    client.query("SELECT VERSION()", [], function (err, result) {
+        if (err)
+            throw err;
+
+        console.log(result.rows[0]);
+        client.end(function (err) {
+            if (err)
+                throw err;
+        });
+    });
+});

--- a/code/products/postgresql/connect.php
+++ b/code/products/postgresql/connect.php
@@ -1,0 +1,18 @@
+<?php
+
+$uri = POSTGRESQL_URI;
+
+$fields = parse_url($uri);
+
+// build the DSN including SSL settings
+$conn = "pgsql:";
+$conn .= "host=" . $fields["host"];
+$conn .= ";port=" . $fields["port"];;
+$conn .= ";dbname=defaultdb";
+$conn .= ";sslmode=verify-ca;sslrootcert=ca.pem";
+
+$db = new PDO($conn, $fields["user"], $fields["pass"]);
+
+foreach ($db->query("SELECT VERSION()") as $row) {
+    print($row[0]);
+}

--- a/docs/products/postgresql/howto/connect-node.rst
+++ b/docs/products/postgresql/howto/connect-node.rst
@@ -1,7 +1,7 @@
-Connect with Go
----------------
+Connect with NodeJS
+-------------------
 
-This example connects to PostgreSQL service from Go, making use of the ``pg`` library.
+This example connects to PostgreSQL service from NodeJS, making use of the ``pg`` module.
 
 Variables
 '''''''''
@@ -19,25 +19,24 @@ Pre-requisites
 
 For this example you will need:
 
-1. The Go ``pq`` library::
+1. The npm ``pg`` library::
 
-    go get github.com/lib/pq
-
+    npm install pg 
 
 
 Code
 ''''
 
-Add the following to ``main.go`` and replace the placeholder with the PostgreSQL URI:
+Add the following to ``index.js`` and replace the placeholder with the PostgreSQL URI:
 
-.. literalinclude:: /code/products/postgresql/connect.go
+.. literalinclude:: /code/products/postgresql/connect.js
 
 This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response
 
 To run the code::
 
-    go run main.go
+    node index.php
 
 If the script runs successfully, the outputs should be the PostgreSQL version running in your service like::
 
-    Version: PostgreSQL 13.3 on x86_64-pc-linux-gnu, compiled by gcc, a 68c5366192 p 6520304dc1, 64-bit
+    PostgreSQL 13.3 on x86_64-pc-linux-gnu, compiled by gcc, a 68c5366192 p 6520304dc1, 64-bit

--- a/docs/products/postgresql/howto/connect-node.rst
+++ b/docs/products/postgresql/howto/connect-node.rst
@@ -1,7 +1,7 @@
 Connect with NodeJS
 -------------------
 
-This example connects to PostgreSQL service from NodeJS, making use of the ``pg`` module.
+This example connects to PostgreSQL service from NodeJS, making use of the ``pg`` package.
 
 Variables
 '''''''''
@@ -19,7 +19,7 @@ Pre-requisites
 
 For this example you will need:
 
-1. The npm ``pg`` library::
+1. The npm ``pg`` package::
 
     npm install pg 
 

--- a/docs/products/postgresql/howto/connect-php.rst
+++ b/docs/products/postgresql/howto/connect-php.rst
@@ -1,7 +1,7 @@
-Connect with Go
----------------
+Connect with PHP
+----------------
 
-This example connects to PostgreSQL service from Go, making use of the ``pg`` library.
+This example connects to PostgreSQL service from PHP, making use of the built-in PDO module.
 
 Variables
 '''''''''
@@ -14,30 +14,19 @@ Variable                Description
 ``POSTGRESQL_URI``      URL for PostgreSQL connection, from the service overview page
 ==================      =============================================================
 
-Pre-requisites
-''''''''''''''
-
-For this example you will need:
-
-1. The Go ``pq`` library::
-
-    go get github.com/lib/pq
-
-
-
 Code
 ''''
 
-Add the following to ``main.go`` and replace the placeholder with the PostgreSQL URI:
+Add the following to ``index.php`` and replace the placeholder with the PostgreSQL URI:
 
-.. literalinclude:: /code/products/postgresql/connect.go
+.. literalinclude:: /code/products/postgresql/connect.php
 
 This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response
 
 To run the code::
 
-    go run main.go
+    php index.php
 
 If the script runs successfully, the outputs should be the PostgreSQL version running in your service like::
 
-    Version: PostgreSQL 13.3 on x86_64-pc-linux-gnu, compiled by gcc, a 68c5366192 p 6520304dc1, 64-bit
+    PostgreSQL 13.3 on x86_64-pc-linux-gnu, compiled by gcc, a 68c5366192 p 6520304dc1, 64-bit

--- a/docs/products/postgresql/howto/connect-python.rst
+++ b/docs/products/postgresql/howto/connect-python.rst
@@ -34,7 +34,7 @@ Add the following to ``main.py`` and replace the placeholders with values for yo
 .. literalinclude:: /code/products/postgresql/connect.py
 
 
-This code creates an PostgreSQL client and connects to the database. Then runs a query checking the database version and prints the response
+This code creates a PostgreSQL client and connects to the database. Then runs a query checking the database version and prints the response
 
 To run the code::
 

--- a/docs/products/postgresql/howto/list-code-samples.rst
+++ b/docs/products/postgresql/howto/list-code-samples.rst
@@ -1,0 +1,4 @@
+Code Samples
+============
+
+.. tableofcontents::

--- a/docs/products/postgresql/howto/list-code-samples.rst
+++ b/docs/products/postgresql/howto/list-code-samples.rst
@@ -1,4 +1,4 @@
-Code Samples
+Code samples
 ============
 
 .. tableofcontents::

--- a/docs/products/postgresql/howto/list-dba-tasks.rst
+++ b/docs/products/postgresql/howto/list-dba-tasks.rst
@@ -1,0 +1,4 @@
+DBA Tasks
+=========
+
+.. tableofcontents::

--- a/docs/products/postgresql/howto/list-dba-tasks.rst
+++ b/docs/products/postgresql/howto/list-dba-tasks.rst
@@ -1,4 +1,4 @@
-DBA Tasks
+DBA tasks
 =========
 
 .. tableofcontents::

--- a/docs/products/postgresql/howto/list-integrations.rst
+++ b/docs/products/postgresql/howto/list-integrations.rst
@@ -1,0 +1,4 @@
+Integrations
+============
+
+.. tableofcontents::

--- a/docs/products/postgresql/howto/list-replication-migration.rst
+++ b/docs/products/postgresql/howto/list-replication-migration.rst
@@ -1,4 +1,4 @@
-Replication and Migrations
-==========================
+Replication and migration
+=========================
 
 .. tableofcontents::

--- a/docs/products/postgresql/howto/list-replication-migration.rst
+++ b/docs/products/postgresql/howto/list-replication-migration.rst
@@ -1,0 +1,4 @@
+Replication and Migrations
+==========================
+
+.. tableofcontents::


### PR DESCRIPTION
# What changed, and why it matters

We have tooooooooo many items in the postgres/howto section of the navigation. This PR adds some structure to this and splits things up a bit - also adds some additional code samples (these are in their own commit and could be merged separately if that would be better).
