### PR TITLE
Add workflows to index pages

### DIFF
--- a/.github/workflows/index-devportal.yaml
+++ b/.github/workflows/index-devportal.yaml
@@ -1,0 +1,26 @@
+name: Index devportal pages
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Index devportal pages
+      run: |
+        make index-devportal
+      env:
+        ES_URL: ${{ secrets.ES_URL }}

--- a/.github/workflows/index-helpcenter.yaml
+++ b/.github/workflows/index-helpcenter.yaml
@@ -1,0 +1,26 @@
+name: Index help center pages
+
+on:
+  schedule:
+    - cron:  '0 2 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Index help center pages
+      run: |
+        make index-helpcenter
+      env:
+        ES_URL: ${{ secrets.ES_URL }}


### PR DESCRIPTION
Add workflows to index devportal pages on changes to main and help center pages daily on schedule. Requires `ES_URL` to be added to repository secrets.