### PR TITLE
Add a script to generate Service EOL table from Aiven API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ index-helpcenter:
 create-feedback-table:
 	python "$(SOURCEDIR)/scripts/create_feedback_table.py" \
 		--pg-url="$(PG_URL)"
+
+eol-table:
+	python "$(SOURCEDIR)/scripts/aiven/service_versions_eol.py" > $(SOURCEDIR)/includes/eol_table.rst

--- a/_toc.yml
+++ b/_toc.yml
@@ -18,6 +18,10 @@ entries:
       - file: docs/platform/howto/create_authentication_token
       - file: docs/platform/howto/download-ca-cert
       - file: docs/platform/howto/console-fork-service.rst
+    - file: docs/platform/reference
+      title: Reference
+      entries:
+      - file: docs/platform/reference/supported-versions
 
   # --------- GLOBAL -----------
   - file: docs/tools/index

--- a/docs/platform/reference.rst
+++ b/docs/platform/reference.rst
@@ -1,0 +1,5 @@
+# Platform reference documentation
+
+Reference documentation for the Aiven platform.
+
+.. tableofcontents::

--- a/docs/platform/reference/supported-versions.rst
+++ b/docs/platform/reference/supported-versions.rst
@@ -1,0 +1,57 @@
+Supported versions on Aiven
+===========================
+
+We aim to offer current, stable versions of all the products on our platform. Aiven aims to follow the deprecation schedule set by the upstream project maintainers. Once the upstream project retires a specific version, that version no longer receives security updates or critical bug fixes. Therefore, we ensure that Aiven services are always running on supported versions of open source software so that our customers have the levels of protection their business needs.
+
+Version numbering
+-----------------
+
+Aiven services inherit the upstream project’s software versioning scheme. Depending on the service, a major version can be either a single digit (e.g. PostgreSQL 14) or ``major.minor`` (e.g. Kafka 2.8). The exact version of the service is visible in the Aiven console once the service is up and running.
+
+Current versions
+----------------
+
+(all dates in ``YYYY-MM-DD`` format)
+
+.. include:: /includes/eol_table.rst
+
+End-of-life policy for major versions
+-------------------------------------
+
+Aiven EOL policy is applicable only for services whose major versions
+are controlled by the customer.
+
+It applies to both **powered-on** and **powered-off** services running
+the affected versions.
+
+Notification of end-of-life
+'''''''''''''''''''''''''''
+
+When Aiven defines the EOL (end-of-life) date for a service major version,
+
+-  Customers will receive an email announcement along with
+   instructions on the next steps.
+
+-  Aiven Console will also show an EOL alert for affected services.
+
+-  Email reminders will be sent to customers on a monthly cadence (weekly when the EOL date is imminent).
+
+When end-of-life is reached
+'''''''''''''''''''''''''''
+
+-  Affected powered-on services will be **automatically upgraded** to the
+   latest available version. For example, if latest version is
+   PostgreSQL 14, then upon PostgreSQL 10 EOL, it will be
+   upgraded to the latest PostgreSQL 14, instead of PostgreSQL 11.
+
+-  Affected powered-off services will **no longer be accessible** and their
+   backups will be deleted.
+
+Recommendations
+---------------
+
+
+We **highly recommend** customers to perform the version upgrade well before EOL so that they can test compatibility for any breaking changes, plan for unforeseen issues, and migrate to the newer version at their own schedule.
+
+Aiven platform offers :doc:`database forking </docs/platform/howto/console-fork-service>` as an efficient tool to verify the version upgrade so that customers can safely test compatibility without committing their production services to a one-way upgrade.
+

--- a/includes/eol_table.rst
+++ b/includes/eol_table.rst
@@ -1,25 +1,25 @@
-==============  =========  ==========  ==========  ===========  =============
-Service type      Version  EOL         EOA         Status       Upgrade to
-==============  =========  ==========  ==========  ===========  =============
-cassandra             3                            available
-elasticsearch         7    2022-03-23  2022-03-23  unavailable  opensearch v1
-elasticsearch         7.1  2022-03-23  2022-03-23  unavailable  opensearch v1
-elasticsearch         7.9  2022-03-23  2022-03-23  unavailable  opensearch v1
-kafka                 2.5  2021-08-13  2021-08-13  unavailable  kafka v2.8
-kafka                 2.7  2022-01-21  2021-10-21  available    kafka v2.8
-kafka                 2.8  2022-04-26  2022-01-26  available
-kafka                 3    2022-10-04  2022-07-04  available
-m3aggregator          1.1                          available
-m3aggregator          1.2                          available
-m3coordinator         1.1                          available
-m3coordinator         1.2                          available
-m3db                  1.1                          available
-m3db                  1.2                          available
-mysql                 8                            available
-opensearch            1                            available
-pg                   10    2022-11-10  2022-05-10  available    pg v13
-pg                   11    2023-11-09  2023-05-09  available    pg v13
-pg                   12    2024-11-14  2024-05-14  available    pg v13
-pg                   13    2025-11-13  2025-05-13  available
-pg                    9.6  2021-11-11  2021-05-11  unavailable  pg v13
-==============  =========  ==========  ==========  ===========  =============
+=======================  =========  ==========  ==========  ===========  =============
+Service type               Version  EOL         EOA         Status       Upgrade to
+=======================  =========  ==========  ==========  ===========  =============
+Aiven for Cassandra            3                            available
+Aiven for Elasticsearch        7    2022-03-23  2022-03-23  unavailable  opensearch v1
+Aiven for Elasticsearch        7.1  2022-03-23  2022-03-23  unavailable  opensearch v1
+Aiven for Elasticsearch        7.9  2022-03-23  2022-03-23  unavailable  opensearch v1
+Aiven for Apache Kafka         2.5  2021-08-13  2021-08-13  unavailable  kafka v2.8
+Aiven for Apache Kafka         2.7  2022-01-21  2021-10-21  available    kafka v2.8
+Aiven for Apache Kafka         2.8  2022-04-26  2022-01-26  available
+Aiven for Apache Kafka         3    2022-10-04  2022-07-04  available
+M3 Aggregator                  1.1                          available
+M3 Aggregator                  1.2                          available
+M3 Coordinator                 1.1                          available
+M3 Coordinator                 1.2                          available
+Aiven for M3DB                 1.1                          available
+Aiven for M3DB                 1.2                          available
+Aiven for MySQL                8                            available
+Aiven for OpenSearch           1                            available
+Aiven for PostgreSQL          10    2022-11-10  2022-05-10  available    pg v13
+Aiven for PostgreSQL          11    2023-11-09  2023-05-09  available    pg v13
+Aiven for PostgreSQL          12    2024-11-14  2024-05-14  available    pg v13
+Aiven for PostgreSQL          13    2025-11-13  2025-05-13  available
+Aiven for PostgreSQL           9.6  2021-11-11  2021-05-11  unavailable  pg v13
+=======================  =========  ==========  ==========  ===========  =============

--- a/includes/eol_table.rst
+++ b/includes/eol_table.rst
@@ -1,0 +1,25 @@
+==============  =========  ==========  ==========  ===========  =============
+Service type      Version  EOL         EOA         Status       Upgrade to
+==============  =========  ==========  ==========  ===========  =============
+cassandra             3                            available
+elasticsearch         7    2022-03-23  2022-03-23  unavailable  opensearch v1
+elasticsearch         7.1  2022-03-23  2022-03-23  unavailable  opensearch v1
+elasticsearch         7.9  2022-03-23  2022-03-23  unavailable  opensearch v1
+kafka                 2.5  2021-08-13  2021-08-13  unavailable  kafka v2.8
+kafka                 2.7  2022-01-21  2021-10-21  available    kafka v2.8
+kafka                 2.8  2022-04-26  2022-01-26  available
+kafka                 3    2022-10-04  2022-07-04  available
+m3aggregator          1.1                          available
+m3aggregator          1.2                          available
+m3coordinator         1.1                          available
+m3coordinator         1.2                          available
+m3db                  1.1                          available
+m3db                  1.2                          available
+mysql                 8                            available
+opensearch            1                            available
+pg                   10    2022-11-10  2022-05-10  available    pg v13
+pg                   11    2023-11-09  2023-05-09  available    pg v13
+pg                   12    2024-11-14  2024-05-14  available    pg v13
+pg                   13    2025-11-13  2025-05-13  available
+pg                    9.6  2021-11-11  2021-05-11  unavailable  pg v13
+==============  =========  ==========  ==========  ===========  =============

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ elasticsearch==7.13.1
 requests==2.25.1
 psycopg2-binary==2.9.1
 sphinxext-opengraph==0.4.2
+tabulate==0.8.9

--- a/scripts/aiven/README.md
+++ b/scripts/aiven/README.md
@@ -1,0 +1,41 @@
+Aiven scripts
+=============
+
+Scripts for generating data from Aiven APIs and codebase.
+
+## service_version_eol.py
+Pulls the data from the public Aiven API (https://api.aiven.io/v1/service_versions) and
+generates a table of current supported service versions and their EOL (End-of-Life) and 
+EOA (End-of-Availability) dates, along with next default upgrade version.
+
+###Run
+```python service_versions_eol.py```
+
+## Example output
+```rst
+==============  =========  ==========  ==========  ===========  =============
+Service type      Version  EOL         EOA         Status       Upgrade to
+==============  =========  ==========  ==========  ===========  =============
+cassandra             3                            available
+elasticsearch         7    2022-03-23  2022-03-23  unavailable  opensearch v1
+elasticsearch         7.1  2022-03-23  2022-03-23  unavailable  opensearch v1
+elasticsearch         7.9  2022-03-23  2022-03-23  unavailable  opensearch v1
+kafka                 2.5  2021-08-13  2021-08-13  unavailable  kafka v2.8
+kafka                 2.7  2022-01-21  2021-10-21  available    kafka v2.8
+kafka                 2.8  2022-04-26  2022-01-26  available
+kafka                 3    2022-10-04  2022-07-04  available
+m3aggregator          1.1                          available
+m3aggregator          1.2                          available
+m3coordinator         1.1                          available
+m3coordinator         1.2                          available
+m3db                  1.1                          available
+m3db                  1.2                          available
+mysql                 8                            available
+opensearch            1                            available
+pg                   10    2022-11-10  2022-05-10  available    pg v13
+pg                   11    2023-11-09  2023-05-09  available    pg v13
+pg                   12    2024-11-14  2024-05-14  available    pg v13
+pg                   13    2025-11-13  2025-05-13  available
+pg                    9.6  2021-11-11  2021-05-11  unavailable  pg v13
+==============  =========  ==========  ==========  ===========  =============
+```

--- a/scripts/aiven/service_versions_eol.py
+++ b/scripts/aiven/service_versions_eol.py
@@ -8,6 +8,26 @@ def date_from_string(date):
 
 
 if __name__ == "__main__":
+    # prepare lookups
+    prod_names = {
+        "pg": "Aiven for PostgreSQL",
+        "cassandra": "Aiven for Cassandra",
+        "elasticsearch": "Aiven for Elasticsearch",
+        "flink": "Aiven for Apache Flink",
+        "grafana": "Aiven for Grafana",
+        "influxdb": "Aiven for InfluxDB",
+        "kafka": "Aiven for Apache Kafka",
+        "kafka_connect": "Kafka Connect",
+        "kafka_mirrormaker": "MirrorMaker",
+        "m3coordinator": "M3 Coordinator",
+        "m3aggregator": "M3 Aggregator",
+        "m3db": "Aiven for M3DB",
+        "mysql": "Aiven for MySQL",
+        "opensearch": "Aiven for OpenSearch",
+        "redis": "Aiven for Redis"
+    }
+
+    # get current data to build page
     response = requests.get("https://api.aiven.io/v1/service_versions")
     data = response.json()
     versions = []
@@ -33,7 +53,7 @@ if __name__ == "__main__":
             upgrade_to = ""
 
         versions.append([
-            version['service_type'],
+            prod_names[version['service_type']],
             version['major_version'],
             aiven_eol,
             aiven_eoa,

--- a/scripts/aiven/service_versions_eol.py
+++ b/scripts/aiven/service_versions_eol.py
@@ -1,0 +1,50 @@
+import requests
+from datetime import datetime
+from tabulate import tabulate
+
+
+def date_from_string(date):
+    return datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ').date()
+
+
+if __name__ == "__main__":
+    response = requests.get("https://api.aiven.io/v1/service_versions")
+    data = response.json()
+    versions = []
+    for version in data['service_versions']:
+        aiven_eol = version['aiven_end_of_life_time']
+        aiven_eoa = version['availability_end_time']
+        next_version = version['upgrade_to_version']
+        next_service_type = version['upgrade_to_service_type']
+        state = version['state']
+        if aiven_eol:
+            aiven_eol = date_from_string(aiven_eol)
+        else:
+            aiven_eol = ""
+
+        if aiven_eoa:
+            aiven_eoa = date_from_string(aiven_eoa)
+        else:
+            aiven_eoa = ""
+
+        if next_version:
+            upgrade_to = f"{next_service_type} v{next_version}"
+        else:
+            upgrade_to = ""
+
+        versions.append([
+            version['service_type'],
+            version['major_version'],
+            aiven_eol,
+            aiven_eoa,
+            state,
+            upgrade_to
+        ])
+    print(tabulate(versions, headers=[
+        "Service type",
+        "Version",
+        "EOL",
+        "EOA",
+        "Status",
+        "Upgrade to"
+    ], tablefmt='rst'))


### PR DESCRIPTION
- Installs tabulate as new dependency
- Script pulls data from Aiven API
- Output is rst table

Currently we have help articles that are maintained by hand: https://help.aiven.io/en/articles/4318172-eol-for-major-versions-of-aiven-services

The actual EOL information is managed in the Aiven DB and any changes to the services are are done automatically based on that information. Customers can also ask for extensions to the EOL dates.

Maintaining the information in multiple places is overhead and we should show the up2date information on thedeveloper portal.

This should be run as part of the build to generate a page with the EOL information.

See Aiven Jira: https://aiven.atlassian.net/browse/SI-1429
