### PR TITLE
Add a rule to check OpenSearch Dashboards capitalization

### DIFF
--- a/.github/styles/Aiven/common_replacements.yml
+++ b/.github/styles/Aiven/common_replacements.yml
@@ -19,3 +19,4 @@ swap:
   "Aiven Cassandra": "Aiven for Cassandra"
   "Aiven OpenSearch": "Aiven for OpenSearch"
   "Aiven ClickHouse": "Aiven for ClickHouse"
+  "OpenSearch dashboards": "OpenSearch Dashboards"


### PR DESCRIPTION
# What changed, and why it matters

After the fix from @tvainika in #270, add a rule to make sure that the linter catches this if it happens again


