### PR TITLE
Add three examples of how tutorials can be presented

### DIFF
--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -472,3 +472,7 @@ h3 > code > .pre {
   color: var(--linkActive);
   text-decoration-color: var(--linkActive) !important;
 }
+
+.card-header .card-text img {
+  vertical-align: middle !important;
+}

--- a/_toc.yml
+++ b/_toc.yml
@@ -157,6 +157,7 @@ entries:
               - file: docs/products/redis/howto/configure-acl-permissions
               - file: docs/products/redis/howto/migrate-aiven-redis
 
+
   - file: docs/products/grafana/index
     title: Grafana
     entries:
@@ -170,5 +171,16 @@ entries:
         entries:
           - glob: docs/products/grafana/reference/*
      
+
+  # -------- TUTORIALS ON DIFFERENT TOPICS -----
+  - file: docs/tutorials/index-table
+    title: Tutorials (Table)
+
+  - file: docs/tutorials/index-list
+    title: Tutorials (List)
+
+  - file: docs/tutorials/index-images
+    title: Tutorials (with images)
+
   # -------- AUXILIARY
   - file: docs/community

--- a/docs/tutorials/index-images.rst
+++ b/docs/tutorials/index-images.rst
@@ -1,0 +1,33 @@
+Tutorials
+=========
+
+In this section you will find links to tutorials on variety of topics covering our products, tools and other technologies that can be useful for you.
+
+
+Example with a table and icons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+    :widths: 70 30
+    :header-rows: 0
+
+    * - :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>`
+      - |icon-redis| ``advanced``
+    * - :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>`
+      - |icon-postgres| ``go`` ``beginners``
+    * - :doc:`Step by step guide how to use OpenSearch with NodeJS <../products/redis/concepts/high-availability-redis>`
+      - |icon-opensearch|  ``NodeJS``
+
+
+
+Example with a list and icons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>` - |icon-redis| ``advanced``
+* :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>` - |icon-postgres| ``go`` ``beginners``
+
+
+
+* :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>`. |icon-redis| ``advanced``
+* :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>` |icon-postgres| ``go`` ``beginners`` ``cli``
+* :doc:`Step by step guide how to use OpenSearch with NodeJS <../products/redis/concepts/high-availability-redis>` |icon-opensearch| ``NodeJS``

--- a/docs/tutorials/index-list.rst
+++ b/docs/tutorials/index-list.rst
@@ -1,0 +1,10 @@
+Tutorials
+=========
+
+In this section you will find links to tutorials on variety of topics covering our products, tools and other technologies that can be useful for you.
+
+* :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>` - ``Redis`` ``advanced``
+* :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>` - ``Postgres`` ``Go`` ``beginners``
+* :doc:`Step by step guide how to use OpenSearch with NodeJS <../products/redis/concepts/high-availability-redis>` - ``OpenSearch`` ``NodeJS`` ``beginners`` ``cli``
+* :doc:`Write data to M3DB with Go <../products/redis/concepts/high-availability-redis>` - ``M3`` ``Go`` ``beginners``
+* :doc:`Set index retention patterns for OpenSearch <../products/redis/concepts/high-availability-redis>` - ``OpenSearch`` ``advanced``

--- a/docs/tutorials/index-list.rst
+++ b/docs/tutorials/index-list.rst
@@ -3,8 +3,53 @@ Tutorials
 
 In this section you will find links to tutorials on variety of topics covering our products, tools and other technologies that can be useful for you.
 
-* :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>` - ``Redis`` ``advanced``
-* :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>` - ``Postgres`` ``Go`` ``beginners``
-* :doc:`Step by step guide how to use OpenSearch with NodeJS <../products/redis/concepts/high-availability-redis>` - ``OpenSearch`` ``NodeJS`` ``beginners`` ``cli``
-* :doc:`Write data to M3DB with Go <../products/redis/concepts/high-availability-redis>` - ``M3`` ``Go`` ``beginners``
-* :doc:`Set index retention patterns for OpenSearch <../products/redis/concepts/high-availability-redis>` - ``OpenSearch`` ``advanced``
+.. panels::
+
+    |icon-opensearch|
+    :badge:`NodeJS,cls=badge-primary text-white badge-pill`
+    :badge:`novice,cls=badge-secondary text-white badge-pill`
+    ^^^^^^^^^^^^^^
+
+    **Prepare a playground to experiment with OpenSearch and NodeJS**
+
+    This tutorial will help you prepare your development environment and OpenSearch cluster to run search and aggregation queries.
+
+    ++++++++++++++
+
+    .. link-button:: ../products/opensearch/howto/opensearch-and-nodejs.html
+        :text: Read
+        :classes: stretched-link
+
+    ---
+
+    |icon-opensearch|
+    :badge:`NodeJS,cls=badge-primary text-white  badge-pill`
+    :badge:`novice,cls=badge-secondary text-white badge-pill`
+    ^^^^^^^^^^^^^^
+
+    **Write search queries with OpenSearch and NodeJS**
+
+    Learn how the OpenSearch JavaScript client gives a clear and useful interface to communicate with an OpenSearch cluster and run search queries
+
+    ++++++++++++++
+
+    .. link-button:: ../products/opensearch/howto/opensearch-and-nodejs.html
+        :text: Read
+        :classes: stretched-link
+
+    ---
+
+    |icon-opensearch|
+    :badge:`NodeJS,cls=badge-primary text-white  badge-pill`
+    :badge:`intermediate,cls=badge-secondary text-white badge-pill`
+    ^^^^^^^^^^^^^^
+
+    **Use Aggregations with OpenSearch and NodeJS**
+
+    Learn how to aggregate data using OpenSearch and its NodeJS client. In this tutorial we’ll look at different types of aggregations, write and execute requests to learn more about the dataset at our hands.
+
+    ++++++++++++++
+
+    .. link-button:: ../products/opensearch/howto/opensearch-and-nodejs.html
+        :text: Read
+        :classes: stretched-link

--- a/docs/tutorials/index-table.rst
+++ b/docs/tutorials/index-table.rst
@@ -1,0 +1,20 @@
+Tutorials
+=========
+
+In this section you will find links to tutorials on variety of topics covering our products, tools and other technologies that can be useful for you.
+
+
+.. list-table::
+    :widths: 70 30
+    :header-rows: 0
+
+    * - :doc:`High availability in Aiven for Redis <../products/redis/concepts/high-availability-redis>`
+      - ``Redis`` ``advanced``
+    * - :doc:`Connect Postgres with Go <../products/redis/concepts/high-availability-redis>`
+      - ``Postgres`` ``Go`` ``beginners``
+    * - :doc:`Step by step guide how to use OpenSearch with NodeJS <../products/redis/concepts/high-availability-redis>`
+      - ``OpenSearch`` ``NodeJS`` ``beginners`` ``cli``
+    * - :doc:`Write data to M3DB with Go <../products/redis/concepts/high-availability-redis>`
+      - ``M3`` ``Go`` ``beginners``
+    * - :doc:`Set index retention patterns for OpenSearch <../products/redis/concepts/high-availability-redis>`
+      - ``OpenSearch`` ``advanced``


### PR DESCRIPTION
Suggesting three options how to present all our tutorials on a single page.
Goal -  users should be able to easily find topics they are interested in, even if the list of tutorials is very long.


