### PR TITLE
Add reference documentation for avn project command

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -7,6 +7,8 @@ entries:
   - file: docs/tools/index
     entries:
       - file: docs/tools/cli
+        entries:
+        - glob: docs/tools/cli/*
       - file: docs/tools/api/index
         title: Aiven API
         entries:

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -92,6 +92,8 @@ Manage all the projects on your Aiven account, and switch which one is the defau
 
 Download the CA cert for this project (CA certs are common for all services in a project).
 
+:doc:`See detailed command information <cli/project>`.
+
 ``service``
 '''''''''''
 

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -1,0 +1,249 @@
+:orphan:
+
+Command reference: ``avn project``
+==================================
+
+Work with project details
+-------------------------
+
+Commands for managing projects and using them with ``avn`` commands.
+
+
+``avn project details``
+'''''''''''''''''''''''
+
+Fetch project details
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--project``
+    - The project to fetch details for
+
+**Example:** show the details of the currently-selected project::
+
+  avn project details
+
+
+**Example:** show the details of a named project::
+
+  avn project details --project my-project
+
+
+``avn project switch``
+''''''''''''''''''''''
+
+Set the default project to use with ``avn``
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--project``
+    - The project to use when a project isn't specified for an ``avn`` command
+
+**Example:** change to use the project called ``my-project`` for all commands where another ``--project`` parameter isn't supplied::
+
+  avn project switch --project my-project
+
+
+``avn project list``
+''''''''''''''''''''
+
+List all the projects that you have access to.
+
+**Example:** list all the projects available to use with a ``--project`` command switch::
+
+  avn project list
+
+
+``avn project create`` and ``avn project update``
+'''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a new project with ``create`` or change the settings with ``update``.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``project_name`` (required for ``create``)
+    - Note: this is a positional argument, not a switch
+  * - ``--project`` (required for ``update``)
+    - The project to amend, use with ``update`` only
+  * - ``--name`` (``update`` only)
+    - Supply a new name for the project
+  * - ``--account-id``
+    - The account to create the project in
+  * - ``--billing-group-id``
+    - Billing group ID to use
+  * - ``--card-id``
+    - The card ID (see ``avn card``)
+  * - ``--cloud``
+    - The cloud to use by default (see ``avn cloud``)
+  * - ``--no-fail-if-exists``
+    - Makes the command safe to run repeatedly, it will succeed if a project of this name already exists.
+  * - ``--copy-from-project`` (``create`` only)
+    - Project name to use as a template
+  * - ``--country-code``
+    - `Code <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements>`_ for the billing country
+  * - ``--billing-address``
+    - Address to bill to
+  * - ``--billing-extra-text``
+    - Information to include with an invoice such as a cost center number
+  * - ``--billing-currency``
+    - The currency to bill in. The choices are: "AUD" "CAD" "CHF" "DKK" "EUR" "GBP" "NOK" "SEK" "USD"
+  * - ``--vat-id``
+    - VAT id for this project
+  * - ``--billing-email``
+    - Email for the billing contact
+  * - ``--tech-email``
+    - Email for the technical contact
+
+**Example:** Create a project named ``my-project``::
+
+  avn project create my-project
+
+**Example:** Create a project in a specific account using ``my-project`` as a template and setting the email address for the technical contact::
+
+  avn project create \
+    --create-project-from my-project \
+    --account-id abcdef0123456789 \
+    --tech-email geek@example.com \
+    my-other-project
+
+**Example:** Rename a project::
+
+  avn project update
+    --project my-project
+    --name my-better-named-project
+
+
+
+``avn project delete``
+''''''''''''''''''''''
+
+Delete an empty project. If the project isn't empty, remove the services in it first.
+
+**Example:** Delete ``my-project``::
+
+  avn project delete my-project
+
+
+Project certificate management
+------------------------------
+
+CA certificates are managed at the project level.
+
+``avn project ca-get``
+''''''''''''''''''''''
+
+Download the CA cert for this project, the certificate will be saved in the file name you supply.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--project``
+    - The project to fetch details for
+  * - ``--target-filepath``
+    - File name, including path, to use
+
+**Example:** Download the CA certificate for the current project and save it in a file in the current directory called ``ca.pem``::
+
+  avn project ca-get --target-filepath ca.pem
+
+
+Users and invitations
+---------------------
+
+Manage user access to the project.
+
+``avn project invite-list``
+'''''''''''''''''''''''''''
+
+See the open invitations to the project.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--project``
+    - The project to show invitations for
+
+**Example:** list the invitations for the current project::
+
+  avn project invite-list
+
+
+``avn project user-list``
+'''''''''''''''''''''''''
+
+See the users with access to the project
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--project``
+    - The project to show users for
+
+
+**Example:** list the users with access to project ``my-project``::
+
+  avn project user-list --project my-project
+
+``avn project user-invite``
+'''''''''''''''''''''''''''
+
+Send an invitation to a user (by email) to join a project
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``email`` (required)
+    - Note: this is a positional argument
+  * - ``--project``
+    - The project to invite the user to
+  * - ``--role``
+    - Can be "operator", "developer" or "admin"
+
+**Example:** invite an important person to be an admin on the currently-selected project::
+
+  avn project user-invite --role admin boss@example.com
+
+
+``avn project user-remove``
+'''''''''''''''''''''''''''
+
+Remove from the project a user with the supplied email address.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``email`` (required)
+    - Note: this is a positional argument
+  * - ``--project``
+    - The project to remove the user from
+
+**Example:** Remove the user with email ``alice@example.com`` from project ``my-project``::
+
+  avn project user-remove --project my-project alice@example.com

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -47,7 +47,7 @@ Set the default project to use with ``avn``
   * - ``--project``
     - The project to use when a project isn't specified for an ``avn`` command
 
-**Example:** change to use the project called ``my-project`` for all commands where another ``--project`` parameter isn't supplied::
+**Example:** change to use the project called ``my-project`` as default for all commands where the ``--project`` parameter isn't supplied::
 
   avn project switch --project my-project
 
@@ -110,7 +110,7 @@ Create a new project with ``create`` or change the settings with ``update``.
 
   avn project create my-project
 
-**Example:** Create a project in a specific account using ``my-project`` as a template and setting the email address for the technical contact::
+**Example:** Create a project in a specific account using ``my-project`` as a template and set the email address for the technical contact::
 
   avn project create \
     --create-project-from my-project \
@@ -130,6 +130,9 @@ Create a new project with ``create`` or change the settings with ``update``.
 ''''''''''''''''''''''
 
 Delete an empty project. If the project isn't empty, remove the services in it first.
+
+.. Note::
+    Aiven doesn't allow the deletion of non-empty projects as safeguard against accidental code execution.
 
 **Example:** Delete ``my-project``::
 

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Command reference: ``avn project``
 ==================================
 
@@ -23,12 +21,16 @@ Fetch project details
   * - ``--project``
     - The project to fetch details for
 
-**Example:** show the details of the currently-selected project::
+**Example:** Show the details of the currently-selected project.
+
+::
 
   avn project details
 
 
-**Example:** show the details of a named project::
+**Example:** Show the details of a named project.
+
+::
 
   avn project details --project my-project
 
@@ -47,7 +49,9 @@ Set the default project to use with ``avn``
   * - ``--project``
     - The project to use when a project isn't specified for an ``avn`` command
 
-**Example:** change to use the project called ``my-project`` as default for all commands where the ``--project`` parameter isn't supplied::
+**Example:** Change to use the project called ``my-project`` as default for all commands where the ``--project`` parameter isn't supplied.
+
+::
 
   avn project switch --project my-project
 
@@ -57,7 +61,9 @@ Set the default project to use with ``avn``
 
 List all the projects that you have access to.
 
-**Example:** list all the projects available to use with a ``--project`` command switch::
+**Example:** list all the projects available to use with a ``--project`` command switch.
+
+::
 
   avn project list
 
@@ -106,11 +112,15 @@ Create a new project with ``create`` or change the settings with ``update``.
   * - ``--tech-email``
     - Email for the technical contact
 
-**Example:** Create a project named ``my-project``::
+**Example:** Create a project named ``my-project``.
+
+::
 
   avn project create my-project
 
-**Example:** Create a project in a specific account using ``my-project`` as a template and set the email address for the technical contact::
+**Example:** Create a project in a specific account using ``my-project`` as a template and set the email address for the technical contact.
+
+::
 
   avn project create \
     --create-project-from my-project \
@@ -118,7 +128,9 @@ Create a new project with ``create`` or change the settings with ``update``.
     --tech-email geek@example.com \
     my-other-project
 
-**Example:** Rename a project::
+**Example:** Rename a project.
+
+::
 
   avn project update
     --project my-project
@@ -134,7 +146,9 @@ Delete an empty project. If the project isn't empty, remove the services in it f
 .. Note::
     Aiven doesn't allow the deletion of non-empty projects as safeguard against accidental code execution.
 
-**Example:** Delete ``my-project``::
+**Example:** Delete ``my-project``.
+
+::
 
   avn project delete my-project
 
@@ -160,7 +174,9 @@ Download the CA cert for this project, the certificate will be saved in the file
   * - ``--target-filepath``
     - File name, including path, to use
 
-**Example:** Download the CA certificate for the current project and save it in a file in the current directory called ``ca.pem``::
+**Example:** Download the CA certificate for the current project and save it in a file in the current directory called ``ca.pem``.
+
+::
 
   avn project ca-get --target-filepath ca.pem
 
@@ -184,7 +200,9 @@ See the open invitations to the project.
   * - ``--project``
     - The project to show invitations for
 
-**Example:** list the invitations for the current project::
+**Example:** List the invitations for the current project.
+
+::
 
   avn project invite-list
 
@@ -204,7 +222,9 @@ See the users with access to the project
     - The project to show users for
 
 
-**Example:** list the users with access to project ``my-project``::
+**Example:** List the users with access to project ``my-project``.
+
+::
 
   avn project user-list --project my-project
 
@@ -226,7 +246,9 @@ Send an invitation to a user (by email) to join a project
   * - ``--role``
     - Can be "operator", "developer" or "admin"
 
-**Example:** invite an important person to be an admin on the currently-selected project::
+**Example:** Invite an important person to be an admin on the currently-selected project.
+
+::
 
   avn project user-invite --role admin boss@example.com
 
@@ -247,6 +269,8 @@ Remove from the project a user with the supplied email address.
   * - ``--project``
     - The project to remove the user from
 
-**Example:** Remove the user with email ``alice@example.com`` from project ``my-project``::
+**Example:** Remove the user with email ``alice@example.com`` from project ``my-project``.
+
+::
 
   avn project user-remove --project my-project alice@example.com

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -1,6 +1,9 @@
 Command reference: ``avn project``
 ==================================
 
+Here you'll find the full list of commands for ``avn project``.
+
+
 Work with project details
 -------------------------
 
@@ -10,7 +13,7 @@ Commands for managing projects and using them with ``avn`` commands.
 ``avn project details``
 '''''''''''''''''''''''
 
-Fetch project details
+Fetches project details.
 
 .. list-table::
   :header-rows: 1
@@ -21,7 +24,7 @@ Fetch project details
   * - ``--project``
     - The project to fetch details for
 
-**Example:** Show the details of the currently-selected project.
+**Example:** Show the details of the currently selected project.
 
 ::
 
@@ -38,7 +41,7 @@ Fetch project details
 ``avn project switch``
 ''''''''''''''''''''''
 
-Set the default project to use with ``avn``
+Sets the default project to use with ``avn``.
 
 .. list-table::
   :header-rows: 1
@@ -59,9 +62,9 @@ Set the default project to use with ``avn``
 ``avn project list``
 ''''''''''''''''''''
 
-List all the projects that you have access to.
+Lists all the projects that you have access to.
 
-**Example:** list all the projects available to use with a ``--project`` command switch.
+**Example:** List all the projects available to use with a ``--project`` command switch.
 
 ::
 
@@ -71,7 +74,7 @@ List all the projects that you have access to.
 ``avn project create`` and ``avn project update``
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create a new project with ``create`` or change the settings with ``update``.
+Creates a new project with ``create`` or changes the settings with ``update``.
 
 .. list-table::
   :header-rows: 1
@@ -80,7 +83,7 @@ Create a new project with ``create`` or change the settings with ``update``.
   * - Parameter
     - Information
   * - ``project_name`` (required for ``create``)
-    - Note: this is a positional argument, not a switch
+    - Note: This is a positional argument, not a switch
   * - ``--project`` (required for ``update``)
     - The project to amend, use with ``update`` only
   * - ``--name`` (``update`` only)
@@ -106,7 +109,7 @@ Create a new project with ``create`` or change the settings with ``update``.
   * - ``--billing-currency``
     - The currency to bill in. The choices are: "AUD" "CAD" "CHF" "DKK" "EUR" "GBP" "NOK" "SEK" "USD"
   * - ``--vat-id``
-    - VAT id for this project
+    - VAT ID for this project
   * - ``--billing-email``
     - Email for the billing contact
   * - ``--tech-email``
@@ -141,7 +144,7 @@ Create a new project with ``create`` or change the settings with ``update``.
 ``avn project delete``
 ''''''''''''''''''''''
 
-Delete an empty project. If the project isn't empty, remove the services in it first.
+Deletes an empty project. If the project isn't empty, it removes the services in it first.
 
 .. Note::
     Aiven doesn't allow the deletion of non-empty projects as safeguard against accidental code execution.
@@ -153,7 +156,7 @@ Delete an empty project. If the project isn't empty, remove the services in it f
   avn project delete my-project
 
 
-Project certificate management
+Manage project certificates
 ------------------------------
 
 CA certificates are managed at the project level.
@@ -161,7 +164,7 @@ CA certificates are managed at the project level.
 ``avn project ca-get``
 ''''''''''''''''''''''
 
-Download the CA cert for this project, the certificate will be saved in the file name you supply.
+Downloads the CA certificate for this project, the certificate is saved in the file name you supply.
 
 .. list-table::
   :header-rows: 1
@@ -174,22 +177,22 @@ Download the CA cert for this project, the certificate will be saved in the file
   * - ``--target-filepath``
     - File name, including path, to use
 
-**Example:** Download the CA certificate for the current project and save it in a file in the current directory called ``ca.pem``.
+**Example:** Download the CA certificate for the current project, and save it in a file in the current directory called ``ca.pem``.
 
 ::
 
   avn project ca-get --target-filepath ca.pem
 
 
-Users and invitations
----------------------
+Manage users and invitations
+----------------------------
 
 Manage user access to the project.
 
 ``avn project invite-list``
 '''''''''''''''''''''''''''
 
-See the open invitations to the project.
+Lists the open invitations to the project.
 
 .. list-table::
   :header-rows: 1
@@ -210,7 +213,7 @@ See the open invitations to the project.
 ``avn project user-list``
 '''''''''''''''''''''''''
 
-See the users with access to the project
+Lists the users with access to the project
 
 .. list-table::
   :header-rows: 1
@@ -231,7 +234,7 @@ See the users with access to the project
 ``avn project user-invite``
 '''''''''''''''''''''''''''
 
-Send an invitation to a user (by email) to join a project
+Sends an invitation to a user (by email) to join a project.
 
 .. list-table::
   :header-rows: 1
@@ -256,7 +259,7 @@ Send an invitation to a user (by email) to join a project
 ``avn project user-remove``
 '''''''''''''''''''''''''''
 
-Remove from the project a user with the supplied email address.
+Removes a user with the supplied email address from the project.
 
 .. list-table::
   :header-rows: 1
@@ -265,7 +268,7 @@ Remove from the project a user with the supplied email address.
   * - Parameter
     - Information
   * - ``email`` (required)
-    - Note: this is a positional argument
+    - Note: This is a positional argument
   * - ``--project``
     - The project to remove the user from
 


### PR DESCRIPTION
# What changed, and why it matters

Fixes #133 by adding documentation for the `avn project` subcommand, including explanations and examples. This is the first of the CLI reference docs to be added so general feedback is also welcome.
