### PR TITLE
feat: update styling to improve code block title visibility

### DIFF
--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -385,6 +385,11 @@ code.literal {
   background-color: var(--lightGray);
 }
 
+div.section > h3 > code.literal > .pre {
+  font-weight: 700 !important;
+  color: black !important;
+}
+
 .pre {
   background-color: var(--lightGray);
   color: var(--secondaryColor);

--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -385,9 +385,10 @@ code.literal {
   background-color: var(--lightGray);
 }
 
-div.section > h3 > code.literal > .pre {
+/* div.section > div.section > h3 > code.literal > .pre { */
+h3 > code > .pre {
   font-weight: 700 !important;
-  color: black !important;
+  color: var(--primaryColor) !important;
 }
 
 .pre {

--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -385,7 +385,6 @@ code.literal {
   background-color: var(--lightGray);
 }
 
-/* div.section > div.section > h3 > code.literal > .pre { */
 h3 > code > .pre {
   font-weight: 700 !important;
   color: var(--primaryColor) !important;


### PR DESCRIPTION
# Task
## Update code blocks with header tags so they are more visible
There are lots of places on the site (particularly in the CLI section) where we use the code-formatted font in titles - sometimes that's the only thing in a title. The default formatted font is very grey and it makes the titles very hard to see. Could we please get some colour or font weight or something for these titles?

e.g.: https://developer.aiven.io/docs/tools/cli.html#billing-group

Related issue: [https://github.com/aiven/devportal/issues/141](https://github.com/aiven/devportal/issues/141)

# Solution
Update the CSS for the code blocks wrapped in h3 tags. 

Preview URL: https://deploy-preview-209--developer-aiven-io-preview.netlify.app/docs/tools/cli.html#billing-group

Result:

<img width="785" alt="Screenshot 2021-09-16 at 13 35 06" src="https://user-images.githubusercontent.com/13418428/133600285-22963f9d-ab61-4617-ab75-3e7f7ef91c15.png">


