### PR TITLE
feat: add version number to mermaid extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,14 +33,19 @@ extensions = [
     'sphinx_gitstamp',
 ]
 
+# Mermaid version
+mermaid_version = "8.12.0"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils', 'CONTRIBUTING.rst']
-
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils',
+    'CONTRIBUTING.rst'
+]
 
 gitstamp_fmt = "%B %Y"
 


### PR DESCRIPTION
# Task: Pages reference redirected JavaScript
## Description: Issue details
87 pages on developer.aiven.io link to JavaScript files via a redirect: https://unpkg.com/mermaid/dist/mermaid.min.js (redirected to https://unpkg.com/mermaid@8.12.0/dist/mermaid.min.js).

This forces web browsers and search engine crawlers to make an additional HTTP request in order to reach the destination JS file URL. On a vast scale, this can increase page loading times for your website.

## How to fix
Review the pages that have a link to the redirecting URL and replace this link with the direct link to the destination JS file.
If you decide to keep links to redirecting URLs that do not belong to your website, make sure that the destination files are relevant.

Can you replace the references to https://unpkg.com/mermaid/dist/mermaid.min.js with https://unpkg.com/mermaid@8.12.0/dist/mermaid.min.js?

# Solution
According to the Mermaid [docs](https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/), you can specify the Mermaid version in the `config.py` file by using the `mermaid_version ` parameter. So I did that and set it to 8.12.0.

Preview URL: https://deploy-preview-199--developer-aiven-io-preview.netlify.app/

