### PR TITLE
Added a brief explanation of Kafka connector types

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -41,4 +41,3 @@ Flink
 Karapace
 subtab
 upsert
-Upsert

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -40,3 +40,4 @@ failover
 Flink
 Karapace
 subtab
+upsert

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -41,3 +41,4 @@ Flink
 Karapace
 subtab
 upsert
+Upsert

--- a/_toc.yml
+++ b/_toc.yml
@@ -102,6 +102,7 @@ entries:
           - file: docs/products/flink/concepts/watermarks
           - file: docs/products/flink/concepts/checkpoints
           - file: docs/products/flink/concepts/supported_syntax_sql_editor
+          - file: docs/products/flink/concepts/kafka_connectors
       - file: docs/products/flink/howto
         title: HowTo
         entries:

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -13,7 +13,7 @@ When you integrate a standard Apache Kafka with your Aiven for Apache Flink serv
         id2-- processed message --> id3[sink topic];
 
 
-Upsert, or ``INSERT/UPDATE``, is a method of updating or deleting data based on a primary key. If a message in the source upsert topic uses a primary key with a value that already exists, the message data is interpreted as an update to the existing data that uses the same key in the upsert sink topic. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
+Another integration approach is upsert, or ``INSERT/UPDATE``, which is a method of updating or deleting data based on a primary key. If a message in the source upsert topic uses a primary key with a value that already exists, the message data is interpreted as an update to the existing data that uses the same key in the upsert sink topic. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
 
 .. mermaid::
 

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -13,7 +13,9 @@ When you integrate a standard Apache Kafka with your Aiven for Apache Flink serv
         id2-- processed message --> id3[sink topic];
 
 
-Another integration approach is upsert, or ``INSERT/UPDATE``, which is a method of updating or deleting data based on a primary key. If a message in the source upsert topic uses a primary key with a value that already exists, the message data is interpreted as an update to the existing data that uses the same key in the upsert sink topic. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
+Another integration approach is upsert, or ``INSERT/UPDATE``, which is a method of updating or deleting data based on the message key. When used as a source, Flink interprets a message that has an existing key as an update and replaces the value for that key. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
+
+When used as a sink, upsert provides a method to create `Kafka compacted topics <https://kafka.apache.org/documentation/#compaction>`_, containing only the latest value for a specific key and pushing a tombstone message on deletion.
 
 .. mermaid::
 
@@ -34,4 +36,6 @@ How to choose the right connector type
 For most common purposes, such as filtering data or performing calculations on streamed data, a standard Kafka connector is sufficient. You can also perform data aggregation with standard connectors, but depending on the type of aggregation, it may require more careful planning and more complex SQL compared to using upsert connectors.
 
 If you want to use multiple data streams as a source, but have the results for matching identifiers combined into single events within the same target topic, choose upsert connectors. While it varies to some extent depending on your specific use case, this means that using upsert connectors often makes it easier and more efficient to implement data aggregation.
+
+In addition, choose upsert connectors if you want to provide the output as a compacted topic and read only the latest value for each message key.
 

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -15,7 +15,7 @@ When you integrate a standard Apache Kafka with your Aiven for Apache Flink serv
 
 Another integration approach is upsert, or ``INSERT/UPDATE``, which is a method of updating or deleting data based on the message key. When used as a source, Flink interprets a message that has an existing key as an update and replaces the value for that key. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
 
-When used as a sink, upsert provides a method to create `Kafka compacted topics <https://kafka.apache.org/documentation/#compaction>`_, containing only the latest value for a specific key and pushing a tombstone message on deletion.
+When used as a sink, upsert provides a method to create Kafka compacted topics (see the Log Compaction section in the `Apache Kafka documentation <https://kafka.apache.org/documentation/>`_ for details), containing only the latest value for a specific key and pushing a tombstone message on deletion.
 
 .. mermaid::
 

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -1,0 +1,37 @@
+Standard and upsert Apache Kafka connectors
+===========================================
+
+In addition to integration with Apache Kafka through a standard connector, Aiven for Apache Flink also supports the use of *upsert* connectors, which allows you to create changelog-type data streams.
+
+When you integrate a standard Apache Kafka with your Aiven for Apache Flink service, you can use the service to read data from one Kafka topic and write the processed data to another Kafka topic. Each message in the source topic that is processed and written to the sink topic is considered unique and is handled as an individual entry.
+
+.. mermaid::
+
+    graph LR;
+
+        id1>Source topic]-- message --> id2{Flink processing};
+        id2-- processed message --> id3[sink topic];
+
+
+Upsert, or ``INSERT/UPDATE``, is a method of updating or deleting data based on a primary key. If a message in the source upsert topic uses a primary key with a value that already exists, the message data is interpreted as an update to the existing data that uses the same key in the upsert sink topic. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
+
+.. mermaid::
+
+    graph LR;
+
+        id1>Source topic]-- key, value --> id2{Flink processing};
+        id2-. key not found .-> id3(INSERT);
+        id2-. key found, value .-> id4(UPDATE);
+        id2-. key found, no value .-> id5(DELETE);
+        id3-.->id6[Sink topic];
+        id4-.->id6;
+        id5-.->id6;
+
+
+How to choose the right connector type
+--------------------------------------
+
+For most common purposes, such as filtering data or performing calculations on streamed data, a standard Kafka connector is sufficient. You can also perform data aggregation with standard connectors, but depending on the type of aggregation, it may require more careful planning and more complex SQL compared to using upsert connectors.
+
+If you want to use multiple data streams as a source, but have the results for matching identifiers combined into single events within the same target topic, choose upsert connectors. While it varies to some extent depending on your specific use case, this means that using upsert connectors often makes it easier and more efficient to implement data aggregation.
+


### PR DESCRIPTION
A somewhat simplified explanation of the differences between standard and upsert Kafka connectors, may require additional examples at some point.