### PR TITLE
Upgraded Sphinx to v4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 furo==2021.08.17.beta43
-sphinx==4.0.3
+sphinx==4.3.0
 sphinx-autobuild==2021.3.14
 sphinx-panels==0.6.0
 sphinxcontrib-mermaid==0.7.1


### PR DESCRIPTION
`Sphinx 4.0.3` breaks when `make livehtml` with `Python 3.10.0`
<pre>
ImportError: cannot import name 'Union' from 'types' (/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/types.py)
Command exited with exit code: 1
</pre>
