### PR TITLE
Changed Flink howto structure

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -107,6 +107,7 @@ entries:
             entries:
               - glob: docs/products/flink/howto/connect/*
           - file: docs/products/flink/howto/create-job
+          - file: docs/products/flink/howto/rest-api-cheatsheet
       - glob: docs/products/flink/reference/
 
 

--- a/docs/products/flink/howto/connect/connect-kafka.rst
+++ b/docs/products/flink/howto/connect/connect-kafka.rst
@@ -1,60 +1,6 @@
 Create a Kafka based Flink table
 ==============================================
 
-Variables
-'''''''''
-
-These are the placeholders you will need to replace in the code sample:
-
-===========================      ===============================================================================================================================
-Variable                         Description
-===========================      ===============================================================================================================================
-``{{aiven_rest_api}}``           Aiven REST API endpoint
-``{{service_name}}``             Name of the Aiven for Flink service
-``{{integration_id}}``           Id of the integration created between Flink and the source/destination system
-``{{source_dest_name}}``         Name of the source or destination Endpoint
-``{{topic_name}}``               Name of the Kafka Topic to use as source or sink
-``{{topic_schema}}``             Definition of `topic schema <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#columns>`_
-``{{partition_by_clause}}``      Topic partition definition
-===========================      ===============================================================================================================================
-
-Create Kafka based Flink table via REST-APIs
-''''''''''''''''''''''''''''''''''''''''''''
-
-To create an Aiven for Apache Kafka based Flink table, use the following REST-API.
-
-Endpoint::
-
-    POST https://{{aiven_rest_api}}/v1/project/{{project_id}}/test/service/{{service_name}}/flink/table
-
-Header: ``Authorization Bearer TOKEN``
-
-Body::
-
-    {
-    "integration_id": "{{integration_id}}",
-    "name": "{{source_dest_name}}",
-    "kafka_topic": "{{topic_name}}",
-    "schema_sql": "{{topic_schema}}",
-    "partitioned_by": "{{partition_by_clause}}"
-    }
-
-**Example**: Define a Flink table named ``KAlert`` pointing to a Kafka topic named ``alert`` available in the Kafka cluster identified by the integration with id ``a4af7409-d167-4f31-af13-ddd4cd06564f``
-
-::
-
-    {
-    "integration_id": "a4af7409-d167-4f31-af13-ddd4cd06564f",
-    "name": "KAlert",
-    "kafka_topic": "alert",
-    "schema_sql": "`node` INT, `occurred_at` TIMESTAMP_LTZ(3), `cpu_in_mb` FLOAT"
-    }
-
-More information on the table definition supported syntax can be found in the :doc:`dedicated page</docs/products/concepts/supported_syntax_sql_editor>`.
-
-Create Kafka based Flink table via Aiven console
-''''''''''''''''''''''''''''''''''''''''''''''''
-
 To create a Flink table based on Aiven for Apache Kafka via Aiven console:
 
 1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab
@@ -75,5 +21,5 @@ Settings:
 The image below shows the Aiven console page with the filled details.
 
 .. image:: /images/products/flink/create-table-topic.png
-  :scale: 50 %
+  :scale: 70 %
   :alt: Image of the Aiven for Apache Flink Jobs and Data tab when creating a Flink table on top of an Aiven for Apache Kafka topic

--- a/docs/products/flink/howto/connect/connect-pg.rst
+++ b/docs/products/flink/howto/connect/connect-pg.rst
@@ -1,56 +1,6 @@
 Create a PostgreSQL based Flink table
 ==============================================
 
-Variables
-'''''''''
-
-These are the placeholders you will need to replace in the code sample:
-
-===========================      ===============================================================================================================================
-Variable                         Description
-===========================      ===============================================================================================================================
-``{{aiven_rest_api}}``           Aiven REST API endpoint
-``{{service_name}}``             Name of the Aiven for Flink service
-``{{integration_id}}``           Id of the integration created between Flink and the source/destination system
-``{{source_dest_name}}``         Name of the source or destination Endpoint
-``{{jdbc_table}}``               Name of the database table to use as source or sink
-``{{table_schema}}``             Definition of `table schema <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#columns>`_
-===========================      ===============================================================================================================================
-
-Create PostgreSQL based Flink table via REST-APIs
-'''''''''''''''''''''''''''''''''''''''''''''''''
-
-The following REST-API can be called.
-
-Endpoint::
-
-    POST https://{{aiven_rest_api}}/v1/project/{{project_id}}/test/service/{{service_name}}/flink/table
-
-Header: ``Authorization Bearer TOKEN``
-
-Body::
-
-    {
-    "integration_id": "{{integration_id}}",
-    "name": "{{source_dest_name}}",
-    "jdbc_table": "{{jdbc_table}}",
-    "schema_sql": "{{table_schema}}"
-    }
-
-**Example**: Define a Flink table named ``node_info`` pointing to a PostgreSQL table named ``public.node_definition`` available in the PostgreSQL database identified by the integration with id ``a4af7409-d167-4f31-af13-ddd4cd06564f``
-
-::
-
-    {
-    "integration_id": "a4af7409-d167-4f31-af13-ddd4cd06564f",
-    "name": "node_info",
-    "jdbc_table": "public.node_definition",
-    "schema_sql": "`node` INT, `node_description` VARCHAR"
-    }
-
-Create PostgreSQL based Flink table via Aiven console
-'''''''''''''''''''''''''''''''''''''''''''''''''''''
-
 To create a Flink table based on Aiven for PostgreSQL via Aiven console:
 
 1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab
@@ -71,5 +21,5 @@ Settings:
 The image below shows the Aiven console page with the filled details.
 
 .. image:: /images/products/flink/create-table-pg.png
-  :scale: 50 %
+  :scale: 70 %
   :alt: Image of the Aiven for Apache Flink Jobs and Data tab when creating a Flink table on top of an Aiven for PostgreSQL table

--- a/docs/products/flink/howto/create-job.rst
+++ b/docs/products/flink/howto/create-job.rst
@@ -6,51 +6,6 @@ Prerequisites
 
 To build data pipelines, Apache Flink requires source or target data structures to :doc:`be mapped as Flink tables <connect>`.
 
-Variables
-'''''''''
-
-These are the placeholders you will need to replace in the code sample:
-
-===========================      ===============================================================================================================================
-Variable                         Description
-===========================      ===============================================================================================================================
-``{{aiven_rest_api}}``           Aiven REST API endpoint
-``{{service_name}}``             Name of the Aiven for Flink service
-``{{sql_statement}}``            SQL statement defining the data transformation
-``{{list_of_tables}}``           Full list of all the Flink-defined tables included in the SQL statement as source or sink
-``{{job_name}}``                 Flink Job name
-===========================      ===============================================================================================================================
-
-Create a Flink job via REST APIs
-'''''''''''''''''''''''''''''''''''''
-
-To create a new data pipeline defined by a Flink job, the following REST-API can be called.
-
-Request:: 
-    
-    POST https://{{aiven_rest_api}}/v1/project/{{project_id}}/test/service/{{service_name}}/flink/job
-
-Headers: ``Authorization Bearer TOKEN``
-
-Body::
-
-    {
-    "statement": "{{sql_statement}}",
-    "tables": {{list_of_tables}},
-    "job_name": "{{job_name}}"
-    }
-
-**Example**: Define a Flink job named ``JobExample`` transforming data from the ``KCpuIn`` table and inserting data in the ``KAlert`` table.
-
-::
-
-    {
-    "statement": "INSERT INTO KAlert SELECT * FROM KCpuIn WHERE `cpu` > 70",
-    "tables": ["KCpuIn", "KAlert"],
-    "job_name": "JobExample"
-    }
-
-
 Create a Flink job via Aiven Console
 '''''''''''''''''''''''''''''''''''''
 

--- a/docs/products/flink/howto/rest-api-cheatsheet.rst
+++ b/docs/products/flink/howto/rest-api-cheatsheet.rst
@@ -1,0 +1,73 @@
+Flink REST API examples cheatsheet
+==================================
+
+This page contains an overview of the REST API calls examples useful to create Aiven for Apache Flink table and job definitions.
+
+Create PostgreSQL based Flink table
+-------------------------------------------------
+
+Define a Flink table named ``node_info``
+
+* pointing to a PostgreSQL table named ``public.node_definition`` available in the PostgreSQL database identified by the integration with id ``a4af7409-d167-4f31-af13-ddd4cd06564f``. 
+* using the Aiven for Flink service named ``my-flink-service`` in the ``my-test-project`` project.
+
+Endpoint::
+
+    POST https://api.aiven.io/v1/project/my-test-project/test/service/my-flink-service/flink/table
+
+Header: ``Authorization Bearer TOKEN``
+
+Body::
+
+    {
+    "integration_id": "a4af7409-d167-4f31-af13-ddd4cd06564f",
+    "name": "node_info",
+    "jdbc_table": "public.node_definition",
+    "schema_sql": "`node` INT, `node_description` VARCHAR"
+    }
+
+Create Kafka based Flink table
+-------------------------------------------------
+
+Define a Flink table named ``KAlert`` 
+
+* pointing to a Kafka topic named ``alert`` available in the Kafka cluster identified by the integration with id ``a4af7409-d167-4f31-af13-ddd4cd06564f``
+* using the Aiven for Flink service named ``my-flink-service`` in the ``my-test-project`` project.
+
+Endpoint::
+
+    POST https://api.aiven.io/v1/project/my-test-project/test/service/my-flink-service/flink/table
+
+Header: ``Authorization Bearer TOKEN``
+
+Body::
+
+    {
+    "integration_id": "a4af7409-d167-4f31-af13-ddd4cd06564f",
+    "name": "KAlert",
+    "kafka_topic": "alert",
+    "schema_sql": "`node` INT, `occurred_at` TIMESTAMP_LTZ(3), `cpu_in_mb` FLOAT"
+    }
+
+
+Create a Flink job
+--------------------------------
+
+Define a Flink job named ``JobExample`` 
+
+* transforming data from the ``KCpuIn`` table and inserting data in the ``KAlert`` table.
+* using the Aiven for Flink service named ``my-flink-service`` in the ``my-test-project`` project.
+
+Request:: 
+    
+    POST https://api.aiven.io/v1/project/my-test-project/test/service/my-flink-service/flink/job
+
+Headers: ``Authorization Bearer TOKEN``
+
+Body::
+
+    {
+    "statement": "INSERT INTO KAlert SELECT * FROM KCpuIn WHERE `cpu` > 70",
+    "tables": ["KCpuIn", "KAlert"],
+    "job_name": "JobExample"
+    }


### PR DESCRIPTION
# What changed, and why it matters

Specific Howtos now only cover the console, with the API part moved to a separated cheatsheet 