### PR TITLE
Add quicklinks for reference and code samples, update concepts icon

### DIFF
--- a/docs/products/grafana/index.rst
+++ b/docs/products/grafana/index.rst
@@ -26,6 +26,10 @@ Take your first steps with Aiven for Grafana by following our :doc:`get-started`
 
     💻 :doc:`howto`
 
+    ---
+
+    📖 :doc:`Reference <reference>`
+
 
 Integrates with your existing Aiven tools
 ------------------------------------------

--- a/docs/products/m3db/index.rst
+++ b/docs/products/m3db/index.rst
@@ -28,7 +28,7 @@ Take your first steps with Aiven for M3 by following our :doc:`getting-started` 
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📚 :doc:`concepts`
 
     ---
 

--- a/docs/products/opensearch/index.rst
+++ b/docs/products/opensearch/index.rst
@@ -22,11 +22,19 @@ Try the :doc:`sample recipes dataset <howto/sample-dataset>` or browse the other
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📚 :doc:`concepts`
 
     ---
 
     💻 :doc:`howto`
+
+    ---
+
+    📖 :doc:`Reference <reference>`
+
+    ---
+
+    🧰 :doc:`Code <howto/opensearch-with-curl>`
 
 
 Ways to use OpenSearch

--- a/docs/products/postgresql/index.rst
+++ b/docs/products/postgresql/index.rst
@@ -8,11 +8,20 @@ Aiven for PostgreSQL is the perfect fit for your relational data. A scalable SQL
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📚 :doc:`concepts`
 
     ---
 
     💻 :doc:`howto`
+
+    ---
+
+    📖 :doc:`reference`
+
+    ---
+
+    🧰 :doc:`howto/list-code-samples`
+
 
 PostgreSQL resources
 --------------------

--- a/docs/products/redis/index.rst
+++ b/docs/products/redis/index.rst
@@ -23,11 +23,15 @@ Take your first steps with Aiven for Redis by following our :doc:`get-started` a
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📚 :doc:`concepts`
 
     ---
 
     💻 :doc:`howto`
+
+    ---
+
+    🧰 :doc:`howto/list-code-samples`
 
 
 Ways to use Aiven for Redis

--- a/index.rst
+++ b/index.rst
@@ -91,6 +91,13 @@ Learn about the Aiven platform
 
     |icon-grafana| **Grafana** The visualization tool you need to explore and understand your data. Grafana integrates with the other services in just a few clicks.
 
+    +++
+
+    .. link-button:: docs/products/grafana/index
+        :type: ref
+        :text: Read more
+        :classes: stretched-link
+
 Tools
 -----
 


### PR DESCRIPTION
# What changed, and why it matters

The code samples are a bit buried in the menus, so this tries to surface those and the reference sections on the product landing pages.
