### PR TITLE
Add google analytics

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -1,0 +1,16 @@
+{% extends "!base.html" %}
+
+{%- block extrahead %}
+{{ super() }}
+<!-- Google Analytics -->
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-68276046-1', 'auto');
+    ga('send', 'pageview');
+</script>
+<!-- End Google Analytics -->
+{% endblock %}


### PR DESCRIPTION
Adds google analytics script to template. Implements #159. Decided not to use sphinx-contrib/googleanalytics -plugin because it does not work on newer sphinx version that we use and seems to be unmaintained overall. Plugin injects the script so this is basically the same thing but at least this works without any hacks (see plugin issues/prs for more info if interested).