### PR TITLE
Use incremental builds for preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+livehtmlall:
 	sphinx-autobuild -a "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --watch _static
 
 spell:

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ Start the HTML version with::
 
 Your preview should be at http://localhost:8000 (if anything doesn't seem to re-render well, the navigation seems particularly unreliable, try ``make clean`` and then ``make livehtml`` again).
 
+> If you are working on the templates, try the additional `make livehtmlall` command. This disables sphinx's incremental build and also observes changes to the assets, so it's slower but more like a full rebuild when things change.
+
 Windows users
 -------------
 

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils', 'CONTRIBUTING.rst']
 
 
 gitstamp_fmt = "%B %Y"


### PR DESCRIPTION
# What changed, and why it matters

We have been using a full rebuild in the `make livehtml` command and it's getting slower now we have more content. Switch to incremental building, and add support for a more full build (with README docs for reference). Also stop including the CONTRIBUTING file as it's triggering a warning.


