### PR TITLE
Add an importer script for help articles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,16 @@ Diagrams use `sphinxcontrib-mermaid <https://github.com/mgaitan/sphinxcontrib-me
 Importing content
 ~~~~~~~~~~~~~~~~~
 
-Some of the content for DevPortal came from a previous incarnation of documentation. To help with the migration, use the scripts in the ``utils/`` directory.
+Some of the content for DevPortal came from a previous incarnation of documentation. There is an import script to help with this process.
+
+To set up the import tooling for the first time:
 
 * Install [pandoc](https://pandoc.org/) and make sure the command is in your path
+* Change into the ``utils/`` directory
+* Run ``pip install -r requirements.txt``
+
+To bring in a page from the previous platform:
+
 * Run ``python import-help-articles.py [paste a URL]``
 * Take the resulting ``*.rst`` file and any images, and place them as appropriate in the file structure of the project
 

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,15 @@ Diagrams
 
 Diagrams use `sphinxcontrib-mermaid <https://github.com/mgaitan/sphinxcontrib-mermaid>`_ and `mermaid.js <https://mermaid-js.github.io/mermaid/#/>`_ syntax.
 
+Importing content
+~~~~~~~~~~~~~~~~~
+
+Some of the content for DevPortal came from a previous incarnation of documentation. To help with the migration, use the scripts in the ``utils/`` directory.
+
+* Install [pandoc](https://pandoc.org/) and make sure the command is in your path
+* Run ``python import-help-articles.py [paste a URL]``
+* Take the resulting ``*.rst`` file and any images, and place them as appropriate in the file structure of the project
+
 License
 -------
 

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils']
 
 
 gitstamp_fmt = "%B %Y"

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,0 +1,2 @@
+# ignore all files because they are probably the result of the import
+*

--- a/utils/import-help-article.py
+++ b/utils/import-help-article.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import requests
 import sys
@@ -6,10 +7,12 @@ from urllib.parse import urlparse
 import pypandoc
 from bs4 import BeautifulSoup
 
-if len(sys.argv) < 2:
-    sys.exit("Give the URL with the command")
+parser = argparse.ArgumentParser(description="Convert an existing help file")
+parser.add_argument('url', help="The URL of the source file")
+args = parser.parse_args()
 
-page_url = sys.argv[1]
+page_url = args.url
+print(page_url)
 
 # tangent: grab a filename
 url_pieces = urlparse(page_url)

--- a/utils/import-help-article.py
+++ b/utils/import-help-article.py
@@ -1,0 +1,59 @@
+import os
+import requests
+import sys
+from urllib.parse import urlparse
+
+import pypandoc
+from bs4 import BeautifulSoup
+
+if len(sys.argv) < 2:
+    sys.exit("Give the URL with the command")
+
+page_url = sys.argv[1]
+
+# tangent: grab a filename
+url_pieces = urlparse(page_url)
+path_pieces = os.path.split(url_pieces.path)
+filename, ext = os.path.splitext(path_pieces[1])
+
+# fetch web page
+html_text = requests.get(page_url).text
+soup = BeautifulSoup(html_text, 'html.parser')
+
+attrs = {
+    'class': 'article'
+}
+content = soup.find('div', attrs=attrs)
+heading = content.find('h1')
+
+# get the text, some tidying up needed
+article = content.find('article')
+
+# remove containers
+for container in article.findAll('div', {'class': 'intercom-container'}):
+    container.unwrap()
+
+# download and replace images
+image_counter = 1
+for image in article.findAll('img'):
+    src = image['src']
+
+    img_path = urlparse(src)
+    imgfile, ext = os.path.splitext(img_path.path)
+    new_img_filename = filename + "_image" + str(image_counter) + ext
+
+    img_data = requests.get(src).content
+    with open(new_img_filename, 'wb') as handler:
+        handler.write(img_data)
+
+    image['src'] = new_img_filename
+    image_counter = image_counter + 1
+
+# output pretend HTML page
+with open(filename + '.html', 'w+') as f:
+    f.write(str(heading) + str(article))
+
+f.close()
+
+# have pandoc convert
+output = pypandoc.convert_file(filename + '.html', 'rst', outputfile=filename + '.rst')

--- a/utils/import-help-article.py
+++ b/utils/import-help-article.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import requests
-import sys
 from urllib.parse import urlparse
 
 import pypandoc
@@ -12,7 +11,6 @@ parser.add_argument('url', help="The URL of the source file")
 args = parser.parse_args()
 
 page_url = args.url
-print(page_url)
 
 # tangent: grab a filename
 url_pieces = urlparse(page_url)
@@ -54,7 +52,7 @@ for image in article.findAll('img'):
 
 # output pretend HTML page
 with open(filename + '.html', 'w+') as f:
-    f.write(str(heading) + str(article))
+    f.write(str(heading) + article.prettify())
 
 f.close()
 

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,3 @@
+pypandoc==1.6.3
+requests==2.22.0
+beautifulsoup4==4.8.1


### PR DESCRIPTION
* Install pandoc https://pandoc.org/
* Run this script from the command line, with the URL of the page to import

  python import-help-articles.py https://help.aiven.io/en/articles/5074009-forking-an-aiven-service

