### PR TITLE
feat: update config file to include canonical url feature

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -3,6 +3,8 @@
 {%- block extrahead %}
 {{ super() }}
 
+<link rel="canonical" href="https://developer.aiven.io/{{ pagename }}" />
+
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">
 <meta property="twitter:domain" content="https://developer.aiven.io/">

--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,8 @@ html_theme_options = {
         "color-sidebar-background-border": "#e1e1e3",
         "color-sidebar-search-background": "#1c1c2f",
     },
-    "navigation_with_keys": True
+    "navigation_with_keys": True,
+    "html_baseurl": "https://developer.aiven.io/"
 }
 
 pygments_style = "monokai"

--- a/conf.py
+++ b/conf.py
@@ -99,8 +99,7 @@ html_theme_options = {
         "color-sidebar-background-border": "#e1e1e3",
         "color-sidebar-search-background": "#1c1c2f",
     },
-    "navigation_with_keys": True,
-    "html_baseurl": "https://developer.aiven.io/"
+    "navigation_with_keys": True
 }
 
 pygments_style = "monokai"


### PR DESCRIPTION
# Task: Page Duplicates w/o canonical
Description: 2-page duplicates appeared on the developer.aiven.io subdomain. Ideally, we get rid of the duplicates completely.

We suggest the following steps:

1. Canonicalize one URL in each set of duplicates
2. Replace all internal references to the canonicalized URL

Duplicate URLs:

1. https://developer.aiven.io/ (87 incoming links)
2. https://developer.aiven.io/index.html (86 incoming links)

→ Which one do you want to keep?

1. https://developer.aiven.io/docs/products/postgresql/reference/pg-metrics → only 1 incoming link via https://aiven.io/blog/metrics-and-graphs-with-m3-and-grafana → replace linked URL by
2. https://developer.aiven.io/docs/products/postgresql/reference/pg-metrics.html (87 incoming links) → keep?

Most important is step 1 in the task description. I can pull all internal links of the canonicalized URLs. I just need to know which URL should be erased from each set. (edited) 

# Attempted Solution
According to the Sphinx documentation [(https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl),](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl) I have updated the `config` file to include the `html_baseurl` setting. However, upon inspection of the head tag, I don't see any mention of the canonical URL. Ideally one would see `<link rel="canonical" href="https://developer.aiven.io/" />`, but that isn't the case.

## Note
It is worth mentioning the Sphinx documentation did say "You can set the canonical URL for your project in the Project Admin page. Check your Admin > Domains page for the domains that we know about."

Please feel free to add any feedback or thoughts.

Preview URL: https://deploy-preview-194--developer-aiven-io-preview.netlify.app/

