### PR TITLE
postgresql: mention how to change backup time

### DIFF
--- a/docs/products/postgresql/concepts/pg-backups.rst
+++ b/docs/products/postgresql/concepts/pg-backups.rst
@@ -3,6 +3,8 @@ PostgreSQL backups
 
 Aiven for PostgreSQL databases are automatically backed up, with **full backups** made daily, and **write-ahead logs (WAL)** copied at 5 minute intervals, or for every new file generated. All backups are encrypted using ``pghoard``, an open source tool developed and maintained by Aiven, that you can find `on GitHub <https://github.com/aiven/pghoard>`_.
 
+The time of day when the daily backups are made is initially randomly selected, but can be customised by setting the ``backup_hour`` and ``backup_minute`` advanced parameters, see :doc:`../reference/list-of-advanced-params`.
+
 Backup retention time by plan
 -----------------------------
 


### PR DESCRIPTION
I've seen a few support cases with customers asking how to change the time of day the daily backups happen, and I think it's worth mentioning how to do this in the docs. I wasn't totally sure if it was better to put this here or in the howto / DBA tasks section, though.

