### PR TITLE
Fixing CRD get example

### DIFF
--- a/docs/tools/kubernetes.rst
+++ b/docs/tools/kubernetes.rst
@@ -129,7 +129,7 @@ You can verify the status of your service with the following command.
 
 .. code:: bash
 
-    kubectl get pgs.aiven.io pg-sample
+    kubectl get postgresqls.aiven.io pg-sample
 
 Check the output of the command for your service; once the ``STATE`` field has the value ``RUNNING``, it is ready to use. 
 


### PR DESCRIPTION
```bash
$ kubectl get "pgs.aiven.io" davide-k8s-pg
error: the server doesn't have a resource type "pgs"
```
Not sure when this changed in the CRD template. Matching value from 

https://github.com/aiven/aiven-charts/blob/main/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml#L9


