### PR TITLE
Additional updates to Flink content (HH-511)

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -3,6 +3,7 @@ ACLs
 Aiven
 API
 APIs
+Avro
 [Bb]oolean
 [Bb]usiness
 cyber
@@ -10,6 +11,7 @@ datacenter
 datasource
 datastore
 [Dd]ashboards
+Debezium
 Distro
 [Dd]ockerized
 downsampled
@@ -69,6 +71,7 @@ sharding
 signups
 Singlestat
 Statusmap
+[Ss]ubnet
 subtab
 Telegraf
 Terraform
@@ -83,6 +86,3 @@ Untrusted
 wget
 Zabbix
 Zipkin
-Debezium
-Avro
-[Ss]ubnet

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -83,3 +83,6 @@ Untrusted
 wget
 Zabbix
 Zipkin
+Debezium
+Avro
+[Ss]ubnet

--- a/_toc.yml
+++ b/_toc.yml
@@ -148,6 +148,7 @@ entries:
           - file: docs/products/flink/concepts/checkpoints
           - file: docs/products/flink/concepts/supported_syntax_sql_editor
           - file: docs/products/flink/concepts/kafka_connectors
+          - file: docs/products/flink/concepts/kafka_connector_requirements
       - file: docs/products/flink/howto
         title: HowTo
         entries:

--- a/_toc.yml
+++ b/_toc.yml
@@ -137,6 +137,7 @@ entries:
   - file: docs/products/flink/index
     title: Flink
     entries:
+      - file: docs/products/flink/overview
       - file: docs/products/flink/getting-started
       - file: docs/products/flink/concepts
         title: Concepts

--- a/docs/products/flink/concepts/kafka_connector_requirements.rst
+++ b/docs/products/flink/concepts/kafka_connector_requirements.rst
@@ -1,0 +1,38 @@
+Requirements for Kafka connectors
+=================================
+
+This article outlines the required settings for standard and upsert Kafka connectors in Aiven for Apache Flink.
+
+.. note::
+
+   Aiven for Apache Flink supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Description
+    - Standard connector
+    - Upsert connector
+  * - Key data format
+    - Sets the format that is used to convert the *key* part of Kafka messages.
+    - Optional
+    - Required
+  * - Key fields
+    - Defines the columns from the SQL schema of the data table that are considered keys in the Kafka messages.
+    - Optional (required if a key data format is selected)
+    - Not available
+  * - Value data format
+    - Sets the format that is used to convert the *value* part of Kafka messages.
+    - Required
+    - Required
+  * - Primary key
+    - Defines the column in the SQL schema that is used to identify each message. Flink uses this to determine whether to insert a new message or update or delete an existing message. Defined with the ``PRIMARY KEY`` entry in the SQL schema for the data table. For example::
+
+         PRIMARY KEY (hostname) NOT ENFORCED
+
+    - Optional
+    - Required
+
+

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -39,3 +39,29 @@ If you want to use multiple data streams as a source, but have the results for m
 
 In addition, choose upsert connectors if you want to provide the output as a compacted topic and read only the latest value for each message key.
 
+
+Requirements for each connector type
+------------------------------------
+
+**Key data format**
+  This sets the format that is used to convert the *key* part of Kafka messages.
+
+  This is optional for standard Kafka connectors, but required for upsert Kafka connectors.
+
+**Key fields**
+  This defines the columns from the SQL schema of the data table that are considered keys in the Kafka messages.
+
+  For standard Kafka connectors, this is required if you select a **Key data format**. It is not available for upsert Kafka connectors.
+
+**Value data format**
+  This sets the format that is used to convert the *value* part of Kafka messages.
+
+  This is required for both types of Kafka connector.
+
+**Primary key**
+  This defines the column in the SQL schema that is used to identify each message. Flink uses this to determine whether to insert a new message or update or delete an existing message.
+
+  Required for upsert Kafka connectors and defined with the ``PRIMARY KEY`` entry in the SQL schema for the data table. For example::
+
+      PRIMARY KEY (hostname) NOT ENFORCED
+

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -39,4 +39,4 @@ If you want to use multiple data streams as a source, but have the results for m
 
 In addition, choose upsert connectors if you want to provide the output as a compacted topic and read only the latest value for each message key.
 
-
+For more details on the required information for each connector type, see :doc:`this article <kafka_connector_requirements>`.

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -40,32 +40,3 @@ If you want to use multiple data streams as a source, but have the results for m
 In addition, choose upsert connectors if you want to provide the output as a compacted topic and read only the latest value for each message key.
 
 
-Requirements for each connector type
-------------------------------------
-
-.. note::
-
-   Aiven for Apache Flink supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
-
-**Key data format**
-  This sets the format that is used to convert the *key* part of Kafka messages.
-
-  This is not required for standard Kafka connectors unless you want to specify a list of keys. Required for upsert Kafka connectors.
-
-**Key fields**
-  This defines the columns from the SQL schema of the data table that are considered keys in the Kafka messages.
-
-  For standard Kafka connectors, this is required if you select a **Key data format**. It is not available for upsert Kafka connectors.
-
-**Value data format**
-  This sets the format that is used to convert the *value* part of Kafka messages.
-
-  This is required for both types of Kafka connector.
-
-**Primary key**
-  This defines the column in the SQL schema that is used to identify each message. Flink uses this to determine whether to insert a new message or update or delete an existing message.
-
-  Required for upsert Kafka connectors and defined with the ``PRIMARY KEY`` entry in the SQL schema for the data table. For example::
-
-      PRIMARY KEY (hostname) NOT ENFORCED
-

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -43,6 +43,10 @@ In addition, choose upsert connectors if you want to provide the output as a com
 Requirements for each connector type
 ------------------------------------
 
+.. note::
+
+   Aiven for Apache Flink supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+
 **Key data format**
   This sets the format that is used to convert the *key* part of Kafka messages.
 

--- a/docs/products/flink/concepts/kafka_connectors.rst
+++ b/docs/products/flink/concepts/kafka_connectors.rst
@@ -50,7 +50,7 @@ Requirements for each connector type
 **Key data format**
   This sets the format that is used to convert the *key* part of Kafka messages.
 
-  This is optional for standard Kafka connectors, but required for upsert Kafka connectors.
+  This is not required for standard Kafka connectors unless you want to specify a list of keys. Required for upsert Kafka connectors.
 
 **Key fields**
   This defines the columns from the SQL schema of the data table that are considered keys in the Kafka messages.

--- a/docs/products/flink/howto/connect/connect-kafka.rst
+++ b/docs/products/flink/howto/connect/connect-kafka.rst
@@ -7,11 +7,9 @@ To create a Flink table based on Aiven for Apache Kafka via Aiven console:
 
 2. Select the **Data Tables** sub-tab and select the Aiven for Apache Kafka integration to use.
 
-3. Select the *Connector type* and *Table data format*.
+3. Select the connector type and data formats.
 
-   For more information on the connector types, see :doc:`this article </docs/products/flink/concepts/kafka_connectors>`.
-
-   For more information on the supported data formats, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+   For more information on the connector types and the requirements for each of them, see :doc:`this article </docs/products/flink/concepts/kafka_connectors>`.
 
 4. Define the Flink table **Name**, the source **Kafka topic** and **Schema SQL**.
 

--- a/docs/products/flink/howto/connect/connect-kafka.rst
+++ b/docs/products/flink/howto/connect/connect-kafka.rst
@@ -3,11 +3,17 @@ Create a Kafka based Apache Flink table
 
 To create a Flink table based on Aiven for Apache Kafka via Aiven console:
 
-1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab
+1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab.
 
-2. Select the **Data Tables** sub-tab and select the Aiven for Apache Kafka integration to use
+2. Select the **Data Tables** sub-tab and select the Aiven for Apache Kafka integration to use.
 
-3. Define the Flink table **Name**, the source **Kafka topic** and **Schema SQL** 
+3. Select the *Connector type* and *Table data format*.
+
+   For more information on the connector types, see :doc:`this article </docs/products/flink/concepts/kafka_connectors>`.
+
+   For more information on the supported data formats, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+
+4. Define the Flink table **Name**, the source **Kafka topic** and **Schema SQL**.
 
 **Example**: Define a Flink table named ``KCpuIn`` pointing to a Kafka topic named ``cpuIn`` available in the Aiven for Apache Kafka service named ``kafka-devportal-example``
 

--- a/docs/products/flink/howto/connect/connect-kafka.rst
+++ b/docs/products/flink/howto/connect/connect-kafka.rst
@@ -7,8 +7,9 @@ To create a Flink table based on Aiven for Apache Kafka via Aiven console:
 
 2. Select the **Data Tables** sub-tab and select the Aiven for Apache Kafka integration to use.
 
-3. Select the connector type and data formats.
+3. Select the Kafka connector type and data formats.
 
+.. Note::   
    For more information on the connector types and the requirements for each of them, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka_connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka_connector_requirements>`.
 
 4. Define the Flink table **Name**, the source **Kafka topic** and **Schema SQL**.

--- a/docs/products/flink/howto/connect/connect-kafka.rst
+++ b/docs/products/flink/howto/connect/connect-kafka.rst
@@ -9,7 +9,7 @@ To create a Flink table based on Aiven for Apache Kafka via Aiven console:
 
 3. Select the connector type and data formats.
 
-   For more information on the connector types and the requirements for each of them, see :doc:`this article </docs/products/flink/concepts/kafka_connectors>`.
+   For more information on the connector types and the requirements for each of them, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka_connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka_connector_requirements>`.
 
 4. Define the Flink table **Name**, the source **Kafka topic** and **Schema SQL**.
 

--- a/docs/products/flink/howto/real_time_alerting_solution.rst
+++ b/docs/products/flink/howto/real_time_alerting_solution.rst
@@ -116,13 +116,13 @@ This setup uses a fixed threshold to filter any instances of high CPU load to a 
 
 #. Go to the **Data Tables** subtab.
 
-#. Select your Kafka service, enter ``CPU_IN`` as the name, select ``cpu_load_stats_real`` as the topic, and enter the following as the SQL schema, then click **Create Table**:
+#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_IN`` as the name, select ``cpu_load_stats_real`` as the topic, and enter the following as the SQL schema, then click **Create Table**:
 
    .. literalinclude:: /code/products/flink/alerting_solution_sql.md
       :lines: 2-8
       :language: sql
 
-#. Create another table by entering ``CPU_OUT_FILTER`` as the name, ``cpu_load_stats_real_filter`` as the topic, and the following as the SQL schema, then click **Create Table**:
+#. Create another table with the default selection for connector type, key, and value data format, enter ``CPU_OUT_FILTER`` as the name, ``cpu_load_stats_real_filter`` as the topic, and the following as the SQL schema, then click **Create Table**:
 
    .. literalinclude:: /code/products/flink/alerting_solution_sql.md
       :lines: 11-14
@@ -152,7 +152,7 @@ This setup uses :doc:`windows </docs/products/flink/concepts/windows>` to determ
 
 1. Go to the **Data Tables** subtab.
 
-#. Select your Kafka service, enter ``CPU_OUT_AGG`` as the name, ``cpu_load_stats_agg`` as the topic, and the following as the SQL schema, then click **Create Table**:
+#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_OUT_AGG`` as the name, ``cpu_load_stats_agg`` as the topic, and the following as the SQL schema, then click **Create Table**:
    
    .. literalinclude:: /code/products/flink/alerting_solution_sql.md
       :lines: 27-32
@@ -221,7 +221,7 @@ This setup uses host-specific thresholds that are stored in PostgreSQL as a basi
       :lines: 57-59
       :language: sql
 
-#. Select your Kafka service, enter ``CPU_OUT_FILTER_PG`` as the name, ``cpu_load_stats_real_filter_pg`` as the topic, and the following as the SQL schema, then click **Create Table**:
+#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_OUT_FILTER_PG`` as the name, ``cpu_load_stats_real_filter_pg`` as the topic, and the following as the SQL schema, then click **Create Table**:
    
    .. literalinclude:: /code/products/flink/alerting_solution_sql.md
       :lines: 62-66

--- a/docs/products/flink/howto/real_time_alerting_solution.rst
+++ b/docs/products/flink/howto/real_time_alerting_solution.rst
@@ -116,17 +116,37 @@ This setup uses a fixed threshold to filter any instances of high CPU load to a 
 
 #. Go to the **Data Tables** subtab.
 
-#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_IN`` as the name, select ``cpu_load_stats_real`` as the topic, and enter the following as the SQL schema, then click **Create Table**:
+#. Create the source Kafka table:
 
-   .. literalinclude:: /code/products/flink/alerting_solution_sql.md
-      :lines: 2-8
-      :language: sql
+   a. Select your Kafka service.
+   b. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Empty key** as the key.
+   d. Select **JSON** as the value data format.
+   e. Enter ``CPU_IN`` as the name
+   f. Select ``cpu_load_stats_real`` as the topic.
+   g. Enter the following as the SQL schema:
 
-#. Create another table with the default selection for connector type, key, and value data format, enter ``CPU_OUT_FILTER`` as the name, ``cpu_load_stats_real_filter`` as the topic, and the following as the SQL schema, then click **Create Table**:
+      .. literalinclude:: /code/products/flink/alerting_solution_sql.md
+         :lines: 2-8
+         :language: sql
 
-   .. literalinclude:: /code/products/flink/alerting_solution_sql.md
-      :lines: 11-14
-      :language: sql
+   h. Click **Create Table**.
+
+#. Create the sink Kafka table:
+
+   a. Select your Kafka service.
+   b. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Empty key** as the key.
+   d. Select **JSON** as the value data format.
+   e. Enter ``CPU_OUT_FILTER`` as the name
+   f. Select ``cpu_load_stats_real_filter`` as the topic.
+   g. Enter the following as the SQL schema:
+
+      .. literalinclude:: /code/products/flink/alerting_solution_sql.md
+         :lines: 11-14
+         :language: sql
+
+   h. Click **Create Table**.
 
 #. Go to the **Create SQL Job** subtab.
 
@@ -152,11 +172,21 @@ This setup uses :doc:`windows </docs/products/flink/concepts/windows>` to determ
 
 1. Go to the **Data Tables** subtab.
 
-#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_OUT_AGG`` as the name, ``cpu_load_stats_agg`` as the topic, and the following as the SQL schema, then click **Create Table**:
-   
-   .. literalinclude:: /code/products/flink/alerting_solution_sql.md
-      :lines: 27-32
-      :language: sql
+#. Create the sink Kafka table:
+
+   a. Select your Kafka service.
+   b. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Empty key** as the key.
+   d. Select **JSON** as the value data format.
+   e. Enter ``CPU_OUT_AGG`` as the name
+   f. Select ``cpu_load_stats_agg`` as the topic.
+   g. Enter the following as the SQL schema:
+
+      .. literalinclude:: /code/products/flink/alerting_solution_sql.md
+         :lines: 27-32
+         :language: sql
+
+   h. Click **Create Table**.
 
 #. Go to the **Create SQL Job** subtab.
 
@@ -221,11 +251,21 @@ This setup uses host-specific thresholds that are stored in PostgreSQL as a basi
       :lines: 57-59
       :language: sql
 
-#. Select your Kafka service, use the default selection for connector type, key, and value data format, enter ``CPU_OUT_FILTER_PG`` as the name, ``cpu_load_stats_real_filter_pg`` as the topic, and the following as the SQL schema, then click **Create Table**:
-   
-   .. literalinclude:: /code/products/flink/alerting_solution_sql.md
-      :lines: 62-66
-      :language: sql
+#. Create the sink Kafka table:
+
+   a. Select your Kafka service.
+   b. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Empty key** as the key.
+   d. Select **JSON** as the value data format.
+   e. Enter ``CPU_OUT_FILTER_PG`` as the name
+   f. Select ``cpu_load_stats_real_filter_pg`` as the topic.
+   g. Enter the following as the SQL schema:
+
+      .. literalinclude:: /code/products/flink/alerting_solution_sql.md
+         :lines: 62-66
+         :language: sql
+
+   h. Click **Create Table**.
 
 #. Go to the **Create SQL Job** subtab
 

--- a/docs/products/flink/howto/real_time_alerting_solution.rst
+++ b/docs/products/flink/howto/real_time_alerting_solution.rst
@@ -120,7 +120,7 @@ This setup uses a fixed threshold to filter any instances of high CPU load to a 
 
    a. Select your Kafka service.
    b. Select **Apache Kafka SQL Connector** as the connector type.
-   c. Select **Empty key** as the key.
+   c. Select **Key not used** as the key.
    d. Select **JSON** as the value data format.
    e. Enter ``CPU_IN`` as the name
    f. Select ``cpu_load_stats_real`` as the topic.
@@ -136,7 +136,7 @@ This setup uses a fixed threshold to filter any instances of high CPU load to a 
 
    a. Select your Kafka service.
    b. Select **Apache Kafka SQL Connector** as the connector type.
-   c. Select **Empty key** as the key.
+   c. Select **Key not used** as the key.
    d. Select **JSON** as the value data format.
    e. Enter ``CPU_OUT_FILTER`` as the name
    f. Select ``cpu_load_stats_real_filter`` as the topic.
@@ -176,7 +176,7 @@ This setup uses :doc:`windows </docs/products/flink/concepts/windows>` to determ
 
    a. Select your Kafka service.
    b. Select **Apache Kafka SQL Connector** as the connector type.
-   c. Select **Empty key** as the key.
+   c. Select **Key not used** as the key.
    d. Select **JSON** as the value data format.
    e. Enter ``CPU_OUT_AGG`` as the name
    f. Select ``cpu_load_stats_agg`` as the topic.
@@ -255,7 +255,7 @@ This setup uses host-specific thresholds that are stored in PostgreSQL as a basi
 
    a. Select your Kafka service.
    b. Select **Apache Kafka SQL Connector** as the connector type.
-   c. Select **Empty key** as the key.
+   c. Select **Key not used** as the key.
    d. Select **JSON** as the value data format.
    e. Enter ``CPU_OUT_FILTER_PG`` as the name
    f. Select ``cpu_load_stats_real_filter_pg`` as the topic.

--- a/docs/products/flink/index.rst
+++ b/docs/products/flink/index.rst
@@ -1,10 +1,12 @@
-Aiven for Apache Flink
-=======================
+Aiven for Apache Flink ``beta``
+===============================
 
 What is Aiven for Apache Flink?
 -------------------------------
 
-Aiven for Apache Flink is a fully managed **distributed processing engine for stateful computations over data streams**, deployable in the cloud of your choice enabling the creation of streaming data pipelines on top of your datasets.
+Aiven for Apache Flink beta is powered by the open-source framework Apache Flink, a **distributed processing engine for stateful computations over data streams**. It enables you to easily get started with real-time stream processing using SQL.
+
+With the launch of this service, data pipelines on Aiven now support data processing. The service is currently available as a beta release and is intended for **non-production use**. We welcome your feedback on the service and feature requests via our support channel.
 
 
 Why Flink?
@@ -19,33 +21,29 @@ A key part of data stream processing is the ability to filter and transform inco
 While the optimal solution depends largely on your use case and goals, the versatility of Apache Flink makes it a good option for many situations. As it uses SQL as a key part of constructing data pipelines, it is quite an approachable option for people who are already familiar with databases and batch processing. However, there are some relevant concepts (such as :doc:`windows <concepts/windows>`, :doc:`watermarks <concepts/watermarks>`, and :doc:`checkpoints <concepts/checkpoints>`) that are worth knowing if you are new to data stream processing.
 
 
-Get started with Aiven for Apache Flink
----------------------------------------
+Get started with Aiven for Apache Flink ``beta``
+------------------------------------------------
 
 Take your first steps with Aiven for Apache Flink by following our :doc:`getting-started` article, or browse through our full list of articles:
 
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📖 :doc:`Overview <overview>`
+
+    ---
+
+    💻 :doc:`Getting started <getting-started>`
+
+    ---
+
+    📙 :doc:`Concepts <concepts>`
 
     ---
 
     💻 :doc:`howto`
 
 
-Integrates with your existing tools
-------------------------------------
-
-Flink is highly compatible with other Aiven products for the following tasks:
-
-- Parse, transform, calculate streaming data from Aiven for Apache Kafka.
-
-- Ingest changes on relational PostgreSQL or MySQL tables.
-
-- Join data coming from various sources listed above to create complex data pipelines.
-  
-- Stream the data pipeline result back to Apache Kafka or any of the supported sinks.
 
 Flink resources
 ---------------

--- a/docs/products/flink/overview.rst
+++ b/docs/products/flink/overview.rst
@@ -25,7 +25,7 @@ Managed service features
 **Scaling a Flink cluster**
   Each node is equipped with a TaskManager and JobManager. We recommend that you scale up your cluster to add more CPU and memory for the TaskManager before attempting to scale out. This approach makes the best use of the resources available in the nodes.
 
-  By default, each created TaskManager is configured with a single slot for best isolation between jobs. We highly recommend that you adjust this setting for your use case.
+  By default, each created TaskManager is configured with a single slot for best isolation between jobs. One slot is equivalent to one running data pipeline or job. We highly recommend that you adjust this setting for your use case. You can change this setting with ``number_of_task_slots`` under **Overview** > **Advanced configuration** in the Aiven web console.
 
   .. note::
      Adjusting the task slots per TaskManager requires a cluster restart.	
@@ -50,7 +50,7 @@ Managed service features
   * push service metrics to M3, InfluxDB, or PostgreSQL services on Aiven
   * create custom OpenSearch or Grafana dashboards to monitor the service 
 
-  The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption.
+  The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <http://help.aiven.io/en/articles/5234705-technical-emails>`_.
 
 
 Apache Flink features

--- a/docs/products/flink/overview.rst
+++ b/docs/products/flink/overview.rst
@@ -1,0 +1,97 @@
+Service overview
+================
+
+This article gives you an overview of the service plans and features available in Aiven for Apache Flink beta.
+
+You can run Aiven for Apache Flink on AWS or GCP cloud environments. Various deployment options are available, ranging from fully managed access over the public internet to subnet deployments under your own cloud account. All services and infrastructure are single-tenant and dedicated solely to a single customer.
+
+Aiven offers single-node and three-node Apache Flink clusters:
+
+* Single-node clusters are not highly available, but support automatic failover. They start from 4GB RAM/2 vCPU and extend up to 32GB/8 vCPU. This setup is a good option for proof of concepts and preliminary testing for development purposes.
+
+* Three-node clusters are highly available, support automatic failover, and range from 4GB RAM/2 vCPU to 32GB/8 vCPU.
+
+Our product page provides you detailed information about the available plans and pricing. 
+
+
+Managed service features
+------------------------
+
+**Default deployment configuration**
+  Aiven for Apache Flink is configured to use the `HashMap state backend <https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.html>`_. This means that the amount of `state <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/stateful-stream-processing/#what-is-state>`_ kept depends on the amount of memory available in the cluster. 
+
+  The Flink cluster executes applications in `session mode <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/deployment/overview/#session-mode>`_, so you can deploy multiple Flink jobs on the same cluster to use the available resources effectively.
+
+**Scaling a Flink cluster**
+  Each node is equipped with a TaskManager and JobManager. We recommend that you scale up your cluster to add more CPU and memory for the TaskManager before attempting to scale out. This approach makes the best use of the resources available in the nodes.
+
+  By default, each created TaskManager is configured with a single slot for best isolation between jobs. We highly recommend that you adjust this setting for your use case.
+
+  .. note::
+     Adjusting the task slots per TaskManager requires a cluster restart.	
+
+**Cluster restart strategy**
+  The cluster’s default restart strategy is configured to Failure Rate. This controls Flink’s restart behaviour in cases of failures during the execution of jobs. Administrators can overwrite this setting in the advanced configuration options for the service.
+
+  For more information on the available options, see the `Apache Flink documentation on fault tolerance <https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/config/#fault-tolerance>`_.
+
+**Disaster recovery**
+  Aiven has configured periodic checkpoints to be persisted externally in object storage. These allow Flink to recover state and positions in the data streams to provide failure-free execution.
+
+**End-to-end security**
+  All services run on a dedicated virtual machine with end-to-end encryption, and all nodes are firewalled.
+
+**Cluster logging, metrics, and alerting**
+  Administrators can configure log and metrics integrations to Aiven services so that you can monitor the health of your service.
+
+  These integrations allow you to
+
+  * push service logs to an index in Aiven for OpenSearch
+  * push service metrics to M3, InfluxDB, or PostgreSQL services on Aiven
+  * create custom OpenSearch or Grafana dashboards to monitor the service 
+
+  The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption.
+
+
+Apache Flink features
+---------------------
+
+**Flink SQL**
+  Apache Flink enables you to develop streaming applications using standard SQL. The :doc:`Aiven web console provides an SQL editor <concepts/supported_syntax_sql_editor>` to explore the table schema and create SQL queries to process streaming data.
+
+**Built-in data flow integration with Aiven for Apache Kafka**
+  Connect with Aiven for Apache Kafka as a source or sink for your data.
+
+  * Autocompletion for finding existing topics in a connected Kafka service when you create data tables.
+  * Choose the table format when reading data from Kafka - JSON, Apache Avro, Confluent Avro, Debezium CDC.
+  * Supports :doc:`upsert Kafka connectors <concepts/kafka_connectors>`, which allow you to produce a changelog stream, where each data record represents an update or delete event.
+
+**Built-in data flow integration with Aiven for PostgreSQL**
+  Connect with Aiven for PostgreSQL as a source or sink for your data. The Aiven web console features autocompletion for finding existing databases in a connected PostgreSQL service when you create data tables.
+
+**Automate workflows**
+  Automate workflows for managing Flink services with :doc:`Aiven Terraform Provider </docs/tools/terraform>`. See the `Flink data source <https://registry.terraform.io/providers/aiven/aiven/latest/docs/data-sources/flink>`_ for details.
+
+
+Limitations
+-----------
+
+* State is kept in memory, which can impact the performance of jobs that require keeping a very large state.
+* User-defined functions are not supported.
+* The Apache Flink CLI tool cannot be used with this service as it requires access to the JobManager in production, which is currently not exposed to customers.
+* Job-level settings are not yet supported. Each job inherits the cluster-level settings.
+* Flame graphs, marked as an experimental feature in Apache Flink 1.13, are not enabled in the Flink web UI.
+* The credentials used for data flow integrations between Flink and other Aiven services have read/write permissions on the clusters.
+
+  As a workaround for more strict access management on the source cluster, you can set up separate clusters for writing processed data from Flink. This minimizes the risk of accidental write events to the source cluster.
+
+
+Known issues
+------------
+
+* Running jobs must be manually restarted after powering off the cluster or when changing service plans.
+* Cancelled and failed jobs cannot be restarted.
+* Jobs and tables cannot be edited after they are created.
+* TaskManager logs are not visible for multi-node clusters in the Flink web UI.
+* If the service that is configured as a source is powered off, creating a new job prompts an internal server error. If you see this error, check that your source services are powered on.
+* While we have aimed to make the error messages more informative, you may see error messages directly rendered as-is from Flink. These messages are technical in nature and include a stack trace of the exception.

--- a/docs/products/flink/overview.rst
+++ b/docs/products/flink/overview.rst
@@ -39,7 +39,7 @@ Managed service features
   Aiven has configured periodic checkpoints to be persisted externally in object storage. These allow Flink to recover state and positions in the data streams to provide failure-free execution.
 
 **End-to-end security**
-  All services run on a dedicated virtual machine with end-to-end encryption, and all nodes are firewalled.
+  All services run on a dedicated virtual machine with end-to-end encryption, and all nodes are firewall-protected.
 
 **Cluster logging, metrics, and alerting**
   Administrators can configure log and metrics integrations to Aiven services so that you can monitor the health of your service.


### PR DESCRIPTION
Updates based on Jira ticket HH-511:
- Added a new "Service overview" article -> removed "Integrates with your existing tools" section from landing page, as that content is pretty much covered in the new article
- Changed "Aiven for Apache Flink" to "Aiven for Apache Flink beta" in the landing page title and a few other places
- Added a step to Kafka table creation flow on connector type and data format selection
- Updated console instructions for the real-time alerting example to include connector type and data format references

Note: The service plan specifications in "Service overview" may require updating once they are finalized.