### PR TITLE
Add per-page twitter card descriptions

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -7,10 +7,9 @@
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">
-<meta property="twitter:domain" content="https://developer.aiven.io/">
-<meta property="twitter:url" content="{{ pagename }}">
+<meta name="twitter:site" content="@aiven_io">
 <meta name="twitter:title" content="{{ docstitle|striptags|e }}">
-<meta name="twitter:description" content="Aiven offers excellent open source data platforms, on a cloud of your choice. Databases as a Service, PostgreSQL, Apache Kafka, Redis ...">
+<meta name="twitter:description" content="{{ body|striptags|e|truncate(120) }}">
 <meta name="twitter:image" content="https://developer.aiven.io/_static/images/site-preview.png">
 
 <!-- Google Analytics -->

--- a/_templates/base.html
+++ b/_templates/base.html
@@ -9,7 +9,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@aiven_io">
 <meta name="twitter:title" content="{{ docstitle|striptags|e }}">
-<meta name="twitter:description" content="{{ body|striptags|e|truncate(120) }}">
+<meta name="twitter:description" content="{{ body|striptags|replace("\u00B6", '')|truncate(200) }}">
 <meta name="twitter:image" content="https://developer.aiven.io/_static/images/site-preview.png">
 
 <!-- Google Analytics -->

--- a/index.rst
+++ b/index.rst
@@ -1,6 +1,10 @@
 Aiven developer
 ===============
 
+Aiven is a database-as-a-service for open source data solutions including Apache Kafka, PostgreSQL, Redis, OpenSearch, MySQL, Cassandra, M3DB and InfluxDB.
+
+----------------
+
 What can we help you with today?
 
 .. raw:: html


### PR DESCRIPTION
# What changed, and why it matters

We were picking up the page titles, but using the same description on every page. This change uses the start of the page content as the description, including filtering the pilcrow characters!

I also added a bit of a blurb to the landing page to influence the twitter preview for the main page of the site.

Relates to #213 but I can't tell from that issue if I fixed everything @gskhan had in mind.

