### PR TITLE
Added `avn user` documentation

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -24,6 +24,9 @@ entries:
     entries:
       - file: docs/tools/cli
         entries:
+        - file: docs/tools/cli/user
+          entries:
+            - glob: docs/tools/cli/user/*
         - glob: docs/tools/cli/*
       - file: docs/tools/api/index
         title: Aiven API

--- a/_toc.yml
+++ b/_toc.yml
@@ -24,10 +24,14 @@ entries:
     entries:
       - file: docs/tools/cli
         entries:
+        - file: docs/tools/cli/card
+        - file: docs/tools/cli/cloud
+        - file: docs/tools/cli/credits
+        - file: docs/tools/cli/events
+        - file: docs/tools/cli/project
         - file: docs/tools/cli/user
           entries:
             - glob: docs/tools/cli/user/*
-        - glob: docs/tools/cli/*
       - file: docs/tools/api/index
         title: Aiven API
         entries:

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -118,6 +118,8 @@ An alternative support ticket interface to either email or the chat widget found
 
 Log in/out and manage your user tokens here. You can also create other users.
 
+:doc:`See detailed command information <cli/user>`
+
 ``vpc``
 '''''''
 

--- a/docs/tools/cli/user.rst
+++ b/docs/tools/cli/user.rst
@@ -57,7 +57,7 @@ Retrieves the current user information such as:
 * Authentication method
 
 
-**Example:** Retrieves the information for the currently logged user.
+**Example:** Retrieve the information for the currently logged user.
 
 ::
 
@@ -76,7 +76,7 @@ An example of user information:
 ``avn user login``
 ''''''''''''''''''''
 
-Logs in the user.
+Logs the user in.
 
 
 .. list-table::
@@ -90,7 +90,7 @@ Logs in the user.
   * - ``--token``
     - Logs in the user with a pre-created token 
 
-**Example:** Log in the user ``john.doe@example.com`` with prompted password.      
+**Example:** Log the ``john.doe@example.com`` user in, and prompt for password.      
 ::
 
   avn user login john.doe@example.com
@@ -98,7 +98,7 @@ Logs in the user.
 The user will be prompted to insert the password.
 
 
-**Example:** Log in the user `john.doe@example.com` with pre-created authentication token.      
+**Example:** Log the `john.doe@example.com` user `john.doe@example.com` with pre-created authentication token.      
 ::
 
   avn user login john.doe@example.com --token 
@@ -108,10 +108,10 @@ The user will be prompted to insert the pre-created authentication token.
 ``avn user logout``
 ''''''''''''''''''''
 
-Logs out the user.
+Logs the user out.
 
 
-**Example:** Log out the user.      
+**Example:** Log the user out.      
 ::
 
   avn user logout
@@ -119,10 +119,10 @@ Logs out the user.
 ``avn user tokens-expire``
 ''''''''''''''''''''''''''
 
-Expires all the authentication tokens associated with the user.
+Makes all the authentication tokens associated with the user expired.
 
 
-**Example:** Expire all the authentication tokens.      
+**Example:** Make all the authentication tokens expired.      
 ::
 
   avn user tokens-expire

--- a/docs/tools/cli/user.rst
+++ b/docs/tools/cli/user.rst
@@ -12,7 +12,7 @@ Commands for managing project users and ``avn`` client sessions.
 ``avn user access-token``
 '''''''''''''''''''''''''
 
-:doc:`See detailed command information <user/user-access-token>`
+Set of commands for managing user's access tokens. :doc:`See detailed command information <user/user-access-token>` for more information.
 
 ``avn user create``
 '''''''''''''''''''''''
@@ -116,6 +116,8 @@ Logs the user out.
 
   avn user logout
 
+.. _avncli user-tokens-expire:
+
 ``avn user tokens-expire``
 ''''''''''''''''''''''''''
 
@@ -127,3 +129,4 @@ Makes all the authentication tokens associated with the user expired.
 
   avn user tokens-expire
 
+See also other :doc:`access-token related commands <user/user-access-token>`

--- a/docs/tools/cli/user.rst
+++ b/docs/tools/cli/user.rst
@@ -1,0 +1,129 @@
+Command reference: ``avn user``
+==================================
+
+Here you'll find the full list of commands for ``avn user``.
+
+
+Create and manage users and sessions
+------------------------------------
+
+Commands for managing project users and ``avn`` client sessions.
+
+``avn user access-token``
+'''''''''''''''''''''''''
+
+:doc:`See detailed command information <user/user-access-token>`
+
+``avn user create``
+'''''''''''''''''''''''
+
+Creates a new user.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``email``
+    - The email associated to the user
+  * - ``--real-name``
+    - The user's real name
+
+**Example:** Create a new user.
+
+::
+
+  avn user create john.doe@example.com
+
+
+**Example:** Create a new user specifying the real name.
+
+::
+
+  avn user create john.doe@example.com --real-name "John Doe"
+
+
+``avn user info``
+''''''''''''''''''''''
+
+Retrieves the current user information such as:
+
+* Username
+* Real name
+* State (``active`` or ``inactive``)
+* Authentication token validity start date 
+* Associated projects 
+* Authentication method
+
+
+**Example:** Retrieves the information for the currently logged user.
+
+::
+
+  avn user info
+
+An example of user information:
+
+.. code:: text
+
+    USER                  REAL_NAME  STATE   TOKEN_VALIDITY_BEGIN              PROJECTS                       AUTH
+    ====================  =========  ======  ================================  =============================  ========
+    john.doe@example.com  John Doe   active  2021-08-18T09:24:10.298796+00:00  dev-sandbox, prod-environment  password
+
+
+
+``avn user login``
+''''''''''''''''''''
+
+Logs in the user.
+
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``email``
+    - The email associated to the user
+  * - ``--token``
+    - Logs in the user with a pre-created token 
+
+**Example:** Log in the user ``john.doe@example.com`` with prompted password.      
+::
+
+  avn user login john.doe@example.com
+
+The user will be prompted to insert the password.
+
+
+**Example:** Log in the user `john.doe@example.com` with pre-created authentication token.      
+::
+
+  avn user login john.doe@example.com --token 
+
+The user will be prompted to insert the pre-created authentication token. 
+
+``avn user logout``
+''''''''''''''''''''
+
+Logs out the user.
+
+
+**Example:** Log out the user.      
+::
+
+  avn user logout
+
+``avn user tokens-expire``
+''''''''''''''''''''''''''
+
+Expires all the authentication tokens associated with the user.
+
+
+**Example:** Expire all the authentication tokens.      
+::
+
+  avn user tokens-expire
+

--- a/docs/tools/cli/user/user-access-token.rst
+++ b/docs/tools/cli/user/user-access-token.rst
@@ -1,0 +1,124 @@
+Command reference: ``avn user access-token``
+============================================
+
+Here you'll find the full list of commands for ``avn user access-token``.
+
+
+Manage access tokens
+----------------------------
+
+Commands for managing user's access tokens.
+
+``avn user access-token create``
+''''''''''''''''''''''''''''''''
+
+Create a new access token for the currently logged user.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--description``
+    - Description of how the token will be used
+  * - ``--max-age-seconds``
+    - Maximum age of the token, if any, after which it will be expired (30 days by default)
+  * - ``extend-when-used``
+    - Extend token's expiry time when used (only applicable if token is set to expire)
+
+**Example:** Create a new access token.
+
+::
+
+  avn user access-token create --description "To be used with python notebooks"
+
+
+**Example:** Create a new token expiring every hour if not used.
+
+::
+
+  avn user access-token create                       \
+    --description "To be used with Python Notebooks" \
+    --max-age-seconds 3600                           \
+    --extend-when-used
+    
+An example of newly created access token:
+
+.. code:: text
+
+    EXPIRY_TIME           DESCRIPTION                       MAX_AGE_SECONDS  EXTEND_WHEN_USED  FULL_TOKEN
+    ====================  ================================  ===============  ================  ===============================
+    2021-08-16T16:26:10Z  To be used with python notebooks  3600             true              6JsKDclT3OMQd1V2Fl2...RaraBPg==
+
+``avn user access-token list``
+''''''''''''''''''''''''''''''
+
+Retrieves user's currently active access tokens information:
+
+* Expiration Time
+* Token TOKEN_PREFIX
+* Description
+* Token's max age in seconds
+* Extended when used flag 
+* Last used time, IP address and user-agent
+
+
+**Example:** Retrieves the information for the currently logged user.
+
+::
+
+  avn user access-token list
+
+An example of user information:
+
+.. code:: text
+
+    EXPIRY_TIME           TOKEN_PREFIX  DESCRIPTION                       MAX_AGE_SECONDS  EXTEND_WHEN_USED  LAST_USED_TIME        LAST_IP      LAST_USER_AGENT
+    ====================  ============  ================================  ===============  ================  ====================  ===========  ===================
+    2021-09-15T15:29:14Z  XCJ3+bgWywIh  Test token                        2592000          true              2021-08-16T15:29:14Z  192.168.1.1  aiven-client/2.12.0
+    2021-08-16T16:26:10Z  6JsKDclT3OMQ  To be used with python notebooks  3600             true              null                  null         null
+
+
+
+``avn user access-token revoke``
+''''''''''''''''''''''''''''''''
+
+Revokes the specified user access token.
+
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``token_prefix``
+    - The full token or token prefix identifying the token to revoke
+
+**Example:** Revoke the access token starting with ``6JsKDclT3OMQ``.      
+::
+
+  avn user access-token revoke "6JsKDclT3OMQ"
+
+
+``avn user access-token update``
+''''''''''''''''''''''''''''''''
+
+Updates the description of an access token.
+
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``token_prefix``
+    - The full token or token prefix identifying the token to update
+
+**Example:** Update the description of the access token starting with ``6JsKDclT3OMQ``.      
+::
+
+  avn user access-token update "6JsKDclT3OMQ" --description "To be used with Jupyter Notebooks"
+

--- a/docs/tools/cli/user/user-access-token.rst
+++ b/docs/tools/cli/user/user-access-token.rst
@@ -86,7 +86,9 @@ An example of user information:
 ``avn user access-token revoke``
 ''''''''''''''''''''''''''''''''
 
-Revokes the specified user access token.
+Revokes the specified user access token. 
+
+Tokens can also be expired via the :ref:`avncli user-tokens-expire` command.
 
 
 .. list-table::

--- a/docs/tools/cli/user/user-access-token.rst
+++ b/docs/tools/cli/user/user-access-token.rst
@@ -12,7 +12,7 @@ Commands for managing user's access tokens.
 ``avn user access-token create``
 ''''''''''''''''''''''''''''''''
 
-Create a new access token for the currently logged user.
+Creates a new access token for the logged-in user.
 
 .. list-table::
   :header-rows: 1
@@ -23,7 +23,7 @@ Create a new access token for the currently logged user.
   * - ``--description``
     - Description of how the token will be used
   * - ``--max-age-seconds``
-    - Maximum age of the token, if any, after which it will be expired (30 days by default)
+    - Maximum age of the token in seconds, if any, after which it will expire(30 days by default)
   * - ``extend-when-used``
     - Extend token's expiry time when used (only applicable if token is set to expire)
 
@@ -31,7 +31,7 @@ Create a new access token for the currently logged user.
 
 ::
 
-  avn user access-token create --description "To be used with python notebooks"
+  avn user access-token create --description "To be used with Python Notebooks"
 
 
 **Example:** Create a new token expiring every hour if not used.
@@ -54,17 +54,19 @@ An example of newly created access token:
 ``avn user access-token list``
 ''''''''''''''''''''''''''''''
 
-Retrieves user's currently active access tokens information:
+Retrieves the information for all the access tokens active session in the session:
 
-* Expiration Time
-* Token TOKEN_PREFIX
+* Expiration time
+* Token prefix
 * Description
 * Token's max age in seconds
 * Extended when used flag 
-* Last used time, IP address and user-agent
+* Last used time
+* Last IP address 
+* Last user agent
 
 
-**Example:** Retrieves the information for the currently logged user.
+**Example:** Retrieve the information for the logged-in user.
 
 ::
 
@@ -77,7 +79,7 @@ An example of user information:
     EXPIRY_TIME           TOKEN_PREFIX  DESCRIPTION                       MAX_AGE_SECONDS  EXTEND_WHEN_USED  LAST_USED_TIME        LAST_IP      LAST_USER_AGENT
     ====================  ============  ================================  ===============  ================  ====================  ===========  ===================
     2021-09-15T15:29:14Z  XCJ3+bgWywIh  Test token                        2592000          true              2021-08-16T15:29:14Z  192.168.1.1  aiven-client/2.12.0
-    2021-08-16T16:26:10Z  6JsKDclT3OMQ  To be used with python notebooks  3600             true              null                  null         null
+    2021-08-16T16:26:10Z  6JsKDclT3OMQ  To be used with Python Notebooks  3600             true              null                  null         null
 
 
 


### PR DESCRIPTION
Added `avn user` documentation with different file for `avn user access-token` which has several options.
Looking for feedback around structure since this could be used for `avn service` as well

