### PR TITLE
Add howto article for resource tagging

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -18,6 +18,7 @@ entries:
       - file: docs/platform/howto/create_authentication_token
       - file: docs/platform/howto/download-ca-cert
       - file: docs/platform/howto/console-fork-service.rst
+      - file: docs/platform/howto/tag-resources.rst
 
   # --------- GLOBAL -----------
   - file: docs/tools/index

--- a/docs/platform/howto/tag-resources.rst
+++ b/docs/platform/howto/tag-resources.rst
@@ -1,9 +1,19 @@
 Tag your Aiven resources
 ========================
 
-You can attach metadata to your Aiven resources using tags. They can help you to categorize your services, and store information specific to your application or business.
+Tags can add metadata to Aiven resources like projects and services. Adding tags can be useful to categorize services, store specific information to your application or business and to group services or bills depending on custom logic.
 
-A tag consist of a string key and value, and you can have at most 10 tags attached to a single resource. Tag keys must be unique for a given resource, and one key can only hold one value. Keys must consist of characters `[A-Za-z0-9_-]` and start with a letter, and they are case sensitive. The maximum length for a key is 64 characters. Tag values can be at most 64 UTF-8 characters long.
+Tag details
+-----------
+
+A tag consists of a string **key** and a single **value** and can be attached to any project or service. 
+
+Tag keys must consist of characters ``[A-Za-z0-9_-]``, are case sensitive, and must **start with a letter**. The maximum length for a key is 64 characters. 
+Tag values can be at most 64 UTF-8 characters long.
+
+.. Note::
+
+    Any single Aiven resource can have **at most 10 tags attached**. Within a resource, the tag keys are unique, meaning that there can't be a duplicated key.
 
 Tags are supported for Aiven projects and services. You currently need to either use the Aiven client, or call the tag APIs by some other means, to use tags. Aiven-client version 2.14.0 or later is required for tagging support.
 
@@ -14,27 +24,27 @@ Add and modify service tags with the Aiven client
 
 2. Add new tags to the service::
 
-    avn service tags update your-service --add-tag key=value --add-tag another=one
+    avn service tags update your-service --add-tag business_unit=sales --add-tag env=smoke_test
 
 3. Modify or remove tags::
 
-    avn service tags update your-service --add-tag another=two --remove-tag key
+    avn service tags update your-service --add-tag env=production --remove-tag business_unit
 
 4. List the tags::
 
     avn service tags list your-service
-    KEY      VALUE
-    =======  =====
-    another  two
+    KEY  VALUE
+    ===  ==========
+    env  production
 
 5. Replace tags with a set of new ones, removing old ones::
 
-    avn service tags replace your-service --tag new_tag=with_value
+    avn service tags replace your-service --tag cost_center=U1345
 
     avn service tags list your-service
-    KEY      VALUE
-    =======  ==========
-    new_tag  with_value
+    KEY          VALUE
+    ===========  =====
+    cost_center  U1345
 
 Add and modify project tags
 ---------------------------
@@ -43,15 +53,15 @@ The commands `update`, `list` and `replace` exist for tagging projects too, and 
 
 1. Add tags to a project::
 
-    avn project tags update --project your-project --add-tag tag_key=tag_value
+    avn project tags update --project your-project --add-tag business_unit=sales
 
 2. Replace project tags::
 
-    avn service tags replace --project your-project --tag new_tag=with_value
+    avn project tags replace --project your-project --tag env=smoke_test
 
 3. List project tags::
 
     avn project tags list
-    KEY      VALUE
-    =======  ==========
-    new_tag  with_value
+    KEY  VALUE
+    ===  ==========
+    env  smoke_test

--- a/docs/platform/howto/tag-resources.rst
+++ b/docs/platform/howto/tag-resources.rst
@@ -1,0 +1,57 @@
+Tag your Aiven resources
+========================
+
+You can attach metadata to your Aiven resources using tags. They can help you to categorize your services, and store information specific to your application or business.
+
+A tag consist of a string key and value, and you can have at most 10 tags attached to a single resource. Tag keys must be unique for a given resource, and one key can only hold one value. Keys must consist of characters `[A-Za-z0-9_-]` and start with a letter, and they are case sensitive. The maximum length for a key is 64 characters. Tag values can be at most 64 UTF-8 characters long.
+
+Tags are supported for Aiven projects and services. You currently need to either use the Aiven client, or call the tag APIs by some other means, to use tags. Aiven-client version 2.14.0 or later is required for tagging support.
+
+Add and modify service tags with the Aiven client
+-------------------------------------------------
+
+1. Select the service you want to tag.
+
+2. Add new tags to the service::
+
+    avn service tags update your-service --add-tag key=value --add-tag another=one
+
+3. Modify or remove tags::
+
+    avn service tags update your-service --add-tag another=two --remove-tag key
+
+4. List the tags::
+
+    avn service tags list your-service
+    KEY      VALUE
+    =======  =====
+    another  two
+
+5. Replace tags with a set of new ones, removing old ones::
+
+    avn service tags replace your-service --tag new_tag=with_value
+
+    avn service tags list your-service
+    KEY      VALUE
+    =======  ==========
+    new_tag  with_value
+
+Add and modify project tags
+---------------------------
+
+The commands `update`, `list` and `replace` exist for tagging projects too, and work the same way:
+
+1. Add tags to a project::
+
+    avn project tags update --project your-project --add-tag tag_key=tag_value
+
+2. Replace project tags::
+
+    avn service tags replace --project your-project --tag new_tag=with_value
+
+3. List project tags::
+
+    avn project tags list
+    KEY      VALUE
+    =======  ==========
+    new_tag  with_value


### PR DESCRIPTION
# What changed, and why it matters
We recently added ability to attach tags to projects and services, and recent versions of avn-client support the feature. This add a howto-article that explains the concept, and includes some examples.