### PR TITLE
Improve PostgreSQL connection code snippets

### DIFF
--- a/code/products/postgresql/connect.go
+++ b/code/products/postgresql/connect.go
@@ -1,28 +1,33 @@
 package main
 
 import (
-    "database/sql"
-    "fmt"
-    _ "github.com/lib/pq"
-    "log"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+
+	_ "github.com/lib/pq"
 )
 
 func main() {
-    serviceURI := "POSTGRESQL_URI"
+	serviceURI := "POSTGRESQL_URI"
 
-    db, err := sql.Open("postgres", serviceURI)
+	conn, _ := url.Parse(serviceURI)
+	conn.RawQuery = "sslmode=verify-ca;sslrootcert=ca.pem"
 
-    if err != nil {
+	db, err := sql.Open("postgres", conn.String())
+
+	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-    rows, err := db.Query("SELECT version()")
+	rows, err := db.Query("SELECT version()")
 	if err != nil {
 		panic(err)
 	}
 
-    for rows.Next() {
+	for rows.Next() {
 		var result string
 		err = rows.Scan(&result)
 		if err != nil {

--- a/code/products/postgresql/connect.js
+++ b/code/products/postgresql/connect.js
@@ -1,11 +1,17 @@
-
 const fs = require('fs');
 const pg = require('pg');
+const url = require('url');
+
+postgresql_uri = POSTGRESQL_URI;
+
+conn = new URL(postgresql_uri);
+conn.search = conn.query = "";
 
 const config = {
-    connectionString: POSTGRESQL_URI
+    connectionString: conn.href,
     ssl: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: true,
+        ca: fs.readFileSync('./ca.pem').toString(),
     },
 };
 

--- a/docs/products/postgresql/howto/connect-go.rst
+++ b/docs/products/postgresql/howto/connect-go.rst
@@ -19,10 +19,11 @@ Pre-requisites
 
 For this example you will need:
 
-1. The Go ``pq`` library::
+* The Go ``pq`` library::
 
     go get github.com/lib/pq
 
+* :doc:`/docs/platform/howto/download-ca-cert` from the service overview page, this example assumes it is in a local file called ``ca.pem``.
 
 
 Code
@@ -33,6 +34,9 @@ Add the following to ``main.go`` and replace the placeholder with the PostgreSQL
 .. literalinclude:: /code/products/postgresql/connect.go
 
 This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response
+
+.. note::
+   This example replaces the query string parameter to specify ``sslmode=verify-ca`` to make sure that the SSL certificate is verified, and adds the location of the cert.
 
 To run the code::
 

--- a/docs/products/postgresql/howto/connect-node.rst
+++ b/docs/products/postgresql/howto/connect-node.rst
@@ -19,10 +19,11 @@ Pre-requisites
 
 For this example you will need:
 
-1. The npm ``pg`` package::
+* The npm ``pg`` package::
 
-    npm install pg 
+    npm install pg --save
 
+* :doc:`/docs/platform/howto/download-ca-cert` from the service overview page, this example assumes it is in a local file called ``ca.pem``.
 
 Code
 ''''
@@ -31,7 +32,10 @@ Add the following to ``index.js`` and replace the placeholder with the PostgreSQ
 
 .. literalinclude:: /code/products/postgresql/connect.js
 
-This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response
+This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response.
+
+.. note::
+    This example removes ``?sslmode=require`` from the URL string to avoid running into `this bug <https://github.com/brianc/node-postgres/issues/2558>`_. Adding the ``rejectUnauthorized: true`` config ensures that the certificate is checked.
 
 To run the code::
 

--- a/docs/products/postgresql/howto/connect-php.rst
+++ b/docs/products/postgresql/howto/connect-php.rst
@@ -14,14 +14,28 @@ Variable                Description
 ``POSTGRESQL_URI``      URL for PostgreSQL connection, from the service overview page
 ==================      =============================================================
 
+Pre-requisites
+''''''''''''''
+
+For this example you will need:
+
+* :doc:`/docs/platform/howto/download-ca-cert` from the service overview page, this example assumes it is in a local file called ``ca.pem``.
+
+.. note::
+   Your PHP installation will need to include the `PostgreSQL functions <https://www.php.net/manual/en/ref.pdo-pgsql.php>`_ (most installations will have this already).
+
 Code
 ''''
 
 Add the following to ``index.php`` and replace the placeholder with the PostgreSQL URI:
 
 .. literalinclude:: /code/products/postgresql/connect.php
+   :language: php
 
 This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response
+
+.. note::
+   This example replaces the query string parameter to specify ``sslmode=verify-ca`` to make sure that the SSL certificate is verified, and adds the location of the cert.
 
 To run the code::
 

--- a/docs/products/postgresql/howto/connect-python.rst
+++ b/docs/products/postgresql/howto/connect-python.rst
@@ -19,9 +19,9 @@ Pre-requisites
 
 For this example you will need:
 
-1. Python 3.6 or later
+* Python 3.6 or later
 
-2. The Python ``psycopg2`` library. You can install this with ``pip``::
+* The Python ``psycopg2`` library. You can install this with ``pip``::
 
     pip install psycopg2
 
@@ -35,6 +35,9 @@ Add the following to ``main.py`` and replace the placeholders with values for yo
 
 
 This code creates a PostgreSQL client and connects to the database. Then runs a query checking the database version and prints the response
+
+.. note::
+    By default, the connection string specifies ``sslmode=require`` which does not verify the CA certificate. A better approach for production would be to change it to ``sslmode=verify-ca`` and include the certificate.
 
 To run the code::
 


### PR DESCRIPTION
# What changed, and why it matters

This adds better information about requirements/dependencies, and either adds the CA certificate to the example, explains what the `sslmode` parameter means, or both.

Replaces #218 

