### PR TITLE
fix: remove the pygments_dark reference

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -103,7 +103,6 @@ html_theme_options = {
 }
 
 pygments_style = "monokai"
-pygments_dark_style = "monokai"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
# Task
The pages of developer.aiven.io reference a broken CSS (https://developer.aiven.io/_static/pygments_dark.css).

# Solution
It looks like the Furo theme no longer supports `pygments_dark.css`, according to this commit: https://github.com/pradyunsg/furo/commit/ac89035e46b7d32bac3f440b0e0dd14782f3685c.

It's also mentioned in their changelog for 2021.08.31: https://github.com/pradyunsg/furo/blob/0a344f591f2626dce9c534fac765071cc0e21a7f/docs/changelog.md

Since the support no longer exists, I have removed the pygments_dark reference from the `config.py` file.


