### PR TITLE
Correct product names and automate checks on them

### DIFF
--- a/.github/styles/Aiven/common_replacements.yml
+++ b/.github/styles/Aiven/common_replacements.yml
@@ -7,3 +7,15 @@ swap:
   kakfa: Kafka
   postgres: PostgreSQL
   multicloud: multi-cloud
+  "Aiven Kafka": "Aiven for Apache Kafka"
+  "Aiven Flink": "Aiven for Apache Flink"
+  "Aiven PostgreSQL": "Aiven for PostgreSQL"
+  "Aiven M3": "Aiven for M3"
+  "Aiven MySQL": "Aiven for MySQL"
+  "Aiven Grafana": "Aiven for Grafana"
+  "Aiven Redis": "Aiven for Redis"
+  "Aiven Influx": "Aiven for Influx"
+  "Aiven Elasticsearch": "Aiven for Elasticsearch"
+  "Aiven Cassandra": "Aiven for Cassandra"
+  "Aiven OpenSearch": "Aiven for OpenSearch"
+  "Aiven ClickHouse": "Aiven for ClickHouse"

--- a/docs/products/postgresql/concepts/pg-connection-pooling.rst
+++ b/docs/products/postgresql/concepts/pg-connection-pooling.rst
@@ -80,7 +80,7 @@ Instead of having dedicated connections per client, now PgBouncer manages the co
 Connection pooling modes
 ------------------------
 
-Aiven PostgreSQL supports three different operational pool modes: ``transaction``, ``session`` and ``statement``.
+Aiven for PostgreSQL supports three different operational pool modes: ``transaction``, ``session`` and ``statement``.
 
 * The default and recommended setting option is ``transaction`` pooling mode allows each client connection to take their turn in using a backend connection for the duration of a single transaction. After the transaction is committed, the backend connection is returned back into the pool and the next waiting client connection gets to reuse the same connection immediately. In practice, this provides quick response times for queries as long as the typical execution times for transactions are not excessively long. This is the most commonly used PgBouncer mode and also the default pooling mode in Aiven for PostgreSQL.
 * The ``session`` pooling mode means that once a client connection is granted access to a PostgreSQL server-side connection, it can hold it until the client disconnects from the pooler. After this, the server connection is added back onto the connection pooler's free connection list to wait for its next client connection. Client connections are accepted (at TCP level), but their queries only proceed once another client disconnects and frees up its backend connection back into the pool. This mode can be helpful in some cases for providing a wait queue for incoming connections while keeping the server memory usage low, but is of limited use under most common scenarios due to the slow recycling of the backend connections.

--- a/docs/products/postgresql/concepts/pg-disk-usage.rst
+++ b/docs/products/postgresql/concepts/pg-disk-usage.rst
@@ -6,7 +6,7 @@ When you create your first Aiven for PostgreSQL service, you may see the disk us
 .. image:: /images/products/postgresql/initial-disk-usage.png
    :alt: Disk space usage graph showing % growing over an hour
 
-This is completely normal within the first 24 hours of operation for Aiven PostgreSQL services because of our WAL (Write-Ahead Logging) archiving settings.
+This is completely normal within the first 24 hours of operation for Aiven for PostgreSQL services because of our WAL (Write-Ahead Logging) archiving settings.
 
 To prevent loss of data due to node failure on Hobbyist and Startup plans, we set the ``archive_timeout`` configuration to write WAL segments to disk at regular intervals. The WAL segments are then backed up to cloud storage. Even if your service is idle, each WAL segment occupies the same amount of space on disk, which is why the disk usage grows steadily over time.
 

--- a/docs/products/postgresql/howto/manage-extensions.rst
+++ b/docs/products/postgresql/howto/manage-extensions.rst
@@ -1,7 +1,7 @@
 Install or update an extension
 =====================================
 
-Aiven PostgreSQL allows a series of pre-approved extensions to be installed.
+Aiven for PostgreSQL allows a series of pre-approved extensions to be installed.
 
 Install an extension
 --------------------

--- a/docs/products/postgresql/howto/migrate-pg-dump-restore.rst
+++ b/docs/products/postgresql/howto/migrate-pg-dump-restore.rst
@@ -24,8 +24,8 @@ Variable                  Description
 ====================      =======================================================================================
 ``SRC_SERVICE_URI``       Service URI for the source PostgreSQL connection
 ``DUMP_FOLDER``           Local Folder used to store the source database dump files
-``DEST_PG_NAME``          Name of the destination Aiven PostgreSQL service
-``DEST_PG_PLAN``          Aiven plan for the destination Aiven PostgreSQL service
+``DEST_PG_NAME``          Name of the destination Aiven for PostgreSQL service
+``DEST_PG_PLAN``          Aiven plan for the destination Aiven for PostgreSQL service
 ``DEST_SERVICE_URI``      Service URI for the destination PostgreSQL connection, available from the Aiven Console
 ====================      =======================================================================================
 

--- a/docs/products/postgresql/howto/report-metrics-grafana.rst
+++ b/docs/products/postgresql/howto/report-metrics-grafana.rst
@@ -32,10 +32,10 @@ Provision and configure Grafana
 
 Now your Grafana service is connected to M3DB as a data source and you can go ahead and visualize your PostgreSQL metrics.
 
-Open Aiven PostgreSQL metrics prebuilt dashboard
-------------------------------------------------
+Open PostgreSQL metrics prebuilt dashboard
+------------------------------------------
 
-In Grafana, go to "Dashboards" and "Manage" and double click on the Aiven PostgreSQL Resources dashboard that bears name of the metrics database.
+In Grafana, go to "Dashboards" and "Manage" and double click on the dashboard that bears name of the metrics database.
 
 .. image:: /images/products/postgresql/metrics-dashboard-manage.png
    :alt: Screenshot of a Grafana Manage Dashboards panel

--- a/docs/products/postgresql/howto/setup-logical-replication.rst
+++ b/docs/products/postgresql/howto/setup-logical-replication.rst
@@ -46,7 +46,7 @@ Set up the replication
 To create a logical replication, there is no need to install any extensions on the source cluster, but a superuser account is required.
 
 .. Tip::
-    The ``aiven_extras`` extension enables the creation of a publish/subscribe-style logical replication without a superuser account, and it is preinstalled on Aiven PostgreSQL servers. For more info on ``aiven_extras`` check the dedicated `GitHub repository <https://github.com/aiven/aiven-extras>`_. The following example will assume ``aiven_extras`` extension is not available in the source PostgreSQL database.
+    The ``aiven_extras`` extension enables the creation of a publish/subscribe-style logical replication without a superuser account, and it is preinstalled on Aiven for PostgreSQL servers. For more info on ``aiven_extras`` check the dedicated `GitHub repository <https://github.com/aiven/aiven-extras>`_. The following example will assume ``aiven_extras`` extension is not available in the source PostgreSQL database.
 
 This example assumes a source database called ``origin_database`` on a self-managed PostgreSQL cluster. The replication will mirror three tables, named ``test_table``, ``test_table_2`` and ``test_table_3``, to the ``defaultdb`` database on Aiven for PostgreSQL. The process to setup the logical replication is the following:
 

--- a/docs/products/postgresql/reference/pg-metrics.rst
+++ b/docs/products/postgresql/reference/pg-metrics.rst
@@ -33,7 +33,7 @@ This section shows a high-level overview of the service node health. Major issue
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-overview.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL Overview Section
+    :alt: Grafana Dashboard for PostgreSQL Overview Section
 
 The following metrics are shown
 
@@ -64,7 +64,7 @@ This section shows a more detailed listing of various generic system-related met
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-system.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL System Metrics Section
+    :alt: Grafana Dashboard for PostgreSQL System Metrics Section
 
 The following metrics are shown
 
@@ -134,7 +134,7 @@ The metrics in the PostgreSQL overview section are grouped by logical database. 
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-pg-overview.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL database Overview Section
+    :alt: Grafana Dashboard for PostgreSQL database Overview Section
 
 
 .. list-table::
@@ -187,7 +187,7 @@ This section contains graphs related to the size and use of **indexes**. Since t
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-pg-indexes.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL database Indexes Section
+    :alt: Grafana Dashboard for PostgreSQL database Indexes Section
 
 
 .. list-table::
@@ -215,7 +215,7 @@ Tables
 This section contains graphs related to the size and use of **tables**. As with indexes, the graph will be convoluted for complex databases, and you may want to make a copy of the dashboard to add additional filters that exclude uninteresting tables.
 
 .. image:: /images/products/postgresql/metrics-dashboard-pg-tables.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL database Indexes Section
+    :alt: Grafana Dashboard for PostgreSQL database Indexes Section
 
 .. list-table::
     :header-rows: 1
@@ -255,7 +255,7 @@ This section contains graphs related to **vacuum** and **analyze** operations. T
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-pg-vacuum.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL database Vacuum and Analyse Section
+    :alt: Grafana Dashboard for PostgreSQL database Vacuum and Analyse Section
 
 .. list-table::
     :header-rows: 1
@@ -286,7 +286,7 @@ This section contains PostgreSQL metrics graphs that are not covered by the prev
 
 
 .. image:: /images/products/postgresql/metrics-dashboard-pg-miscellaneous.png
-    :alt: Aiven Grafana Dashboard for PostgreSQL database Miscellaneous Section
+    :alt: Grafana Dashboard for PostgreSQL database Miscellaneous Section
 
 .. list-table::
     :header-rows: 1


### PR DESCRIPTION
# What changed, and why it matters

Added extra replacements to the checking to make sure we are naming the products correctly and consistently. We can keep adding any misspellings we come across to the list!

Fixes #56


