### PR TITLE
Reinstate the repetition rule in Vale for 2.11.1 release

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,4 +4,3 @@ Vocab = "Docs"
 [*.rst]
 BasedOnStyles = Vale, Aiven
 
-Vale.Repetition = NO


### PR DESCRIPTION
# What changed, and why it matters

There was a bug in the repetition rule in Vale in the 2.11.0 release, so we disabled the rule. The bug is fixed, so this reinstates the rule


