### PR TITLE
Initial commit for `avn account`

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -23,6 +23,9 @@ entries:
     entries:
       - file: docs/tools/cli
         entries:
+        - file: docs/tools/cli/account
+          entries:
+            - glob: docs/tools/cli/account/*
         - file: docs/tools/cli/card
         - file: docs/tools/cli/cloud
         - file: docs/tools/cli/credits
@@ -31,6 +34,7 @@ entries:
         - file: docs/tools/cli/user
           entries:
             - glob: docs/tools/cli/user/*
+
       - file: docs/tools/api/index
         title: Aiven API
         entries:

--- a/docs/tools/cli/account.rst
+++ b/docs/tools/cli/account.rst
@@ -7,7 +7,9 @@ Here you’ll find the full list of commands for ``avn account``.
 Manage account details
 -------------------------
 
-Commands for managing Aiven accounts via ``avn`` commands.
+Commands for managing Aiven accounts via ``avn`` commands. 
+
+Check out the full description of :doc:`Aiven's security model </docs/platform/concepts/cloud-security>` for more information.
 
 
 ``avn account authentication-method``

--- a/docs/tools/cli/account.rst
+++ b/docs/tools/cli/account.rst
@@ -1,0 +1,103 @@
+Command reference: ``avn account``
+==================================
+
+Here you’ll find the full list of commands for ``avn account``.
+
+
+Manage account details
+-------------------------
+
+Commands for managing Aiven accounts via ``avn`` commands.
+
+
+``avn account authentication-method``
+'''''''''''''''''''''''''''''''''''''
+
+:doc:`See detailed command information <account/account-authentication-method>`
+
+
+``avn account create``
+'''''''''''''''''''''''
+
+Creates a new account.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--name``
+    - The name of the account
+
+**Example:** Create a new account for the  ``billing-analytics`` department.
+
+::
+
+  avn account create --name "Billing Analytics"
+
+``avn account delete``
+'''''''''''''''''''''''
+
+Deletes an existing account.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+
+**Example:** Delete the account with id ``123456789123``.
+
+::
+
+  avn account delete 123456789123
+
+``avn account list``
+'''''''''''''''''''''''
+
+Lists existing accounts information including account id, name, team owner id, created time, tenant id and update time.
+
+**Example:** List existing accounts.
+
+::
+
+  avn account list
+
+An example of account list output:
+
+.. code:: text
+
+    ACCOUNT_ID    ACCOUNT_NAME            ACCOUNT_OWNER_TEAM_ID  CREATE_TIME           IS_ACCOUNT_OWNER  PRIMARY_BILLING_GROUP_ID  TENANT_ID     UPDATE_TIME
+    ============  ======================  =====================  ====================  ================  ========================  ============  ====================
+    123456789123  Billing Analytics       45678910111213         2020-09-09T20:28:44Z  true              null                      my_tenant_id  2020-09-09T20:28:44Z
+
+``avn account team``
+'''''''''''''''''''''''
+
+:doc:`See detailed command information <account/account-team>`
+
+``avn account update``
+'''''''''''''''''''''''
+
+Updates an existing account's name.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--name``
+    - The account new name
+
+**Example:** Update the name of account with id ``123456789123`` to ``Billing Analytics Account``.
+
+::
+
+  avn account update 123456789123 --name "Billing Analytics Account"

--- a/docs/tools/cli/account/account-authentication-method.rst
+++ b/docs/tools/cli/account/account-authentication-method.rst
@@ -1,0 +1,126 @@
+Command reference: ``avn account authentication-method``
+========================================================
+
+Here you’ll find the full list of commands for ``avn account authentication-method``.
+
+
+Manage account authentication methods
+-------------------------------------
+
+Commands for managing Aiven accounts authentication methods.
+
+``avn account authentication-method create``
+''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new authentication method. More information about authentication methods creation is available at the `dedicated page <https://help.aiven.io/en/articles/3376377-saml-authentication>`_
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--name``
+    - New authentication method name
+  * - ``--type``
+    - The type of the new authentication method. Currently only ``saml`` is available
+  * - ``-c``
+    - Additional configuration option (in the ``KEY=VALUE`` format)
+  * - ``-f``
+    - Path to file containing additional configuration options (in the ``KEY=VALUE`` format)
+
+**Example:** Create a new ``saml`` authentication method named ``My Authentication Method`` for the account id ``123456789123``.
+
+::
+
+  avn account authentication-method create 123456789123 \
+    --name "My Authentication Method"                   \
+    --type saml
+
+``avn account authentication-method delete``
+''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes an existing authentication method.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``authentication_id``
+    - Id of the authentication method
+
+**Example:** Delete the authentication method with id ``88888888888`` belonging to the account id ``123456789123``.
+
+::
+
+  avn account authentication-method delete 123456789123 88888888888
+
+``avn account authentication-method list``
+''''''''''''''''''''''''''''''''''''''''''''
+
+Lists the existing authentication methods.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+
+**Example:** List all the authentication methods belonging to the account id ``123456789123``.
+
+::
+
+  avn account authentication-method list 123456789123
+
+An example of account authentication-method list output:
+
+.. code:: text
+
+    ACCOUNT_ID    AUTHENTICATION_METHOD_ENABLED  AUTHENTICATION_METHOD_ID  AUTHENTICATION_METHOD_NAME  AUTHENTICATION_METHOD_TYPE  STATE                  CREATE_TIME           UPDATE_TIME
+    ============  =============================  ========================  ==========================  ==========================  =====================  ====================  ====================
+    123456789123  true                           am2exxxxxxxxx             Okta                        saml                        active                 2020-10-13T16:48:29Z  2021-08-10T08:33:15Z
+    123456789123  true                           am2wwwwwwwwww             Centrify                    saml                        active                 2020-09-28T10:22:50Z  2020-09-28T12:06:06Z
+    123456789123  true                           am2qqqqqqqqqq             Azure                       saml                        active                 2020-09-22T12:30:19Z  2020-09-22T12:34:02Z
+    123456789123  true                           am2yyyyyyyyyy             Platform authentication     internal                    active                 2020-09-09T20:28:44Z  2020-09-09T20:28:44Z
+
+
+``avn account authentication-method update``
+''''''''''''''''''''''''''''''''''''''''''''
+
+Updates an existing authentication method.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``authentication_id``
+    - Id of the authentication method
+  * - ``--name``
+    - New authentication method name
+  * - ``--enable``
+    - Enables the authentication method
+  * - ``--disable``
+    - Disables the authentication method
+  * - ``-c``
+    - Additional configuration option (in the ``KEY=VALUE`` format)
+  * - ``-f``
+    - Path to file containing additional configuration options (in the ``KEY=VALUE`` format)
+
+**Example:** Disable the authentication method with id ``am2exxxxxxxxx`` for the account id ``123456789123``.
+
+::
+
+  avn account authentication-method update 123456789123 am2exxxxxxxxx --disable

--- a/docs/tools/cli/account/account-team.rst
+++ b/docs/tools/cli/account/account-team.rst
@@ -1,0 +1,255 @@
+Command reference: ``avn account team``
+=======================================
+
+Here you’ll find the full list of commands for ``avn account team``.
+
+
+Manage account teams
+-------------------------
+
+Commands for managing Aiven account teams via ``avn`` commands.
+
+``avn account team create``
+'''''''''''''''''''''''''''
+
+Creates a new account team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-name``
+    - The name of the team
+
+**Example:** Create a new team named ``clickstream analytics`` for the account id ``123456789123``.
+
+::
+
+  avn account team create 123456789123 --team-name "clickstream analytics"
+
+``avn account team delete``
+'''''''''''''''''''''''''''
+
+Deletes an existing account team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team to delete
+
+**Example:** Delete the team with id ``at31d79d311b3`` for the account id ``123456789123``.
+
+::
+
+  avn account team delete 123456789123 --team-id at31d79d311b3
+
+``avn account team list``
+'''''''''''''''''''''''''''
+
+Lists an existing account teams.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+
+
+**Example:** List all the teams belonging to the account id ``123456789123``.
+
+::
+
+  avn account team list 123456789123 
+
+An example of ``account team list`` output:
+
+.. code:: text
+
+    ACCOUNT_ID    CREATE_TIME           TEAM_ID        TEAM_NAME           UPDATE_TIME
+    ============  ====================  =============  ==================  ====================
+    123456789123  2020-09-09T20:28:44Z  at3exxxxxxxxx  Account Owners      2020-09-09T20:28:44Z
+    123456789123  2021-08-19T20:06:24Z  at3yyyyyyyyyy  admin-team-test     2021-08-19T20:06:24Z
+    123456789123  2021-08-17T15:48:29Z  at3zzzzzzzzzz  dev-team-test       2021-08-17T15:48:29Z
+
+``avn account team project-attach``
+'''''''''''''''''''''''''''''''''''
+
+Attaches an existing account team to a project.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team
+  * - ``--project``
+    - The project to attach to
+  * - ``--team-type``
+    - The permission level (possible values ``admin``, ``developer``, ``operator``, ``read_only``). 
+      More info at the `dedicated page <https://help.aiven.io/en/articles/4206498-accounts-teams-members-and-roles>`_
+
+
+**Example:** Attach the team with id ``at3exxxxxxxxx`` belonging to the account ``123456789123`` to the project named ``testing-sandbox`` granting ``operator`` access.
+
+::
+
+  avn account team project-attach 123456789123  \
+    --team-id at3exxxxxxxxx                     \
+    --project testing-sandbox                   \
+    --team-type operator
+
+``avn account team project-detach``
+'''''''''''''''''''''''''''''''''''
+
+Detaches an existing account team from a project.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team
+  * - ``--project``
+    - The project to detach from
+
+
+**Example:** Detach the team with id ``at3exxxxxxxxx`` belonging to the account ``123456789123`` from the project named ``testing-sandbox``.
+
+::
+
+  avn account team project-detach 123456789123  \
+    --team-id at3exxxxxxxxx                     \
+    --project testing-sandbox
+
+``avn account team user-invite``
+'''''''''''''''''''''''''''''''''''
+
+Invites a new user to an Aiven team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``email``
+    - The new user's email address
+  * - ``--team-id``
+    - The id of the team
+
+**Example:** Invite the user ``jane.doe@example.com`` to the team id ``at3exxxxxxxxx`` belonging to the account ``123456789123``.
+
+::
+
+  avn account team user-invite 123456789123 jane.doe@example.com  --team-id at3exxxxxxxxx
+
+``avn account team user-delete``
+'''''''''''''''''''''''''''''''''''
+
+Deletes an existing user from an Aiven team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team
+  * - ``--user-id``
+    - The existing user's id
+
+**Example:** Remove the user with id ``x5dxxxxxxxxx`` from the team id ``at3exxxxxxxxx`` belonging to the account ``123456789123``.
+
+::
+
+  avn account team user-delete 123456789123 --team-id at3exxxxxxxxx --user-id x5dxxxxxxxxx
+
+``avn account team user-list``
+'''''''''''''''''''''''''''''''''''
+
+Lists the existing users in an Aiven team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team
+
+**Example:** List all the users in the team id ``at3exxxxxxxxx`` belonging to the account ``123456789123``.
+
+::
+
+  avn account team user-list 123456789123 --team-id at3exxxxxxxxx 
+
+An example of ``account team user-list`` output:
+
+.. code:: text
+
+    CREATE_TIME           REAL_NAME            TEAM_ID        TEAM_NAME        UPDATE_TIME           USER_EMAIL                    USER_ID
+    ====================  ===================  =============  ===============  ====================  ============================  ============
+    2020-09-22T12:37:21Z  Jane Doe             at3exxxxxxxxx  admin-team-test  2020-09-22T12:37:21Z  jane.doe@example.com          u2xxxxxxxxxx
+    2020-09-10T09:05:54Z  Diana Smith          at3exxxxxxxxx  admin-team-test  2020-09-10T09:05:54Z  diana.smith@example.com       u2yyyyyyyyyy
+    2020-09-10T04:28:59Z  Filiberta Esposito   at3exxxxxxxxx  admin-team-test  2020-09-10T04:28:59Z  f.esposito@example.com        u2zzzzzzzzzz
+    2021-03-18T08:56:47Z  Aki Halvari          at3exxxxxxxxx  admin-team-test  2021-03-18T08:56:47Z  aki.halvari@example.com       u3rrrrrrrrrr
+    2021-08-09T13:23:00Z  Michael Klein        at3exxxxxxxxx  admin-team-test  2021-08-09T13:23:00Z  mklein@example.com            u3qqqqqqqqqq
+
+``avn account team user-list-pending``
+''''''''''''''''''''''''''''''''''''''
+
+Lists the users with pending invitation in an Aiven team.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``account_id``
+    - The id of the account
+  * - ``--team-id``
+    - The id of the team
+
+**Example:** List all the users with pending invitations for the team id ``at3exxxxxxxxx`` belonging to the account ``123456789123``.
+
+::
+
+  avn account team user-list-pending 123456789123 --team-id at3exxxxxxxxx 
+
+An example of ``account team user-list`` output:
+
+.. code:: text
+
+    ACCOUNT_ID    ACCOUNT_NAME    CREATE_TIME           INVITED_BY_USER_EMAIL  TEAM_ID        TEAM_NAME        USER_EMAIL
+    ============  ==============  ====================  =====================  =============  ===============  ==========================
+    123456789123  Jana Reinhardt  2021-08-23T13:14:20Z  jane.doe@example.com   at3exxxxxxxxx  admin-team-test  jana.reinhardt@example.com

--- a/docs/tools/cli/account/account-team.rst
+++ b/docs/tools/cli/account/account-team.rst
@@ -227,7 +227,7 @@ An example of ``account team user-list`` output:
 ``avn account team user-list-pending``
 ''''''''''''''''''''''''''''''''''''''
 
-Lists the users with pending invitation in an Aiven team.
+Lists the users with pending invitation from an Aiven team. Unacknowledged invitations are automatically deleted in 72 hours.
 
 .. list-table::
   :header-rows: 1
@@ -246,7 +246,7 @@ Lists the users with pending invitation in an Aiven team.
 
   avn account team user-list-pending 123456789123 --team-id at3exxxxxxxxx 
 
-An example of ``account team user-list`` output:
+An example of ``account team user-list-pending`` output:
 
 .. code:: text
 


### PR DESCRIPTION
# What changed, and why it matters

Documentation for `avn account`: there are several options split in 3 files.

The `avn account authentication-method` probably needs better examples.
