### PR TITLE
feat: add language to html tag

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -99,8 +99,7 @@ html_theme_options = {
         "color-sidebar-background-border": "#e1e1e3",
         "color-sidebar-search-background": "#1c1c2f",
     },
-    "navigation_with_keys": True,
-    "language" = "en"
+    "navigation_with_keys": True
 }
 
 pygments_style = "monokai"

--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,8 @@ html_theme_options = {
         "color-sidebar-background-border": "#e1e1e3",
         "color-sidebar-search-background": "#1c1c2f",
     },
-    "navigation_with_keys": True
+    "navigation_with_keys": True,
+    "language" = "en"
 }
 
 pygments_style = "monokai"
@@ -108,6 +109,7 @@ pygments_dark_style = "monokai"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+language = "en"
 html_static_path = ['_static']
 html_css_files = ['css/aiven.css']
 


### PR DESCRIPTION
# Task: HTML lang attribute missing [developer.aiven.io]
## Description: Issue details
93 Pages where the <html lang=“”> language attribute is missing, e.g. https://developer.aiven.io/docs/platform/howto/console-fork-service.html.

Although Google might not be using the HTML lang attribute today, other search engines and browsers do.

## How to fix
Make sure your pages have language (or language and country) code declared in the HTML lang attribute.
Note that the language code must conform to ISO 639-1 format.

# Solution
By referring to the base template, I used the example there to add the language feature to the `config.py` file. See this [link](https://github.com/pradyunsg/furo/blob/db4dd7395d7f962a1fd02e90eb3e182ca316d518/docs/conf.py#L78).

After I added the language parameter to the config file, I didn't see any changes on my localhost. I have noticed that sometimes new changes aren't visible. Maybe it's just my computer.

Preview URL: https://deploy-preview-197--developer-aiven-io-preview.netlify.app/

