### PR TITLE
Experimental branch for avn service

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -47,8 +47,8 @@ Memorystore
 NodeJS
 npm
 Okta
-[Oo]perator
 OpenSearch
+[Oo]perator
 Pagerduty
 Pagila
 parallelization

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -18,6 +18,7 @@ Epicurious
 etcd
 failover
 fileset[s]?
+Flink
 Geomap
 geospatial
 [Gg]o

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -34,6 +34,8 @@ Instana
 jq
 Kaggle
 Karapace
+[Kk]eypair
+[Kk]eystore
 Kibana
 Kubernetes
 kuromoji
@@ -56,6 +58,7 @@ Plotly
 pooler
 PostgreSQL
 Postman
+[Pp]rivatelink
 psql
 Python
 Redis
@@ -73,6 +76,7 @@ Terraform
 Terraforming
 TimescaleDB
 toolchain
+[Tt]ruststore
 Uber
 unencrypted
 Untrusted

--- a/_toc.yml
+++ b/_toc.yml
@@ -33,6 +33,9 @@ entries:
         - file: docs/tools/cli/credits
         - file: docs/tools/cli/events
         - file: docs/tools/cli/project
+        - file: docs/tools/cli/service
+          entries:
+            - glob: docs/tools/cli/service/* 
         - file: docs/tools/cli/user
           entries:
             - glob: docs/tools/cli/user/*

--- a/docs/tools/cli/cloud.rst
+++ b/docs/tools/cli/cloud.rst
@@ -9,6 +9,7 @@ List cloud region details
 
 Commands for listing cloud regions to be used when creating or moving instances with ``avn`` commands.
 
+.. _avn-cloud-list:
 
 ``avn cloud list``
 '''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -296,12 +296,45 @@ Service M3 commands
 ``avn service maintenance-start``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Start service maintenance updates
+Starts the service maintenance updates.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Start the maintenance updates for the service named ``pg-demo``.
+
+::
+
+    avn service maintenance-start pg-demo
 
 ``avn service metrics``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Get service metrics
+Retrieves the metrics for a defined service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--period``
+    - The time period to retrieve the metrics for (possible values ``hour``, ``day``, ``week``, ``month``, ``year``)
+
+**Example:** Retrieve the daily metrics for the service named ``pg-demo``.
+
+::
+
+    avn service metrics pg-demo --period day
+
 
 ``avn service migration-status``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -353,12 +386,43 @@ Service Privatelink commands
 ``avn service queries``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List service query statistics
+Lists the service connections/queries statistics for an Aiven for PostgreSQL, Aiven for MySQL or Aiven for Redis service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the queries for a service named ``pg-demo``.
+
+::
+  
+  avn service queries pg-demo
+
 
 ``avn service queries-reset``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Reset service query statistics
+Resets service connections/queries statistics for an Aiven for PostgreSQL, Aiven for MySQL or Aiven for Redis service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Reset the queries for a service named ``pg-demo``.
+
+::
+  
+  avn service queries-reset pg-demo
 
 ``avn service schema``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -10,87 +10,12 @@ Manage service details
 Commands for managing Aiven services via ``avn`` commands. 
 
 
-``avn service acl-add``
+``avn service acl``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Adds an Aiven for Apache Kafka ACL entry.
+Manages the Aiven for Apache Kafka ACL entries. 
 
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--permission``
-    - The permission type: possible values are ``read``, ``write`` or ``readwrite``
-  * - ``--topic``
-    - The topic name pattern: accepts ``*`` and ``?`` as wildcard characters
-  * - ``--username``
-    - The username pattern: accepts ``*`` and ``?`` as wildcard characters
-
-**Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service``kafka-doc``.
-
-::
-
-  avn service acl-add kafka-doc --username *userA --permission readwrite --topic topic2020*
-
-
-
-``avn service acl-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Deletes an Aiven for Apache Kafka ACL entry.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``acl_id``
-    - The id of the ACL to delete
-
-
-**Example:** Delete the ACLs with id ``acl3604f96c74a`` on the Aiven for Apache Kafka instance named ``kafka-doc``.
-
-::
-
-  avn service acl-delete kafka-doc acl3604f96c74a
-
-``avn service acl-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Lists Aiven for Apache Kafka ACL entries.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-
-**Example:** List the ACLs defined for a service named ``kafka-doc``.
-
-::
-
-  avn service acl-list kafka-doc
-
-
-An example of ``account service acl-list`` output:
-
-.. code:: text
-
-    ID              USERNAME  TOPIC      PERMISSION
-    ==============  ========  =========  ==========
-    default         *         *          admin
-    acl3604f96c74a  Jon       orders     readwrite
-    acl3604fa706cb  Frida     invoices*  write
+More information on ``acl-add``, ``acl-delete`` and ``acl-list`` can be found in :doc:`the dedicated page <service/acl>`.
 
 ``avn service ca``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -135,130 +60,12 @@ Opens an interactive shell to the given service. Supported only for Aiven for In
 
   avn service cli pg-doc
 
-``avn service connection-pool-create``
+``avn service connection-pool``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
+Manages the :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
 
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--pool-name``
-    - The name of the connection pool
-  * - ``--dbname``
-    - The name of the database
-  * - ``--username``
-    - The database username to use for the connection pool
-  * - ``--pool-size``
-    - Size of the connection pool in number of connections
-  * - ``--pool-mode``
-    - The :ref:`pool mode <pooling-modes>`. Possible values are ``transaction``, ``session`` and ``statement``
-
-**Example:** In the service ``pg-doc`` Create a new connection pool named ``cp-analytics-it`` for the database ``it-analytics`` with:
-
-* username ``avnadmin``
-* pool-size of ``10`` connections 
-* ``transaction`` pool-mode
-
-::
-
-  avn service connection-pool-create pg-doc \
-    --pool-name cp-analytics-it             \
-    --dbname analytics-it                   \
-    --username avnadmin                     \
-    --pool-size 10                          \
-    --pool-mode transaction
-
-``avn service connection-pool-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Deletes a :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--pool-name``
-    - The name of the connection pool
-
-**Example:** Delete the connection pool named ``cp-analytics-it`` in the service ``pg-doc``.
-
-::
-
-  avn service connection-pool-delete pg-doc --pool-name cp-analytics-it
-
-
-``avn service connection-pool-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Lists the :doc:`PgBouncer connection pools </docs/products/postgresql/concepts/pg-connection-pooling>` available in a given PostgreSQL service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the Service
-
-**Example:** List the PgBouncer connection pools for the service ``pg-doc``.
-
-::
-
-  avn service connection-pool-list pg-doc 
-
-
-An example of ``account service connection-pool-list`` output:
-
-.. code:: text
-
-  POOL_NAME        DATABASE   USERNAME  POOL_MODE    POOL_SIZE
-  ===============  =========  ========  ===========  =========
-  cp-analytics-it  defaultdb  avnadmin  transaction  10
-
-
-``avn service connection-pool-update``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Updates a :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service. 
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--pool-name``
-    - The name of the connection pool
-  * - ``--dbname``
-    - The name of the database
-  * - ``--username``
-    - The database username to use for the connection pool
-  * - ``--pool-size``
-    - Size of the connection pool in number of connections
-  * - ``--pool-mode``
-    - The :ref:`pool mode <pooling-modes>`. Possible values are ``transaction``, ``session`` and ``statement``
-
-**Example:** Update the connection pool named ``cp-analytics-it`` in the service ``pg-doc`` and set the ``--pool-size`` parameter to ``20``.
-
-::
-  
-  avn service connection-pool-update pg-doc \
-    --pool-name cp-analytics-it             \
-    --pool-size 20
-
+More information on ``connection-pool-add``, ``connection-pool-delete``, ``connection-pool-list`` and ``connection-pool-update`` can be found in :doc:`the dedicated page <service/connection-pool>`.
 
 ``avn service connector``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -308,7 +115,7 @@ Creates a new service.
 ``avn service credentials-reset``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Resets the service credentials.
+Resets the service credentials. More information on user password change is provided in the :doc:`dedicated page <service/user>`.
 
 
 .. list-table::
@@ -347,104 +154,20 @@ List current service connections/queries for an Aiven for PostgreSQL, Aiven for 
   
   avn service current-queries pg-demo
 
-``avn service database-create``
+``avn service database``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+Manages databases within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
 
-.. list-table::
-  :header-rows: 1
-  :align: left
+More information on ``database-add``, ``database-delete`` and ``database-list`` can be found in :doc:`the dedicated page <service/database>`.
 
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--dbname``
-    - The name of the database
 
-**Example:** Create a new database named ``analytics-it`` within the service named ``pg-demo``.
-
-::
-  
-  avn service database-create pg-demo --dbname analytics-it
-
-``avn service database-delete``
+``avn service es-acl``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Removes a specific database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+Manages rules to opensearch ACL and extended ACL configuration.
 
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--dbname``
-    - The name of the database
-
-**Example:** Delete the database named ``analytics-it`` within the service named ``pg-demo``
-
-::
-
-    avn service database-delete pg-demo --dbname analytics-it  
-
-``avn service database-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Lists the service databases available in an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-
-**Example:** List the service databases within the service named ``pg-demo``
-
-::
-
-    avn service database-list pg-demo
-
-``avn service es-acl-add``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Add rules to opensearch ACL configuration
-
-``avn service es-acl-del``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Delete rules from opensearch ACL configuration
-
-``avn service es-acl-disable``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Disable Opensearch ACL configuration
-
-``avn service es-acl-enable``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Enable Opensearch ACL configuration
-
-``avn service es-acl-extended-disable``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Disable Opensearch Extended ACL 
-
-``avn service es-acl-extended-enable``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Enable Opensearch Extended ACL 
-
-``avn service es-acl-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List Opensearch ACL configuration
+More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl-enable``, ``es-acl-extended-disable``, ``es-acl-extended-enable`` and ``es-acl-extended-list``  can be found in :doc:`the dedicated page <service/es-acl>`.
 
 ``avn service get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -475,65 +198,19 @@ Retrieves a single service details.
     avn service get pg-demo --json
 
 
-``avn service index-delete``
+``avn service index``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete Opensearch service index
+Manages Opensearch service indexes.
 
-``avn service index-list``
+More information on ``index-delete`` and  ``index-list`` can be found in :doc:`the dedicated page <service/index>`.
+
+``avn service integration``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List Opensearch service indexes
+Manages Aiven internal and external services integrations.
 
-``avn service integration-create``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Create a service integration
-
-``avn service integration-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Delete a service integration
-
-``avn service integration-endpoint-create``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Create a service integration endpoint 
-
-``avn service integration-endpoint-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Delete a service integration endpoint 
-
-``avn service integration-endpoint-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List service integration endpoints 
-
-``avn service integration-endpoint-types-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List all available integration endpoint types for given project 
-
-``avn service integration-endpoint-update``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Update a service integration endpoint 
-
-``avn service integration-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List service integrations
-
-``avn service integration-types-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List all available integration types for given project 
-
-``avn service integration-update``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Update a service integration
+More information on ``integration-delete``, ``integration-endpoint-create``, ``integration-endpoint-delete``, ``integration-endpoint-list``, ``integration-endpoint-types-list``, ``integration-endpoint-update``, ``integration-list``, ``integration-types-list`` and ``integration-update`` can be found in :doc:`the dedicated page <service/integration>`.
 
 ``avn service keypair``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -665,30 +342,12 @@ Create a service task
 
 Terminate service
 
-``avn service topic-create``
+``avn service topic``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create a Kafka topic
+Manages Aiven for Apache Kafka topics.
 
-``avn service topic-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Delete a Kafka topic
-
-``avn service topic-get``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Get Kafka service topic
-
-``avn service topic-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-List Kafka service topics
-
-``avn service topic-update``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Update a Kafka topic
+More information on ``topic-create``, ``topic-delete``, ``topic-list`` and  ``topic-update`` can be found in :doc:`the dedicated page <service/topic>`.
 
 
 .. _avn-cli-service-type:
@@ -703,197 +362,13 @@ List service types
 
 Update service settings
 
-``avn service user-create``
+``avn service user``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new user for the selected service.
+Manages Aiven users and credentials.
 
-.. list-table::
-  :header-rows: 1
-  :align: left
+More information on ``user-create``, ``user-creds-download``, ``user-delete``, ``user-get``, ``user-kafka-java-creds``, ``user-list``, ``user-password-reset`` and  ``user-set-access-control`` can be found in :doc:`the dedicated page <service/user>`.
 
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The new username to be created
-  * - ``--m3-group``
-    - The name of the group the user belongs to (for Aiven for M3 services only)
-  * - ``--redis-acl-keys``
-    - The ACL rules for keys (Aiven for Redis services only)
-  * - ``--redis-acl-commands``
-    - The ACL rules for commands (Aiven for Redis services only)
-  * - ``--redis-acl-categories``
-    - The ACL rules for categories (Aiven for Redis services only)
-  * - ``--redis-acl-channels``
-    - The ACL rules for channels (Aiven for Redis services only)
-
-**Example:** Create a new user named ``janedoe`` for a service named ``pg-demo``.
-
-::
-
-  avn service user-create pg-demo --username janedoe
-
-``avn service user-creds-download``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Downloads the SSL certificate, key and CA certificate for the selected service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The username for which to download the certificates
-  * - ``-d``
-    - The target directory where certificates will be stored
-
-**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``.
-
-::
-
-  avn service user-creds-download kafka-demo --username janedoe -d /tmp/certs
-
-``avn service user-delete``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Delete a service in a given Aiven service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The username to delete
-
-**Example:** Delete the user ``janedoe`` defined in a service named ``kafka-demo``.
-
-::
-
-  avn service user-delete kafka-demo --username janedoe
-
-``avn service user-get``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Retrieves the details for a single user in a given Aiven service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The username for which to retrieve the details
-
-**Example:** Retrieve the details for the user ``janedoe`` defined for a service named ``kafka-demo``.
-
-::
-
-  avn service user-get kafka-demo --username janedoe
-
-.. Tip::
-
-    Use the ``--json`` parameter to retrieve all the service specific information for a specific user.
-
-``avn service user-kafka-java-creds``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Download user certificate/key/CA certificate and create a Java keystore/truststore/properties from them 
-
-Downloads the SSL certificate, key and CA certificate and creates a Java keystore and truststore for the selected service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The username for which to download the certificates
-  * - ``-d``
-    - The target directory where certificates will be stored
-  * - ``--password``
-    - The Java keystore and truststore password (default: ``changeit``)
-
-**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``. Furthermore, secure the Java keystore and truststore with the password ``safePassword123``.
-
-::
-
-  avn service user-kafka-java-creds kafka-demo --username janedoe -d /tmp/certs --password safePassword123
-
-``avn service user-list``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Lists the users defined for the selected service, and the related type (``primary`` or ``normal``).
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-
-**Example:** List the users defined for a service named ``pg-doc``.
-
-::
-
-  avn service user-list pg-doc
-
-
-An example of ``account service user-list`` output:
-
-.. code:: text
-
-    USERNAME   TYPE
-    =========  =======
-    analytics  normal
-    avnadmin   primary
-
-``avn service user-password-reset``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Resets or changes the service user password.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--username``
-    - The username to change the password for
-  * - ``--new-password``
-    - The new password for the user
-
-**Example:** Change the password for the ``avnadmin`` user of the service named ``pg-doc`` to ``VerySecurePwd123``.
-
-::
-
-  avn service user-password-reset pg-doc --username avnadmin --new-password VerySecurePwd123
-
-
-``avn service user-set-access-control``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Set Redis service user access control 
 
 ``avn service versions``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -920,9 +395,9 @@ An example of ``account service versions`` output:
     SERVICE_TYPE   MAJOR_VERSION  STATE        AVAILABILITY_START_TIME  AVAILABILITY_END_TIME  AIVEN_END_OF_LIFE_TIME  UPSTREAM_END_OF_LIFE_TIME  TERMINATION_TIME  END_OF_LIFE_HELP_ARTICLE_URL
     =============  =============  ===========  =======================  =====================  ======================  =========================  ================  ====================================================================================================
     cassandra      3.11           available    2018-11-08T00:00:00Z     null                   null                    null                       null              null
-    Opensearch  7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    Opensearch  7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    Opensearch  7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch     7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch     7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch     7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
     kafka          2.3            unavailable  2019-09-05T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     kafka          2.4            unavailable  2019-10-21T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     ...

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -70,7 +70,9 @@ More information on ``connection-pool-add``, ``connection-pool-delete``, ``conne
 ``avn service connector``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Set of commands for managing Aiven for Apache Kafka Connect connectors. :doc:`See detailed command information <service/connector>` for more information
+Set of commands for managing Aiven for Apache Kafka Connect connectors. 
+
+More information on ``connector available``, ``connector create``, ``connector delete``, ``connector list``, ``connector pause``, ``connector restart``, ``connector restart-task``, ``connector resume``, ``connector schema``, ``connector status`` and ``connector update`` can be found in the :doc:`dedicated page <service/connector>`.
 
 ``avn service create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -241,7 +241,7 @@ Lists services within an Aiven project.
 
 An example of ``account service list`` output:
 
-.. code:: tex
+.. code:: text
 
   SERVICE_NAME        SERVICE_TYPE  STATE    CLOUD_NAME           PLAN         CREATE_TIME           UPDATE_TIME
   ==================  ============  =======  ===================  ===========  ====================  ====================
@@ -357,12 +357,79 @@ More information on ``topic-create``, ``topic-delete``, ``topic-list`` and  ``to
 ``avn service types``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List service types
+Lists the Aiven service types available in a project.
+
+
+**Example:** Retrieve all the services types available in the currently selected project.
+
+::
+
+    avn service types
+
+An example of ``account service types`` output:
+
+.. code:: text
+
+  SERVICE_TYPE       DESCRIPTION
+  =================  ===================================================================================
+  cassandra          Cassandra - Distributed NoSQL data store
+  elasticsearch      Elasticsearch - Search & Analyze Data in Real Time
+  grafana            Grafana - Metrics Dashboard
+  influxdb           InfluxDB - Distributed Time Series Database
+  kafka              Kafka - High-Throughput Distributed Messaging System
+  kafka_connect      Kafka Connect - Kafka Connect service
+  kafka_mirrormaker  Kafka MirrorMaker - Kafka MirrorMaker service
+  m3aggregator       M3 Aggregator - Aggregates metrics and provides downsampling
+  m3db               M3DB - Distributed time series database
+  mysql              MySQL - Relational Database Management System
+  opensearch         OpenSearch - Search & Analyze Data in Real Time, derived from Elasticsearch v7.10.2
+  pg                 PostgreSQL - Object-Relational Database Management System
+  redis              Redis - In-Memory Data Structure Store
 
 ``avn service update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Update service settings
+Updates the settings for an Aiven service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--cloud``
+    - The name of the cloud region where to deploy the service
+  * - ``--disk-space-gib``
+    - Amount of disk space for data storage (GiB)
+  * - ``--power-on``
+    - Power on the service
+  * - ``--power-off``
+    - Power off the service
+  * - ``--mainenance-dow``
+    - Set the automatic maintenance window's day of the week (possible values ``monday``,``tuesday``,``wednesday``,``thursday``,``friday``,``saturday``,``sunday``,``never``)
+  * - ``--mainenance-time``
+    - Set the automatic maintenance window's start time (``HH:MM:SS``)
+  * - ``--enable-termination-protection``
+    - Enable termination protection
+  * - ``--disable-termination-protection``
+    - Disable termination protection
+  * - ``--project-vpc-id``
+    - The ID of the project VPC to use for the service. The VPC's cloud must match the service's cloud.
+  * - ``--no-project-vpc``
+    - The service will not use any VPC
+  * - ``--force``
+    - Force the action without requiring confirmation
+
+**Example:** Update the service named ``demo-pg``, move it to ``azure-germany-north`` region and enable termination protection.
+
+::
+
+    avn service update demo-pg        \
+      --cloud google-europe-west1     \
+      --enable-termination-protection
+
 
 ``avn service user``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -296,7 +296,16 @@ Service M3 commands
 ``avn service maintenance-start``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Starts the service maintenance updates.
+Starts the service maintenance updates. 
+
+.. Warning::
+
+  Maintenance updates do not typically cause any noticeable impact on the service in use but may sometimes cause a short period of lower performance or downtime which shall not exceed 1 hour.
+
+
+.. Note::
+  
+  If there are no updates available, the command will show a ``service is up to date, maintenance not required`` message.
 
 .. list-table::
   :header-rows: 1
@@ -316,7 +325,17 @@ Starts the service maintenance updates.
 ``avn service metrics``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the metrics for a defined service.
+Retrieves the metrics for a defined service in Google chart compatible format. The list of service metrics includes:
+
+* ``cpu_usage``: CPU usage percentage
+* ``disk_usage``: Disk space usage percentage
+* ``disk_ioread``: Disk reads IOPS
+* ``disk_iowrites``: Disk writes IOPS
+* ``load_average``: 5 min CPU load average
+* ``mem_usage``: Memory usage percentage
+* ``net_receive``: Network traffic received in bytes/s
+* ``net_send``: Network traffic transmitted in bytes/s
+
 
 .. list-table::
   :header-rows: 1
@@ -327,7 +346,17 @@ Retrieves the metrics for a defined service.
   * - ``service_name``
     - The name of the service
   * - ``--period``
-    - The time period to retrieve the metrics for (possible values ``hour``, ``day``, ``week``, ``month``, ``year``)
+    - The time period to retrieve the metrics for (possible values ``hour``, ``day``, ``week``, ``month``, ``year``); the time period is relative to the current date and time, e.g. ``hour`` will retrieve metrics for the last hour.
+
+.. Note::
+
+  The **granularity** of retrieved data changes based on the ``--period`` flag:
+
+  * ``hour``: 30 seconds
+  * ``day``: 5 minutes
+  * ``week``: 30 minutes
+  * ``month``: 3 hours
+  * ``year``: 1 day
 
 **Example:** Retrieve the daily metrics for the service named ``pg-demo``.
 
@@ -386,7 +415,13 @@ Service Privatelink commands
 ``avn service queries``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists the service connections/queries statistics for an Aiven for PostgreSQL, Aiven for MySQL or Aiven for Redis service.
+Lists the service connections/queries statistics for an Aiven for PostgreSQL or Aiven for MySQL. 
+The list of queries data points retrievable includes:
+
+* the ``public.pg_stat_statements`` `columns <https://www.postgresql.org/docs/current/pgstatstatements.html>`_, for Aiven for PostgreSQL services.
+* the ``performance_schema.events_statements_summary_by_digest`` `columns <https://dev.mysql.com/doc/refman/8.0/en/performance-schema-statement-summary-tables.html>`_, for Aiven for MySQL services.
+
+A description of the retrieved columns for Aiven for PostgreSQL can be found in the dedicated `PostgreSQL documentation <https://www.postgresql.org/docs/current/pgstatstatements.html>`_ .
 
 .. list-table::
   :header-rows: 1
@@ -396,18 +431,21 @@ Lists the service connections/queries statistics for an Aiven for PostgreSQL, Ai
     - Information
   * - ``service_name``
     - The name of the service
+  * - ``--fromat``
+    - The format string for output defining the query metrics to retrieve, e.g. `'{calls} {total_time}'` 
 
-**Example:** List the queries for a service named ``pg-demo``.
+**Example:** List the queries for an Aiven for PostgreSQL service named ``pg-demo`` including the query blurb, number of calls and both total and mean execution time.
 
 ::
   
-  avn service queries pg-demo
+  avn service queries pg-demo --format '{query},{calls},{total_time},{mean_time}'
 
 
 ``avn service queries-reset``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Resets service connections/queries statistics for an Aiven for PostgreSQL, Aiven for MySQL or Aiven for Redis service.
+Resets service connections/queries statistics for an Aiven for PostgreSQL or Aiven for MySQL service. 
+Resetting query statistics could be useful to measure database behaviour in a precise point in time or after a change has been deployed.
 
 .. list-table::
   :header-rows: 1

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -648,7 +648,7 @@ Service Schema commands
 ``avn service sstableloader``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Service Sstableloader commands
+Service ``sstableloader`` commands
 
 ``avn service task-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -311,7 +311,7 @@ Lists the service plans available in a selected project for a defined service ty
   * - Parameter
     - Information
   * - ``--service-type``
-    - The type of service
+    - The type of service, check :ref:`avn-cli-service-type` for more information
   * - ``--cloud``
     - The cloud region
   * - ``--monthly``

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -303,10 +303,6 @@ Starts the service maintenance updates.
   Maintenance updates do not typically cause any noticeable impact on the service in use but may sometimes cause a short period of lower performance or downtime which shall not exceed 1 hour.
 
 
-.. Note::
-  
-  If there are no updates available, the command will show a ``service is up to date, maintenance not required`` message.
-
 .. list-table::
   :header-rows: 1
   :align: left
@@ -321,6 +317,10 @@ Starts the service maintenance updates.
 ::
 
     avn service maintenance-start pg-demo
+
+.. Note::
+  
+  If there are no updates available, the command will show a ``service is up to date, maintenance not required`` message.
 
 ``avn service metrics``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -431,8 +431,8 @@ A description of the retrieved columns for Aiven for PostgreSQL can be found in 
     - Information
   * - ``service_name``
     - The name of the service
-  * - ``--fromat``
-    - The format string for output defining the query metrics to retrieve, e.g. `'{calls} {total_time}'` 
+  * - ``--format``
+    - The format string for output defining the query metrics to retrieve, e.g. ``'{calls} {total_time}'`` 
 
 **Example:** List the queries for an Aiven for PostgreSQL service named ``pg-demo`` including the query blurb, number of calls and both total and mean execution time.
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -173,6 +173,13 @@ Manages rules to OpenSearch ACL and extended ACL configuration.
 
 More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl-enable``, ``es-acl-extended-disable``, ``es-acl-extended-enable`` and ``es-acl-extended-list``  can be found in :doc:`the dedicated page <service/es-acl>`.
 
+``avn service flink``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Manages Aiven for Apache Flink tables and jobs.
+
+More info on LIST_HERE can be found in :doc:`the dedicated page <service/flink>`.
+
 ``avn service get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -23,11 +23,11 @@ Adds an Aiven for Apache Kafka ACL entry.
     - Information
   * - ``service_name``
     - The name of the service
-    - ``--permission``
+  * - ``--permission``
     - The permission type: possible values are ``read``, ``write`` or ``readwrite``
-    - ``--topic``
+  * - ``--topic``
     - The topic name pattern: accepts ``*`` and ``?`` as wildcard characters
-    - ``--username``
+  * - ``--username``
     - The username pattern: accepts ``*`` and ``?`` as wildcard characters
 
 **Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service``kafka-doc``.
@@ -138,107 +138,352 @@ Opens an interactive shell to the given service. Supported only for Aiven for In
 ``avn service connection-pool-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create a connection pool for a given PostgreSQL service 
+Creates a new :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--pool-name``
+    - The name of the connection pool
+  * - ``--dbname``
+    - The name of the database
+  * - ``--username``
+    - The database username to use for the connection pool
+  * - ``--pool-size``
+    - Size of the connection pool in number of connections
+  * - ``--pool-mode``
+    - The :ref:`pool mode <pooling-modes>`. Possible values are ``transaction``, ``session`` and ``statement``
+
+**Example:** In the service ``pg-doc`` Create a new connection pool named ``cp-analytics-it`` for the database ``it-analytics`` with:
+
+* username ``avnadmin``
+* pool-size of ``10`` connections 
+* ``transaction`` pool-mode
+
+::
+
+  avn service connection-pool-create pg-doc \
+    --pool-name cp-analytics-it             \
+    --dbname analytics-it                   \
+    --username avnadmin                     \
+    --pool-size 10                          \
+    --pool-mode transaction
 
 ``avn service connection-pool-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete a connection pool from a given service 
+Deletes a :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--pool-name``
+    - The name of the connection pool
+
+**Example:** Delete the connection pool named ``cp-analytics-it`` in the service ``pg-doc``.
+
+::
+
+  avn service connection-pool-delete pg-doc --pool-name cp-analytics-it
+
 
 ``avn service connection-pool-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List PGBouncer pools for a service 
+Lists the :doc:`PgBouncer connection pools </docs/products/postgresql/concepts/pg-connection-pooling>` available in a given PostgreSQL service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+
+**Example:** List the PgBouncer connection pools for the service ``pg-doc``.
+
+::
+
+  avn service connection-pool-list pg-doc 
+
+
+An example of ``account service connection-pool-list`` output:
+
+.. code:: text
+
+  POOL_NAME        DATABASE   USERNAME  POOL_MODE    POOL_SIZE
+  ===============  =========  ========  ===========  =========
+  cp-analytics-it  defaultdb  avnadmin  transaction  10
+
 
 ``avn service connection-pool-update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Update a connection pool for a given PostgreSQL service 
+Updates a :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service. 
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--pool-name``
+    - The name of the connection pool
+  * - ``--dbname``
+    - The name of the database
+  * - ``--username``
+    - The database username to use for the connection pool
+  * - ``--pool-size``
+    - Size of the connection pool in number of connections
+  * - ``--pool-mode``
+    - The :ref:`pool mode <pooling-modes>`. Possible values are ``transaction``, ``session`` and ``statement``
+
+**Example:** Update the connection pool named ``cp-analytics-it`` in the service ``pg-doc`` and set the ``--pool-size`` parameter to ``20``.
+
+::
+  
+  avn service connection-pool-update pg-doc \
+    --pool-name cp-analytics-it             \
+    --pool-size 20
+
 
 ``avn service connector``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Service Connector commands
+Set of commands for managing Aiven for Apache Kafka Connect connectors. :doc:`See detailed command information <service/connector>` for more information
 
 ``avn service create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create a service
+Creates a new service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--service-type``
+    - The type of service; check :ref:`avn-cli-service-type` for more information
+  * - ``--plan``
+    - Aiven subscription plan name; check :ref:`avn-cloud-list` for more information
+  * - ``--cloud``
+    - The cloud region name; check :ref:`avn-cloud-list` for more information
+  * - ``--no-fail-if-exists``
+    - The create command will not fail if a service with the same name already exists
+  * - ``--project-vpc-id``
+    - Id of the project VPC where to include the created service. The project VPC's cloud must match the service's cloud
+  * - ``--no-project-vpc``
+    - Stops the service to be included in the project VPC even if one is available in the selected cloud
+  * - ``--enable-termination-protection``
+    - Enables termination protection for the service
+  * - ``-c KEY=VALUE``
+    - Additional configuration settings; check :ref:`avn-cli-service-type` for more information
+
+**Example:** Create a new Aiven for Kafka service named ``kafka-demo`` in the region ``google-europe-west3`` with the plan ``business-4`` and enable Kafka Connect.
+
+::
+  
+  avn service create kafka-demo             \
+    --service-type kafka                    \
+    --cloud google-europe-west3             \
+    --plan business-4                       \
+    -c kafka_connect=true                   
 
 ``avn service credentials-reset``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Reset service credentials
+Resets the service credentials.
+
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Reset the credentials of a service named ``kafka-demo``.
+
+::
+  
+  avn service credentials-reset kafka-demo
+
 
 ``avn service current-queries``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List current service connections/queries
+List current service connections/queries for an Aiven for PostgreSQL, Aiven for MySQL or Aiven for Redis service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the queries running for a service named ``pg-demo``.
+
+::
+  
+  avn service current-queries pg-demo
 
 ``avn service database-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create a database within a given service
+Creates a database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--dbname``
+    - The name of the database
+
+**Example:** Create a new database named ``analytics-it`` within the service named ``pg-demo``.
+
+::
+  
+  avn service database-create pg-demo --dbname analytics-it
 
 ``avn service database-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete a database within a given service
+Removes a specific database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--dbname``
+    - The name of the database
+
+**Example:** Delete the database named ``analytics-it`` within the service named ``pg-demo``
+
+::
+
+    avn service database-delete pg-demo --dbname analytics-it  
 
 ``avn service database-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List service databases
+Lists the service databases available in an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the service databases within the service named ``pg-demo``
+
+::
+
+    avn service database-list pg-demo
 
 ``avn service es-acl-add``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Add rules to elastic ACL configuration
+Add rules to opensearch ACL configuration
 
 ``avn service es-acl-del``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete rules from elastic ACL configuration
+Delete rules from opensearch ACL configuration
 
 ``avn service es-acl-disable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Disable Elasticsearch ACL configuration
+Disable Opensearch ACL configuration
 
 ``avn service es-acl-enable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Enable Elasticsearch ACL configuration
+Enable Opensearch ACL configuration
 
 ``avn service es-acl-extended-disable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Disable Elasticsearch Extended ACL 
+Disable Opensearch Extended ACL 
 
 ``avn service es-acl-extended-enable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Enable Elasticsearch Extended ACL 
+Enable Opensearch Extended ACL 
 
 ``avn service es-acl-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List Elasticsearch ACL configuration
+List Opensearch ACL configuration
 
 ``avn service get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Show a single service
+Retrieves a single service details.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--format``
+    - Format of the output string
+
+**Example:** Retrieve the ``pg-demo`` service details in the ``'{service_name} {service_uri}'`` format.
+
+::
+
+    avn service get pg-demo --format '{service_name} {service_uri}'
+
+**Example:** Retrieve the ``pg-demo`` full service details in JSON format.
+
+::
+
+    avn service get pg-demo --json
+
 
 ``avn service index-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete Elasticsearch service index
+Delete Opensearch service index
 
 ``avn service index-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List Elasticsearch service indexes
+List Opensearch service indexes
 
 ``avn service integration-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -293,17 +538,67 @@ Update a service integration
 ``avn service keypair``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Service Keypair commands
+Service keypair commands
 
 ``avn service list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List services
+Lists services within an Aiven project.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Retrieve all the services running in the currently selected project.
+
+::
+
+    avn service list
+
+An example of ``account service list`` output:
+
+.. code:: tex
+
+  SERVICE_NAME        SERVICE_TYPE  STATE    CLOUD_NAME           PLAN         CREATE_TIME           UPDATE_TIME
+  ==================  ============  =======  ===================  ===========  ====================  ====================
+  cassandra-28962a5b  cassandra     RUNNING  google-europe-west3  business-16  2021-09-27T10:18:19Z  2021-09-27T10:25:58Z
+  os-24a6d6db         opensearch    RUNNING  google-europe-west3  business-4   2021-09-27T10:18:04Z  2021-09-27T10:23:31Z
+  influx-103c3f07     influxdb      RUNNING  google-europe-west3  startup-4    2021-09-27T10:18:13Z  2021-09-27T10:22:05Z
+  kafka-2134          kafka         RUNNING  google-europe-west3  business-4   2021-09-27T08:48:35Z  2021-09-27T11:20:55Z
+  mysql-12f7628c      mysql         RUNNING  google-europe-west3  business-4   2021-09-27T10:18:09Z  2021-09-27T10:23:02Z
+  pg-123456           pg            RUNNING  google-europe-west3  business-4   2021-09-27T07:41:04Z  2021-09-27T10:56:19Z
+
+**Example:** Retrieve all the services with name ``demo-pg`` running in the project named ``mytestproject``.
+
+::
+
+    avn service list demo-pg --project mytestproject
+
 
 ``avn service logs``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-View project logs
+Retrieves the selected service logs.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Retrieve the logs for the service named ``pg-demo``.
+
+::
+
+    avn service logs pg-demo
 
 ``avn service m3``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -394,6 +689,9 @@ List Kafka service topics
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Update a Kafka topic
+
+
+.. _avn-cli-service-type:
 
 ``avn service types``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -515,9 +813,9 @@ An example of ``account service versions`` output:
     SERVICE_TYPE   MAJOR_VERSION  STATE        AVAILABILITY_START_TIME  AVAILABILITY_END_TIME  AIVEN_END_OF_LIFE_TIME  UPSTREAM_END_OF_LIFE_TIME  TERMINATION_TIME  END_OF_LIFE_HELP_ARTICLE_URL
     =============  =============  ===========  =======================  =====================  ======================  =========================  ================  ====================================================================================================
     cassandra      3.11           available    2018-11-08T00:00:00Z     null                   null                    null                       null              null
-    elasticsearch  7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    elasticsearch  7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    elasticsearch  7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch  7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch  7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    Opensearch  7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
     kafka          2.3            unavailable  2019-09-05T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     kafka          2.4            unavailable  2019-10-21T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     ...

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -178,7 +178,7 @@ More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl
 
 Manages Aiven for Apache Flink tables and jobs.
 
-More info on LIST_HERE can be found in :doc:`the dedicated page <service/flink>`.
+More info on ``flink table create``, ``flink table delete``, ``flink table get``, ``flink table list``, ``flink job create``, ``flink job cancel``, ``flink job get`` and ``flink job list`` can be found in :doc:`the dedicated page <service/flink>`.
 
 ``avn service get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -1,0 +1,546 @@
+Command reference: ``avn service``
+==================================
+
+Here you’ll find the full list of commands for ``avn service``.
+
+
+Manage service details
+-------------------------
+
+Commands for managing Aiven services via ``avn`` commands. 
+
+
+``avn service acl-add``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Adds an Aiven for Apache Kafka ACL entry.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+    - ``--permission``
+    - The permission type: possible values are ``read``, ``write`` or ``readwrite``
+    - ``--topic``
+    - The topic name pattern: accepts ``*`` and ``?`` as wildcard characters
+    - ``--username``
+    - The username pattern: accepts ``*`` and ``?`` as wildcard characters
+
+**Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service``kafka-doc``.
+
+::
+
+  avn service acl-add kafka-doc --username *userA --permission readwrite --topic topic2020*
+
+
+
+``avn service acl-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes an Aiven for Apache Kafka ACL entry.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``acl_id``
+    - The id of the ACL to delete
+
+
+**Example:** Delete the ACLs with id ``acl3604f96c74a`` on the Aiven for Apache Kafka instance named ``kafka-doc``.
+
+::
+
+  avn service acl-delete kafka-doc acl3604f96c74a
+
+``avn service acl-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Aiven for Apache Kafka ACL entries.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the ACLs defined for a service named ``kafka-doc``.
+
+::
+
+  avn service acl-list kafka-doc
+
+
+An example of ``account service acl-list`` output:
+
+.. code:: text
+
+    ID              USERNAME  TOPIC      PERMISSION
+    ==============  ========  =========  ==========
+    default         *         *          admin
+    acl3604f96c74a  Jon       orders     readwrite
+    acl3604fa706cb  Frida     invoices*  write
+
+``avn service ca``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the project CA that the selected service belongs to.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--target-filepath``
+    - The file path used to store the CA certificate locally
+
+**Example:** Retrieve the CA certificate for the project where the service named ``kafka-doc`` belongs and store it under ``/tmp/ca.pem``.
+
+::
+
+  avn service ca get kafka-doc --target-filepath /tmp/ca.pem
+
+
+``avn service cli``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Opens an interactive shell to the given service. Supported only for Aiven for InfluxDB and Aiven for PostgreSQL services.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Open a new ``psql`` shell connecting to an Aiven for PostgreSQL service named ``pg-doc``.
+
+::
+
+  avn service cli pg-doc
+
+``avn service connection-pool-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a connection pool for a given PostgreSQL service 
+
+``avn service connection-pool-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a connection pool from a given service 
+
+``avn service connection-pool-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List PGBouncer pools for a service 
+
+``avn service connection-pool-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Update a connection pool for a given PostgreSQL service 
+
+``avn service connector``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service Connector commands
+
+``avn service create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a service
+
+``avn service credentials-reset``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Reset service credentials
+
+``avn service current-queries``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List current service connections/queries
+
+``avn service database-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a database within a given service
+
+``avn service database-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a database within a given service
+
+``avn service database-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service databases
+
+``avn service es-acl-add``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Add rules to elastic ACL configuration
+
+``avn service es-acl-del``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete rules from elastic ACL configuration
+
+``avn service es-acl-disable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Disable Elasticsearch ACL configuration
+
+``avn service es-acl-enable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Enable Elasticsearch ACL configuration
+
+``avn service es-acl-extended-disable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Disable Elasticsearch Extended ACL 
+
+``avn service es-acl-extended-enable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Enable Elasticsearch Extended ACL 
+
+``avn service es-acl-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List Elasticsearch ACL configuration
+
+``avn service get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Show a single service
+
+``avn service index-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete Elasticsearch service index
+
+``avn service index-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List Elasticsearch service indexes
+
+``avn service integration-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a service integration
+
+``avn service integration-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a service integration
+
+``avn service integration-endpoint-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a service integration endpoint 
+
+``avn service integration-endpoint-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a service integration endpoint 
+
+``avn service integration-endpoint-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service integration endpoints 
+
+``avn service integration-endpoint-types-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List all available integration endpoint types for given project 
+
+``avn service integration-endpoint-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Update a service integration endpoint 
+
+``avn service integration-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service integrations
+
+``avn service integration-types-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List all available integration types for given project 
+
+``avn service integration-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Update a service integration
+
+``avn service keypair``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service Keypair commands
+
+``avn service list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List services
+
+``avn service logs``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+View project logs
+
+``avn service m3``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service M3 commands
+
+``avn service maintenance-start``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Start service maintenance updates
+
+``avn service metrics``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Get service metrics
+
+``avn service migration-status``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Get migration status
+
+``avn service plans``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service plans
+
+``avn service privatelink``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service Privatelink commands
+
+``avn service queries``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service query statistics
+
+``avn service queries-reset``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Reset service query statistics
+
+``avn service schema``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service Schema commands
+
+``avn service sstableloader``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Service Sstableloader commands
+
+``avn service task-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a service task
+
+``avn service task-get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a service task
+
+``avn service terminate``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Terminate service
+
+``avn service topic-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create a Kafka topic
+
+``avn service topic-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a Kafka topic
+
+``avn service topic-get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Get Kafka service topic
+
+``avn service topic-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List Kafka service topics
+
+``avn service topic-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Update a Kafka topic
+
+``avn service types``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List service types
+
+``avn service update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Update service settings
+
+``avn service user-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Create service user
+
+``avn service user-creds-download``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Download service user certificate/key/CA certificate 
+
+``avn service user-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a service user
+
+``avn service user-get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Get details for a single user
+
+``avn service user-kafka-java-creds``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Download user certificate/key/CA certificate and create a Java keystore/truststore/properties from them 
+
+``avn service user-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists the users defined for the selected service, and the related type (``primary`` or ``normal``).
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the users defined for a service named ``pg-doc``.
+
+::
+
+  avn service user-list pg-doc
+
+
+An example of ``account service user-list`` output:
+
+.. code:: text
+
+    USERNAME   TYPE
+    =========  =======
+    analytics  normal
+    avnadmin   primary
+
+``avn service user-password-reset``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Resets or changes the service user password.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username to change the password for
+  * - ``--new-password``
+    - The new password for the user
+
+**Example:** Change the password for the ``avnadmin`` user of the service named ``pg-doc`` to ``VerySecurePwd123``.
+
+::
+
+  avn service user-password-reset pg-doc --username avnadmin --new-password VerySecurePwd123
+
+
+``avn service user-set-access-control``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Set Redis service user access control 
+
+``avn service versions``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+For each service, lists the versions available together with:
+
+* ``STATE``: if the version is ``available`` or ``unavailable``
+* ``AVAILABILITY_START_TIME`` and ``AVAILABILITY_END_TIME``: Period in which the specific version is available
+* ``AIVEN_END_OF_LIFE_TIME``: Aiven deprecation date for the specific version
+* ``UPSTREAM_END_OF_LIFE_TIME``: Upstream deprecation date for the specific version 
+* ``TERMINATION_TIME``: Termination time of the active instances
+* ``END_OF_LIFE_HELP_ARTICLE_URL``: URL to "End of Life" documentation
+
+**Example:** List all service versions.
+
+::
+
+  avn service versions
+
+An example of ``account service versions`` output:
+
+.. code:: text
+
+    SERVICE_TYPE   MAJOR_VERSION  STATE        AVAILABILITY_START_TIME  AVAILABILITY_END_TIME  AIVEN_END_OF_LIFE_TIME  UPSTREAM_END_OF_LIFE_TIME  TERMINATION_TIME  END_OF_LIFE_HELP_ARTICLE_URL
+    =============  =============  ===========  =======================  =====================  ======================  =========================  ================  ====================================================================================================
+    cassandra      3.11           available    2018-11-08T00:00:00Z     null                   null                    null                       null              null
+    elasticsearch  7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    elasticsearch  7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    elasticsearch  7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    kafka          2.3            unavailable  2019-09-05T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
+    kafka          2.4            unavailable  2019-10-21T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
+    ...
+    pg             12             available    2019-11-18T00:00:00Z     2024-05-14T00:00:00Z   2024-11-14T00:00:00Z    2024-11-14T00:00:00Z       null              https://help.aiven.io/en/articles/2461799-how-to-perform-a-postgresql-in-place-major-version-upgrade
+    pg             13             available    2021-02-15T00:00:00Z     2025-05-13T00:00:00Z   2025-11-13T00:00:00Z    2025-11-13T00:00:00Z       null              https://help.aiven.io/en/articles/2461799-how-to-perform-a-postgresql-in-place-major-version-upgrade
+    pg             9.6            unavailable  2016-09-29T00:00:00Z     2021-05-11T00:00:00Z   2021-11-11T00:00:00Z    2021-11-11T00:00:00Z       null              https://help.aiven.io/en/articles/2461799-how-to-perform-a-postgresql-in-place-major-version-upgrade
+
+``avn service wait``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Waits for the service to reach the ``RUNNING`` state
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Wait for the service named ``pg-doc`` to reach the ``RUNNING`` state.
+
+::
+
+  avn service wait pg-doc

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -90,7 +90,7 @@ Creates a new service.
   * - ``service_name``
     - The name of the service
   * - ``--service-type``
-    - The type of service; check :ref:`avn-cli-service-type` for more information
+    - The type of service; the :ref:`service types command <avn-cli-service-type>` has the available values
   * - ``--plan``
     - Aiven subscription plan name; check :ref:`avn-cloud-list` for more information
   * - ``--cloud``
@@ -104,7 +104,7 @@ Creates a new service.
   * - ``--enable-termination-protection``
     - Enables termination protection for the service
   * - ``-c KEY=VALUE``
-    - Additional configuration settings; check :ref:`avn-cli-service-type` for more information
+    - Any additional configuration settings for your service; check our documentation for more information, or use the :ref:`service types command <avn-cli-service-type>` which has a verbose mode that shows all options.
 
 **Example:** Create a new Aiven for Kafka service named ``kafka-demo`` in the region ``google-europe-west3`` with the plan ``business-4`` and enable Kafka Connect.
 
@@ -376,16 +376,12 @@ Create a service task
 ``avn service terminate``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Terminates a service.
+Permanently deletes a service.
 
 .. Warning::
 
   The ``terminate`` command deletes the service and the associated data. The data is not recoverable. 
   To temporarily shut down the service use the :ref:`service update command <avn-cli-service-update>` ``avn service update SERVICE_NAME --power-off``
-
-.. Note::
-
-  To avoid accidental service deletion, enable the termination protection during service :ref:`creation <avn-cli-service-create>`  or :ref:`update <avn-cli-service-update>` via the ``--enable-termination-protection`` flag 
 
 .. list-table::
   :header-rows: 1
@@ -403,6 +399,10 @@ Terminates a service.
 ::
 
     avn service terminate demo-pg
+
+.. Note::
+
+  To avoid accidental service deletion, enable the termination protection during service :ref:`creation <avn-cli-service-create>`  or :ref:`update <avn-cli-service-update>` by using the ``--enable-termination-protection`` flag 
 
 ``avn service topic``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -445,6 +445,12 @@ An example of ``service types`` output:
   opensearch         OpenSearch - Search & Analyze Data in Real Time, derived from Elasticsearch v7.10.2
   pg                 PostgreSQL - Object-Relational Database Management System
   redis              Redis - In-Memory Data Structure Store
+
+The service types command in verbose mode also shows all the configuration options for each type of service::
+
+    avn service types -v
+
+You might find it helpful to pipe the output to ``less`` since there are a large number of options available and the command output is long.
 
 .. _avn-cli-service-update:
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -706,27 +706,134 @@ Update service settings
 ``avn service user-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Create service user
+Creates a new user for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The new username to be created
+  * - ``--m3-group``
+    - The name of the group the user belongs to (for Aiven for M3 services only)
+  * - ``--redis-acl-keys``
+    - The ACL rules for keys (Aiven for Redis services only)
+  * - ``--redis-acl-commands``
+    - The ACL rules for commands (Aiven for Redis services only)
+  * - ``--redis-acl-categories``
+    - The ACL rules for categories (Aiven for Redis services only)
+  * - ``--redis-acl-channels``
+    - The ACL rules for channels (Aiven for Redis services only)
+
+**Example:** Create a new user named ``janedoe`` for a service named ``pg-demo``.
+
+::
+
+  avn service user-create pg-demo --username janedoe
 
 ``avn service user-creds-download``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Download service user certificate/key/CA certificate 
+Downloads the SSL certificate, key and CA certificate for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to download the certificates
+  * - ``-d``
+    - The target directory where certificates will be stored
+
+**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``.
+
+::
+
+  avn service user-creds-download kafka-demo --username janedoe -d /tmp/certs
 
 ``avn service user-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete a service user
+Delete a service in a given Aiven service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username to delete
+
+**Example:** Delete the user ``janedoe`` defined in a service named ``kafka-demo``.
+
+::
+
+  avn service user-delete kafka-demo --username janedoe
 
 ``avn service user-get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Get details for a single user
+Retrieves the details for a single user in a given Aiven service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to retrieve the details
+
+**Example:** Retrieve the details for the user ``janedoe`` defined for a service named ``kafka-demo``.
+
+::
+
+  avn service user-get kafka-demo --username janedoe
+
+.. Tip::
+
+    Use the ``--json`` parameter to retrieve all the service specific information for a specific user.
 
 ``avn service user-kafka-java-creds``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Download user certificate/key/CA certificate and create a Java keystore/truststore/properties from them 
+
+Downloads the SSL certificate, key and CA certificate and creates a Java keystore and truststore for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to download the certificates
+  * - ``-d``
+    - The target directory where certificates will be stored
+  * - ``--password``
+    - The Java keystore and truststore password (default: ``changeit``)
+
+**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``. Furthermore, secure the Java keystore and truststore with the password ``safePassword123``.
+
+::
+
+  avn service user-kafka-java-creds kafka-demo --username janedoe -d /tmp/certs --password safePassword123
 
 ``avn service user-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -302,10 +302,42 @@ Get migration status
 ``avn service plans``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List service plans
+Lists the service plans available in a selected project for a defined service type.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--service-type``
+    - The type of service
+  * - ``--cloud``
+    - The cloud region
+  * - ``--monthly``
+    - To show the monthly price estimate
+
+**Example:** List the service plans available for a PostgreSQL service in the ``google-europe-west3`` region.
+
+::
+
+    avn service plans --service-type pg --cloud google-europe-west3
+
+An example of ``service plans`` output:
+
+.. code:: text
+
+  pg:hobbyist                    $0.034/h  Hobbyist (1 CPU, 2 GB RAM, 8 GB disk)
+  pg:startup-4                   $0.136/h  Startup-4 (1 CPU, 4 GB RAM, 80 GB disk)
+  pg:startup-8                   $0.267/h  Startup-8 (2 CPU, 8 GB RAM, 175 GB disk)
+  ...
+  pg:premium-360                $36.027/h  Premium-360 (96 CPU, 384 GB RAM, 3000 GB disk) 3-node high availability set
+  pg:premium-512                $43.836/h  Premium-512 (128 CPU, 512 GB RAM, 3000 GB disk) 3-node high availability set
+  pg:premium-896                $72.329/h  Premium-896 (224 CPU, 896 GB RAM, 3000 GB disk) 3-node high availability set
 
 ``avn service privatelink``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
 
 Service Privatelink commands
 
@@ -342,7 +374,24 @@ Create a service task
 ``avn service terminate``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Terminate service
+Terminates a service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--force``
+    - Force the action without requiring confirmation
+
+**Example:** Terminate the service named ``demo-pg``.
+
+::
+
+    avn service terminate demo-pg
 
 ``avn service topic``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -366,7 +415,7 @@ Lists the Aiven service types available in a project.
 
     avn service types
 
-An example of ``account service types`` output:
+An example of ``service types`` output:
 
 .. code:: text
 
@@ -408,7 +457,7 @@ Updates the settings for an Aiven service.
   * - ``--power-off``
     - Power off the service
   * - ``--mainenance-dow``
-    - Set the automatic maintenance window's day of the week (possible values ``monday``,``tuesday``,``wednesday``,``thursday``,``friday``,``saturday``,``sunday``,``never``)
+    - Set the automatic maintenance window's day of the week (possible values ``monday``, ``tuesday``, ``wednesday``, ``thursday``, ``friday``, ``saturday``, ``sunday``, ``never``)
   * - ``--mainenance-time``
     - Set the automatic maintenance window's start time (``HH:MM:SS``)
   * - ``--enable-termination-protection``

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -74,6 +74,8 @@ Set of commands for managing Aiven for Apache Kafka Connect connectors.
 
 More information on ``connector available``, ``connector create``, ``connector delete``, ``connector list``, ``connector pause``, ``connector restart``, ``connector restart-task``, ``connector resume``, ``connector schema``, ``connector status`` and ``connector update`` can be found in the :doc:`dedicated page <service/connector>`.
 
+.. _avn-cli-service-create:
+
 ``avn service create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -167,7 +169,7 @@ More information on ``database-add``, ``database-delete`` and ``database-list`` 
 ``avn service es-acl``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Manages rules to opensearch ACL and extended ACL configuration.
+Manages rules to OpenSearch ACL and extended ACL configuration.
 
 More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl-enable``, ``es-acl-extended-disable``, ``es-acl-extended-enable`` and ``es-acl-extended-list``  can be found in :doc:`the dedicated page <service/es-acl>`.
 
@@ -203,7 +205,7 @@ Retrieves a single service details.
 ``avn service index``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Manages Opensearch service indexes.
+Manages OpenSearch service indexes.
 
 More information on ``index-delete`` and  ``index-list`` can be found in :doc:`the dedicated page <service/index>`.
 
@@ -376,6 +378,15 @@ Create a service task
 
 Terminates a service.
 
+.. Warning::
+
+  The ``terminate`` command deletes the service and the associated data. The data is not recoverable. 
+  To temporarily shut down the service use the :ref:`service update command <avn-cli-service-update>` ``avn service update SERVICE_NAME --power-off``
+
+.. Note::
+
+  To avoid accidental service deletion, enable the termination protection during service :ref:`creation <avn-cli-service-create>`  or :ref:`update <avn-cli-service-update>` via the ``--enable-termination-protection`` flag 
+
 .. list-table::
   :header-rows: 1
   :align: left
@@ -435,6 +446,8 @@ An example of ``service types`` output:
   pg                 PostgreSQL - Object-Relational Database Management System
   redis              Redis - In-Memory Data Structure Store
 
+.. _avn-cli-service-update:
+
 ``avn service update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -476,7 +489,7 @@ Updates the settings for an Aiven service.
 ::
 
     avn service update demo-pg        \
-      --cloud google-europe-west1     \
+      --cloud azure-germany-north     \
       --enable-termination-protection
 
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -532,9 +532,9 @@ An example of ``account service versions`` output:
     SERVICE_TYPE   MAJOR_VERSION  STATE        AVAILABILITY_START_TIME  AVAILABILITY_END_TIME  AIVEN_END_OF_LIFE_TIME  UPSTREAM_END_OF_LIFE_TIME  TERMINATION_TIME  END_OF_LIFE_HELP_ARTICLE_URL
     =============  =============  ===========  =======================  =====================  ======================  =========================  ================  ====================================================================================================
     cassandra      3.11           available    2018-11-08T00:00:00Z     null                   null                    null                       null              null
-    Opensearch     7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    Opensearch     7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
-    Opensearch     7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    OpenSearch     7              unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    OpenSearch     7.10           unavailable  2021-02-22T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
+    OpenSearch     7.9            unavailable  2020-08-27T00:00:00Z     2021-09-23T00:00:00Z   2022-03-23T00:00:00Z    null                       null              https://help.aiven.io/en/articles/5424825
     kafka          2.3            unavailable  2019-09-05T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     kafka          2.4            unavailable  2019-10-21T00:00:00Z     2021-08-13T00:00:00Z   2021-08-13T00:00:00Z    null                       null              https://help.aiven.io/en/articles/4472730-eol-instructions-for-aiven-for-kafka
     ...

--- a/docs/tools/cli/service/acl.rst
+++ b/docs/tools/cli/service/acl.rst
@@ -1,0 +1,92 @@
+Command reference: ``avn service acl``
+============================================
+
+Here you’ll find the full list of commands for ``avn service acl``.
+
+
+Manage Kafka access control lists
+--------------------------------------------------------
+
+Commands for managing Aiven for Apache Kafka access control lists via ``avn`` commands. 
+
+``avn service acl-add``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Adds an Aiven for Apache Kafka ACL entry.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--permission``
+    - The permission type: possible values are ``read``, ``write`` or ``readwrite``
+  * - ``--topic``
+    - The topic name pattern: accepts ``*`` and ``?`` as wildcard characters
+  * - ``--username``
+    - The username pattern: accepts ``*`` and ``?`` as wildcard characters
+
+**Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service``kafka-doc``.
+
+::
+
+  avn service acl-add kafka-doc --username *userA --permission readwrite --topic topic2020*
+
+
+
+``avn service acl-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes an Aiven for Apache Kafka ACL entry.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``acl_id``
+    - The id of the ACL to delete
+
+
+**Example:** Delete the ACLs with id ``acl3604f96c74a`` on the Aiven for Apache Kafka instance named ``kafka-doc``.
+
+::
+
+  avn service acl-delete kafka-doc acl3604f96c74a
+
+``avn service acl-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Aiven for Apache Kafka ACL entries.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the ACLs defined for a service named ``kafka-doc``.
+
+::
+
+  avn service acl-list kafka-doc
+
+
+An example of ``account service acl-list`` output:
+
+.. code:: text
+
+    ID              USERNAME  TOPIC      PERMISSION
+    ==============  ========  =========  ==========
+    default         *         *          admin
+    acl3604f96c74a  Jon       orders     readwrite
+    acl3604fa706cb  Frida     invoices*  write

--- a/docs/tools/cli/service/connection-pool.rst
+++ b/docs/tools/cli/service/connection-pool.rst
@@ -1,0 +1,47 @@
+Command reference: ``avn service connection-pool``
+==================================================
+
+Here you’ll find the full list of commands for ``avn service connection-pool``.
+
+
+Manage PgBouncer connection pools
+--------------------------------------------------------
+
+``avn service connection-pool-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new :doc:`PgBouncer connection pool </docs/products/postgresql/concepts/pg-connection-pooling>` for a given PostgreSQL service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--pool-name``
+    - The name of the connection pool
+  * - ``--dbname``
+    - The name of the database
+  * - ``--username``
+    - The database username to use for the connection pool
+  * - ``--pool-size``
+    - Size of the connection pool in number of connections
+  * - ``--pool-mode``
+    - The :ref:`pool mode <pooling-modes>`. Possible values are ``transaction``, ``session`` and ``statement``
+
+**Example:** In the service ``pg-doc`` Create a new connection pool named ``cp-analytics-it`` for the database ``it-analytics`` with:
+
+* username ``avnadmin``
+* pool-size of ``10`` connections 
+* ``transaction`` pool-mode
+
+::
+
+  avn service connection-pool-create pg-doc \
+    --pool-name cp-analytics-it             \
+    --dbname analytics-it                   \
+    --username avnadmin                     \
+    --pool-size 10                          \
+    --pool-mode transaction

--- a/docs/tools/cli/service/connector.rst
+++ b/docs/tools/cli/service/connector.rst
@@ -1,0 +1,314 @@
+Command reference: ``avn service connector``
+============================================
+
+Here you’ll find the full list of commands for ``avn service connector``.
+
+
+Manage Kafka Connect connectors details
+--------------------------------------------------------
+
+Commands for managing Aiven for Apache Kafka Connect connectors via ``avn`` commands. 
+
+
+``avn service connector available``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Kafka Connect connector plugins available in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+
+**Example:** List the Kafka Connect connector plugins available for the service ``kafka-demo``.
+
+::
+
+  avn service connector available kafka-demo
+
+``avn service connector create``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector_config``
+    - JSON string or path (preceded by ``@``) to a Kafka Connect connector JSON configuration file
+
+**Example:** Create a new JDBC source Kafka Connect connector in the service ``kafka-demo`` passing the JSON configuation string.
+
+::
+
+  avn service connector create kafka-demo '{
+    "name": "pg-bulk-invoices-source",
+    "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+    "connection.url": "jdbc:postgresql://demo-pg-myinventedprojectname.aivencloud.com:13039/defaultdb?sslmode=require",
+    "connection.user": "avnadmin",
+    "connection.password": "verysecurepassword123",
+    "table.whitelist": "invoices",
+    "mode": "bulk",
+    "poll.interval.ms": "10000",
+    "topic.prefix": "pg_source_"
+    }'
+
+
+``avn service connector delete``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+
+**Example:** Delete the Kafka Connect connector named ``pg-bulk-invoices-source`` in the service ``kafka-demo``.
+
+::
+
+   avn service connector delete kafka-demo pg-bulk-invoices-source 
+
+``avn service connector list``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Kafka Connect connectors in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+
+**Example:** List all Kafka Connect connectors in the service ``kafka-demo``.
+
+::
+
+    avn service connector list kafka-demo
+
+An example of ``avn service connector list`` output:
+
+.. code:: text
+
+    {
+        "connectors": [
+            {
+                "config": {
+                    "connection.password": "verysecurepassword123",
+                    "connection.url": "jdbc:postgresql://demo-test-myinventedprojectname.aivencloud.com:13039/defaultdb?sslmode=require",
+                    "connection.user": "avnadmin",
+                    "connector.class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+                    "mode": "bulk",
+                    "name": "pg-bulk-invoices-source",
+                    "poll.interval.ms": "10000",
+                    "table.whitelist": "invoices",
+                    "topic.prefix": "pg_source_"
+                },
+                "name": "pg-bulk-invoices-source",
+                "plugin": {
+                    "author": "Aiven",
+                    "class": "io.aiven.connect.jdbc.JdbcSourceConnector",
+                    "docURL": "https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md",
+                    "title": "JDBC Source",
+                    "type": "source",
+                    "version": "6.6.0"
+                },
+                "tasks": []
+            }
+        ]
+    }
+
+``avn service connector pause``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Pauses a Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+
+**Example:** Pause the Kafka Connect connector named ``pg-bulk-invoices-source`` in the service ``kafka-demo``.
+
+::
+
+   avn service connector pause kafka-demo pg-bulk-invoices-source 
+
+
+``avn service connector restart``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Restarts a Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+
+**Example:** Restart the Kafka Connect connector named ``pg-bulk-invoices-source`` in the service ``kafka-demo``.
+
+::
+
+   avn service connector restart kafka-demo pg-bulk-invoices-source 
+
+``avn service connector restart-task``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Restarts a Kafka Connect connector task in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+  * - ``task``
+    - Kafka Connect connector task id
+
+**Example:** Restart the task with id ``0`` in the Kafka Connect connector named ``pg-bulk-invoices-source`` belonging to the service ``kafka-demo``.
+
+::
+
+    avn service connector restart-task kafka-demo pg-bulk-invoices-source 0
+
+``avn service connector resume``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Resumes a Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+
+**Example:** Resume the Kafka Connect connector named ``pg-bulk-invoices-source`` belonging to the service ``kafka-demo``.
+
+::
+
+    avn service connector resume kafka-demo pg-bulk-invoices-source
+
+``avn service connector schema``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the configuration information for a Connect connector plugin in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector plugin class name
+
+**Example:** Retrieve the schema for the Kafka Connect plugin with class ``io.debezium.connector.sqlserver.SqlServerConnector`` belonging to the service ``kafka-demo``.
+
+::
+
+    avn service connector schema kafka-demo io.debezium.connector.sqlserver.SqlServerConnector
+
+``avn service connector status``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Gets a Kafka Connect connector status in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+
+**Example:** Check the status of a Kafka Connect connector named ``pg-bulk-invoices-source`` belonging to the service ``kafka-demo``.
+
+::
+
+    avn service connector status kafka-demo pg-bulk-invoices-source
+
+An example of ``avn service connector status`` output:
+
+.. code:: text
+
+    {
+        "status": {
+            "state": "RUNNING",
+            "tasks": [
+                {
+                    "id": 0,
+                    "state": "RUNNING",
+                    "trace": ""
+                }
+            ]
+        }
+    }
+
+``avn service connector update``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Updates a Kafka Connect connector in a given Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the Service
+  * - ``connector``
+    - Kafka Connect connector name
+  * - ``connector_config``
+    - JSON string or path (preceded by ``@``) to a Kafka Connect connector JSON configuration file
+
+**Example:** Update a the JDBC source Kafka Connect connector named ``pg-bulk-invoices-source`` in the service ``kafka-demo`` with the JSON configuation string contained in the file ``kafka-connect-config.json``.
+
+::
+
+    avn service connector update kafka-demo pg-bulk-invoices-source @kafka-connect-config.json

--- a/docs/tools/cli/service/database.rst
+++ b/docs/tools/cli/service/database.rst
@@ -1,0 +1,72 @@
+Command reference: ``avn service database``
+============================================
+
+Here you’ll find the full list of commands for ``avn service database``.
+
+
+Manage databases
+--------------------------------------------------------
+
+``avn service database-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--dbname``
+    - The name of the database
+
+**Example:** Create a new database named ``analytics-it`` within the service named ``pg-demo``.
+
+::
+  
+  avn service database-create pg-demo --dbname analytics-it
+
+``avn service database-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Removes a specific database within an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--dbname``
+    - The name of the database
+
+**Example:** Delete the database named ``analytics-it`` within the service named ``pg-demo``
+
+::
+
+    avn service database-delete pg-demo --dbname analytics-it  
+
+``avn service database-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists the service databases available in an Aiven for PostgreSQL, Aiven for MySQL or Aiven for InfluxDB service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the service databases within the service named ``pg-demo``
+
+::
+
+    avn service database-list pg-demo

--- a/docs/tools/cli/service/es-acl.rst
+++ b/docs/tools/cli/service/es-acl.rst
@@ -1,0 +1,43 @@
+Command reference: ``avn service es-acl``
+============================================
+
+Here you’ll find the full list of commands for ``avn service es-acl``.
+
+
+Manage Opensearch access control lists
+--------------------------------------------------------
+
+``avn service es-acl-add``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Add rules to opensearch ACL configuration
+
+``avn service es-acl-del``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete rules from opensearch ACL configuration
+
+``avn service es-acl-disable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Disable Opensearch ACL configuration
+
+``avn service es-acl-enable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Enable Opensearch ACL configuration
+
+``avn service es-acl-extended-disable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Disable Opensearch Extended ACL 
+
+``avn service es-acl-extended-enable``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Enable Opensearch Extended ACL 
+
+``avn service es-acl-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+List Opensearch ACL configuration

--- a/docs/tools/cli/service/es-acl.rst
+++ b/docs/tools/cli/service/es-acl.rst
@@ -4,40 +4,40 @@ Command reference: ``avn service es-acl``
 Here you’ll find the full list of commands for ``avn service es-acl``.
 
 
-Manage Opensearch access control lists
+Manage OpenSearch access control lists
 --------------------------------------------------------
 
 ``avn service es-acl-add``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Add rules to opensearch ACL configuration
+Add rules to OpenSearch ACL configuration
 
 ``avn service es-acl-del``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Delete rules from opensearch ACL configuration
+Delete rules from OpenSearch ACL configuration
 
 ``avn service es-acl-disable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Disable Opensearch ACL configuration
+Disable OpenSearch ACL configuration
 
 ``avn service es-acl-enable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Enable Opensearch ACL configuration
+Enable OpenSearch ACL configuration
 
 ``avn service es-acl-extended-disable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Disable Opensearch Extended ACL 
+Disable OpenSearch Extended ACL 
 
 ``avn service es-acl-extended-enable``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Enable Opensearch Extended ACL 
+Enable OpenSearch Extended ACL 
 
 ``avn service es-acl-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List Opensearch ACL configuration
+List OpenSearch ACL configuration

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -158,10 +158,10 @@ Creates a new Aiven for Apache Flink job.
     --tables KCpuIn KAlert                                     \
     --statement "INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_in_mb > 70" 
 
-``avn service flink job delete``
+``avn service flink job cancel``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Deletes an existing Aiven for Apache Flink job.
+Cancels an existing Aiven for Apache Flink job.
 
 .. list-table::
   :header-rows: 1
@@ -171,14 +171,14 @@ Deletes an existing Aiven for Apache Flink job.
     - Information
   * - ``service_name``
     - The name of the service
-  * - ``table_id``
+  * - ``job_id``
     - The ID of the job to delete
 
-**Example:** Delete the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** Cancel the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
-  avn service flink job delete flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
+  avn service flink job cancel flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
 
 ``avn service flink job get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -116,7 +116,7 @@ Lists all the Aiven for Apache Flink tables in a selected service.
 
 An example of ``avn service flink table list`` output:
 
-.. code:: tex
+.. code:: text
 
   INTEGRATION_ID                        TABLE_ID                              TABLE_NAME
   ====================================  ====================================  ==========
@@ -204,7 +204,7 @@ Retrieves the definition of an existing Aiven for Apache Flink job.
 
 An example of ``avn service flink job get`` output:
 
-.. code:: tex
+.. code:: text
 
   JID                               NAME        STATE    START-TIME     END-TIME  DURATION  ISSTOPPABLE  MAXPARALLELISM
   ================================  ==========  =======  =============  ========  ========  ===========  ==============
@@ -232,7 +232,7 @@ Lists all the Aiven for Apache Flink jobs in a selected service.
 
 An example of ``avn service flink job list`` output:
 
-.. code:: tex
+.. code:: text
 
   ID                                STATUS
   ================================  =======

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -4,7 +4,7 @@ Command reference: ``avn service flink``
 Here you’ll find the full list of commands for ``avn service flink``.
 
 
-Create a new Flink table
+Manage a Flink table
 --------------------------------------------------------
 
 ``avn service flink table create``
@@ -21,7 +21,7 @@ Creates a new Aiven for Apache Flink table.
   * - ``service_name``
     - The name of the service
   * - ``integration_id``
-    - The id of the integration to use to locate the source/sink table/topic
+    - The ID of the integration to use to locate the source/sink table/topic
   * - ``--table-name``
     - The Flink table name
   * - ``--kafka-topic``
@@ -36,8 +36,204 @@ Creates a new Aiven for Apache Flink table.
     - Flink table schema SQL definition
  
 
-**Example:** Create a Flink table named ``analytics-it`` within the service named ``pg-demo``.
+**Example:** Create a Flink table named ``KAlert`` with:
+
+* ``alert`` as source Apache Kafka **topic**
+* ``node INT, occurred_at TIMESTAMP_LTZ(3), cpu_in_mb FLOAT`` as **SQL schema**
+* ``ab8dd446-c46e-4979-b6c0-1aad932440c9`` as integration ID
+* ``flink-devportal-demo`` as service name
 
 ::
   
-  avn service database-create pg-demo --dbname analytics-it
+  avn service flink table create flink-devportal-demo ab8dd446-c46e-4979-b6c0-1aad932440c9  \
+    --table-name KAlert                                                                     \
+    --kafka-topic alert                                                                     \
+    --schema-sql "node INT, occurred_at TIMESTAMP_LTZ(3), cpu_in_mb FLOAT"
+
+``avn service flink table delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes an existing Aiven for Apache Flink table.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``table_id``
+    - The ID of the table to delete
+
+**Example:** Delete the Flink table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink table delete flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
+
+``avn service flink table get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the definition of an existing Aiven for Apache Flink table.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``table_id``
+    - The ID of the table to retrieve
+
+**Example:** Retrieve the definition of the Flink table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink table get flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
+
+``avn service flink table list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists all the Aiven for Apache Flink tables in a selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List all the Flink tables available in the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink table list flink-devportal-demo
+
+An example of ``avn service flink table list`` output:
+
+.. code:: tex
+
+  INTEGRATION_ID                        TABLE_ID                              TABLE_NAME
+  ====================================  ====================================  ==========
+  ab8dd446-c46e-4979-b6c0-1aad932440c9  acb601d7-2000-4076-ae58-563aa7d9ab5a  KAlert
+
+Manage a Flink job
+--------------------------------------------------------
+
+``avn service flink job create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new Aiven for Apache Flink job.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``job_name``
+    - Name of the Flink job
+  * - ``--tables``
+    - List of Flink tables to use as source/sink
+  * - ``--statement``
+    - Flink job sql statement
+ 
+
+**Example:** Create a Flink job named ``JobExample`` with:
+
+* ``KCpuIn, KAlert`` as source/sink **tables**
+* ``INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_in_mb > 70`` as **SQL statement**
+* ``flink-devportal-demo`` as service name
+
+::
+  
+  avn service flink job create flink-devportal-demo JobExample \
+    --tables KCpuIn KAlert                                     \
+    --statement "INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_in_mb > 70" 
+
+``avn service flink job delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes an existing Aiven for Apache Flink job.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``table_id``
+    - The ID of the job to delete
+
+**Example:** Delete the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink job delete flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
+
+``avn service flink job get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the definition of an existing Aiven for Apache Flink job.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``job_id``
+    - The ID of the table to retrieve
+
+**Example:** Retrieve the definition of the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink table get flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
+
+An example of ``avn service flink job get`` output:
+
+.. code:: tex
+
+  JID                               NAME        STATE    START-TIME     END-TIME  DURATION  ISSTOPPABLE  MAXPARALLELISM
+  ================================  ==========  =======  =============  ========  ========  ===========  ==============
+  b63c78c70033e00afa84de9029257e31  JobExample  RUNNING  1633336792083  -1        423503    false        96
+
+``avn service flink job list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists all the Aiven for Apache Flink jobs in a selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List all the Flink jobs available in the Aiven for Flink service ``flink-devportal-demo``.
+
+::
+  
+  avn service flink jobs list flink-devportal-demo
+
+An example of ``avn service flink job list`` output:
+
+.. code:: tex
+
+  ID                                STATUS
+  ================================  =======
+  b63c78c70033e00afa84de9029257e31  RUNNING

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -1,0 +1,43 @@
+Command reference: ``avn service flink``
+============================================
+
+Here you’ll find the full list of commands for ``avn service flink``.
+
+
+Create a new Flink table
+--------------------------------------------------------
+
+``avn service flink table create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new Aiven for Apache Flink table.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``integration_id``
+    - The id of the integration to use to locate the source/sink table/topic
+  * - ``--table-name``
+    - The Flink table name
+  * - ``--kafka-topic``
+    - The Aiven for Apache Kafka topic to be used as source/sink (Only for Kafka integrations)
+  * - ``--jdbc-table``
+    - The Aiven for PostgreSQL table name to be used as source/sink (Only for PostgreSQL integrations)
+  * - ``partitioned-by``
+    - A column from the table schema to use as Flink table partition definition
+  * - ``--like-options``
+    - Creates the Flink table based on the definition of another existing Flink table
+  * - ``--schema-sql``
+    - Flink table schema SQL definition
+ 
+
+**Example:** Create a Flink table named ``analytics-it`` within the service named ``pg-demo``.
+
+::
+  
+  avn service database-create pg-demo --dbname analytics-it

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -143,7 +143,7 @@ Creates a new Aiven for Apache Flink job.
   * - ``--tables``
     - List of Flink tables to use as source/sink
   * - ``--statement``
-    - Flink job sql statement
+    - Flink job SQL statement
  
 
 **Example:** Create a Flink job named ``JobExample`` with:

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -21,7 +21,7 @@ Creates a new Aiven for Apache Flink table.
   * - ``service_name``
     - The name of the service
   * - ``integration_id``
-    - The ID of the integration to use to locate the source/sink table/topic
+    - The ID of the integration to use to locate the source/sink table/topic. The integration ID can be found with the :ref:`integration-list<avn_service_integration_list>` command
   * - ``--table-name``
     - The Flink table name
   * - ``--kafka-topic``
@@ -32,8 +32,6 @@ Creates a new Aiven for Apache Flink table.
     - A column from the table schema to use as Flink table partition definition
   * - ``--like-options``
     - Creates the Flink table based on the definition of another existing Flink table
-  * - ``--schema-sql``
-    - Flink table schema SQL definition
  
 
 **Example:** Create a Flink table named ``KAlert`` with:
@@ -94,6 +92,8 @@ Retrieves the definition of an existing Aiven for Apache Flink table.
   
   avn service flink table get flink-devportal-demo 8b8ac2fe-b6eb-46bc-b327-fb4b84d27276
 
+.. _avn_service_flink_table_list:
+
 ``avn service flink table list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -140,22 +140,22 @@ Creates a new Aiven for Apache Flink job.
     - The name of the service
   * - ``job_name``
     - Name of the Flink job
-  * - ``--tables``
-    - List of Flink tables to use as source/sink
+  * - ``--table-ids``
+    - List of Flink tables IDs to use as source/sink. Table IDs can be found using the :ref:`list <avn_service_flink_table_list>` command
   * - ``--statement``
     - Flink job SQL statement
  
 
 **Example:** Create a Flink job named ``JobExample`` with:
 
-* ``KCpuIn, KAlert`` as source/sink **tables**
+* ``KCpuIn`` (with id ``cac53785-d1b5-4856-90c8-7cbcc3efb2b6``) and ``KAlert`` (with id ``54c2f4e6-a446-4d62-8dc9-2b81179c6f43``) as source/sink **tables**
 * ``INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_in_mb > 70`` as **SQL statement**
 * ``flink-devportal-demo`` as service name
 
 ::
   
-  avn service flink job create flink-devportal-demo JobExample \
-    --tables KCpuIn KAlert                                     \
+  avn service flink job create flink-devportal-demo JobExample                        \
+    --table-ids cac53785-d1b5-4856-90c8-7cbcc3efb2b6 54c2f4e6-a446-4d62-8dc9-2b81179c6f43 \
     --statement "INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_in_mb > 70" 
 
 ``avn service flink job cancel``

--- a/docs/tools/cli/service/index.rst
+++ b/docs/tools/cli/service/index.rst
@@ -1,0 +1,18 @@
+Command reference: ``avn service index``
+============================================
+
+Here you’ll find the full list of commands for ``avn service index``.
+
+
+Manage Opensearch indexes
+--------------------------------------------------------
+
+``avn service index-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes Opensearch service indexes.
+
+``avn service index-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Opensearch service indexes.

--- a/docs/tools/cli/service/index.rst
+++ b/docs/tools/cli/service/index.rst
@@ -4,15 +4,15 @@ Command reference: ``avn service index``
 Here you’ll find the full list of commands for ``avn service index``.
 
 
-Manage Opensearch indexes
+Manage OpenSearch indexes
 --------------------------------------------------------
 
 ``avn service index-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Deletes Opensearch service indexes.
+Deletes OpenSearch service indexes.
 
 ``avn service index-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists Opensearch service indexes.
+Lists OpenSearch service indexes.

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -35,7 +35,7 @@ Creates a new service integration.
 
 .. Note::
 
-  Both the ``--user-config-json`` and ``-c`` flags provide a way to customise the service integration using different methods. Only one of the flag is allowed per command. When when using both in the same command, the following error will appear
+  Both the ``--user-config-json`` and ``-c`` flags provide a way to customise the service integration using different methods. Only one of the flag is allowed per command. When using both in the same command, an error will be shown
   ::
 
     ERROR	command failed: UserError: -c (user config) and --user-config-json parameters can not be used at the same time

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -1,5 +1,5 @@
 Command reference: ``avn service integration``
-============================================
+===============================================
 
 Here you’ll find the full list of commands for ``avn service integration``.
 
@@ -10,49 +10,272 @@ Manage Aiven internal and external integrations
 ``avn service integration-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a service integration.
+Creates a new service integration.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--integration-type``
+    - The type of integration (check :ref:`the command details<avn service integraton types>` for more details)
+  * - ``--source-service``
+    - The integration source service
+  * - ``--dest-service``
+    - The integration destination service
+  * - ``--source-endpoint-id``
+    - The integration source endpoint ID
+  * - ``--dest-endpoint-id``
+    - The integration destination endpoint ID
+  * - ``--user-config-json`` 
+    - The integration parameters as JSON string or path to file (preceded by ``@``)
+  * - ``-c KEY=VALUE``
+    - The custom configuration settings. 
+  
+
+**Example:** Create a new ``kafka_logs`` service integration to send the logs of the service named ``demo-pg`` to an Aiven for Kafka service named ``demo-kafka`` in the topic ``test_log``.
+
+::
+
+  avn service integration-create            \
+    --integration-type kafka_logs           \
+    --source-service demo-pg                \
+    --dest-service demo-kafka               \
+    -c 'kafka_topic=test_log'
 
 ``avn service integration-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Deletes a service integration.
 
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``integration-id``
+    - The ID of the integration to delete
+
+**Example:** Delete the integration with id ``8e752fa9-a0c1-4332-892b-f1757390d53f``.
+
+::
+
+    avn service integration-delete 8e752fa9-a0c1-4332-892b-f1757390d53f
+
 ``avn service integration-endpoint-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a service integration endpoint. 
+Creates an external service integration endpoint. 
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``--endpoint-name``
+    - The name of the endpoint
+  * - ``--endpoint-type``
+    - The type of endpoint (check :ref:`the command details<avn service integraton endpoint types>` for more details)
+  * - ``--user-config-json``
+    - The endpoint configuration in JSON format or as path to a file (preceded by ``@``)
+  * - ``-c KEY=VALUE``
+    - The custom configuration settings. 
+
+**Example:** Create an external Apache Kafka endpoint named ``demo-ext-kafka``.
+
+::
+
+    avn service integration-endpoint-create --endpoint-name demo-ext-kafka \
+        --endpoint-type external_kafka  \
+        --user-config-json  '{"bootstrap_servers":"servertest:123","security_protocol":"PLAINTEXT"}'
+
 
 ``avn service integration-endpoint-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Deletes a service integration endpoint.
 
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``endpoint-id``
+    - The ID of the endpoint to delete
+
+**Example:** Delete the endpoint with ID ``97590813-4a58-4c0c-91fd-eef0f074873b``.
+
+::
+
+    avn service integration-endpoint-delete 97590813-4a58-4c0c-91fd-eef0f074873b
+
+
 ``avn service integration-endpoint-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists service integration endpoints.
+Lists all service integration endpoints available in a selected project.
+
+**Example:** Lists all service integration endpoints available in the selected project.
+
+::
+
+    avn service integration-endpoint-list
+
+An example of ``account service integration-endpoint-list`` output:
+
+.. code:: text
+
+    ENDPOINT_ID                           ENDPOINT_NAME     ENDPOINT_TYPE
+    ====================================  ================  ==============
+    97590813-4a58-4c0c-91fd-eef0f074873b  datadog instance  datadog
+    821e0144-1503-42db-aa9f-b4aa34c4af6b  demo-ext-kafka    external_kafka
+
+
+.. _avn service integraton endpoint types:
 
 ``avn service integration-endpoint-types-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Lists all available integration endpoint types for given project.
 
+**Example:** Lists all service integration endpoint types available in the selected project.
+
+::
+
+    avn service integration-endpoint-types-list
+
+An example of ``account service integration-endpoint-types-list`` output:
+
+.. code:: text
+
+    TITLE                                        ENDPOINT_TYPE                    SERVICE_TYPES
+    ===========================================  ===============================  =====================================================================================================================================================================================================================
+    Send service metrics to Datadog              datadog                          cassandra, elasticsearch, kafka, kafka_connect, kafka_mirrormaker, mysql, pg, redis
+    Send service logs to AWS CloudWatch          external_aws_cloudwatch_logs     alerta, alertmanager, cassandra, clickhouse, elasticsearch, flink, grafana, influxdb, kafka, kafka_connect, kafka_mirrormaker, m3aggregator, m3coordinator, m3db, mysql, opensearch, pg, redis, sw
+    Send service metrics to AWS CloudWatch       external_aws_cloudwatch_metrics  cassandra, elasticsearch, kafka, kafka_connect, kafka_mirrormaker, mysql, pg, redis
+    Send service logs to external Elasticsearch  external_elasticsearch_logs      alerta, alertmanager, cassandra, clickhouse, elasticsearch, flink, grafana, influxdb, kafka, kafka_connect, kafka_mirrormaker, m3aggregator, m3coordinator, m3db, mysql, opensearch, pg, redis, sw
+    Send service logs to Google Cloud Logging    external_google_cloud_logging    alerta, alertmanager, cassandra, clickhouse, elasticsearch, flink, grafana, influxdb, kafka, kafka_connect, kafka_mirrormaker, m3aggregator, m3coordinator, m3db, mysql, opensearch, pg, redis, sw
+    Integrate external Kafka cluster             external_kafka                   alerta, alertmanager, cassandra, clickhouse, elasticsearch, flink, grafana, influxdb, kafka, kafka_connect, kafka_mirrormaker, kafka_mirrormaker, m3aggregator, m3coordinator, m3db, mysql, opensearch, pg, redis, sw
+    Integrate external Schema Registry           external_schema_registry         kafka
+    Access JMX metrics via Jolokia               jolokia                          kafka, kafka_connect, kafka_mirrormaker
+    Send service metrics to Prometheus           prometheus                       cassandra, elasticsearch, kafka, kafka_connect, kafka_mirrormaker, mysql, pg, redis
+    Send service logs to remote syslog           rsyslog                          alerta, alertmanager, cassandra, clickhouse, elasticsearch, flink, grafana, influxdb, kafka, kafka_connect, kafka_mirrormaker, m3aggregator, m3coordinator, m3db, mysql, opensearch, pg, redis, sw
+    Send service metrics to SignalFX             signalfx                         kafka
+
 ``avn service integration-endpoint-update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Updates a service integration endpoint.
 
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``endpoint-id``
+    - The ID of the endpoint
+  * - ``--user-config-json``
+    - The endpoint configuration in JSON format or as path to a file (preceded by ``@``)
+  * - ``-c KEY=VALUE``
+    - The custom configuration settings. 
+
+**Example:** Update an external Apache Kafka endpoint with id ``821e0144-1503-42db-aa9f-b4aa34c4af6b``.
+
+::
+
+    avn service integration-endpoint-update 821e0144-1503-42db-aa9f-b4aa34c4af6b \
+        --user-config-json  '{"bootstrap_servers":"servertestABC:123","security_protocol":"PLAINTEXT"}'
+
 ``avn service integration-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists service integrations.
+Lists the integrations defined for a selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  
+**Example:** List all integrations for the service named ``demo-pg``.
+
+::
+
+    avn service integration-list demo-pg
+
+An example of ``account service integration-list`` output:
+
+.. code:: text
+
+    SERVICE_INTEGRATION_ID                SOURCE        DEST        INTEGRATION_TYPE  ENABLED  ACTIVE  DESCRIPTION
+    ====================================  ============  ==========  ================  =======  ======  ============================================================
+    0e431dab-175a-4029-b417-d74a6437af1a  demo-grafana  demo-pg     dashboard         true     true    Provide a datasource for Grafana service
+    (integration not enabled)             demo-grafana  demo-pg     datasource        false    false   Provide a datasource for Grafana service (without dashboard)
+    (integration not enabled)             demo-kafka    demo-pg     metrics           false    false   Receive service metrics from service
+    8e752fa9-a0c1-4332-892b-f1757390d53f  demo-pg       demo-kafka  kafka_logs        true     true    Send logs to Kafka
+    (integration not enabled)             demo-pg       demo-pg     metrics           false    false   Send service metrics to InfluxDB, M3 or PostgreSQL service
+
+.. _avn service integraton types:
 
 ``avn service integration-types-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Lists all available integration types for given project.
+  
+**Example:** List all integration types for the currently selected project.
+
+::
+
+    avn service integration-types-list
+
+An example of ``account service integration-types-list`` output:
+
+.. code:: text
+
+    INTEGRATION_TYPE                 DEST_DESCRIPTION                                                      DEST_SERVICE_TYPE                SOURCE_DESCRIPTION                                          SOURCE_SERVICE_TYPES
+    ===============================  ====================================================================  ===============================  ==========================================================  ==================================================================================================================================================================================================
+    alertmanager                     Runs alert rules against time series databases and sends to Opsgenie  alertmanager                     Provide a datasource for Alertmanager service               m3coordinator
+    dashboard                        Provide a datasource for Grafana service                              influxdb                         Dashboards for InfluxDB, M3 or PostgreSQL backed metrics    grafana
+    datadog                          Receive service metrics from service                                  datadog                          Send service metrics to Datadog endpoint                    cassandra, elasticsearch, kafka, kafka_connect, kafka_mirrormaker, mysql, pg, redis
+    datasource                       Provide a datasource for Grafana service (without dashboard)          elasticsearch                    Grafana datasource                                          grafana
+    datasource                       Provide a datasource for Kafka Connect service                        alerta                           Kafka Connect datasource                                    kafka, kafka_connect
+    datasource                       Provide a datasource for PostgreSQL service                           pg                               PostgreSQL datasource                                       pg
+    datasource                       Provide a datasource for Elasticsearch service                        elasticsearch                    Elasticsearch datasource                                    elasticsearch
+    ...
+    schema_registry_proxy            Proxy Schema Registry requests                                        kafka                                                                                        external_schema_registry
+    signalfx                         Receive service metrics from service                                  signalfx                         Send service metrics to SignalFX                            kafka
+
 
 ``avn service integration-update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Updates a service integration.
+Updates an existing service integration.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``integration_id``
+    - The ID of integration
+  * - ``--user-config-json`` 
+    - The integration parameters as JSON string or path to file (preceded by ``@``)
+  * - ``-c KEY=VALUE``
+    - The custom configuration settings. 
+  
+
+**Example:** Update the service integration with ID  ``8e752fa9-a0c1-4332-892b-f1757390d53f`` changing the Aiven for Kafka topic storing the logs to ``test_pg_log``.
+
+::
+
+  avn service integration-update 8e752fa9-a0c1-4332-892b-f1757390d53f \
+    -c 'kafka_topic=test_pg_log'

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -19,7 +19,7 @@ Creates a new service integration.
   * - Parameter
     - Information
   * - ``--integration-type``
-    - The type of integration (check :ref:`the command details<avn service integraton types>` for more details)
+    - The type of integration (check :ref:`the command details<avn service integration types>` for more details)
   * - ``--source-service``
     - The integration source service
   * - ``--dest-service``
@@ -32,7 +32,13 @@ Creates a new service integration.
     - The integration parameters as JSON string or path to file (preceded by ``@``)
   * - ``-c KEY=VALUE``
     - The custom configuration settings. 
-  
+
+.. Note::
+
+  Both the `--user-config-json` and `-c` flags provide a way to customise the service integration using different methods. Only one of the flag is allowed per command. When when using both in the same command, the following error will appear
+  ::
+
+    ERROR	command failed: UserError: -c (user config) and --user-config-json parameters can not be used at the same time
 
 **Example:** Create a new ``kafka_logs`` service integration to send the logs of the service named ``demo-pg`` to an Aiven for Kafka service named ``demo-kafka`` in the topic ``test_log``.
 
@@ -78,7 +84,7 @@ Creates an external service integration endpoint.
   * - ``--endpoint-name``
     - The name of the endpoint
   * - ``--endpoint-type``
-    - The type of endpoint (check :ref:`the command details<avn service integraton endpoint types>` for more details)
+    - The type of endpoint (check :ref:`the command details<avn service integration endpoint types>` for more details)
   * - ``--user-config-json``
     - The endpoint configuration in JSON format or as path to a file (preceded by ``@``)
   * - ``-c KEY=VALUE``
@@ -125,7 +131,7 @@ Lists all service integration endpoints available in a selected project.
 
     avn service integration-endpoint-list
 
-An example of ``account service integration-endpoint-list`` output:
+An example of ``avn service integration-endpoint-list`` output:
 
 .. code:: text
 
@@ -135,7 +141,7 @@ An example of ``account service integration-endpoint-list`` output:
     821e0144-1503-42db-aa9f-b4aa34c4af6b  demo-ext-kafka    external_kafka
 
 
-.. _avn service integraton endpoint types:
+.. _avn service integration endpoint types:
 
 ``avn service integration-endpoint-types-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -223,7 +229,7 @@ An example of ``account service integration-list`` output:
     8e752fa9-a0c1-4332-892b-f1757390d53f  demo-pg       demo-kafka  kafka_logs        true     true    Send logs to Kafka
     (integration not enabled)             demo-pg       demo-pg     metrics           false    false   Send service metrics to InfluxDB, M3 or PostgreSQL service
 
-.. _avn service integraton types:
+.. _avn service integration types:
 
 ``avn service integration-types-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -1,0 +1,58 @@
+Command reference: ``avn service integration``
+============================================
+
+Here you’ll find the full list of commands for ``avn service integration``.
+
+
+Manage Aiven internal and external integrations
+--------------------------------------------------------
+
+``avn service integration-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a service integration.
+
+``avn service integration-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes a service integration.
+
+``avn service integration-endpoint-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a service integration endpoint. 
+
+``avn service integration-endpoint-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes a service integration endpoint.
+
+``avn service integration-endpoint-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists service integration endpoints.
+
+``avn service integration-endpoint-types-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists all available integration endpoint types for given project.
+
+``avn service integration-endpoint-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Updates a service integration endpoint.
+
+``avn service integration-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists service integrations.
+
+``avn service integration-types-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists all available integration types for given project.
+
+``avn service integration-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Updates a service integration.

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -1,5 +1,5 @@
 Command reference: ``avn service integration``
-===============================================
+==============================================
 
 Here you’ll find the full list of commands for ``avn service integration``.
 

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -197,6 +197,8 @@ Updates a service integration endpoint.
     avn service integration-endpoint-update 821e0144-1503-42db-aa9f-b4aa34c4af6b \
         --user-config-json  '{"bootstrap_servers":"servertestABC:123","security_protocol":"PLAINTEXT"}'
 
+.. _avn_service_integration_list:
+
 ``avn service integration-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -35,7 +35,7 @@ Creates a new service integration.
 
 .. Note::
 
-  Both the `--user-config-json` and `-c` flags provide a way to customise the service integration using different methods. Only one of the flag is allowed per command. When when using both in the same command, the following error will appear
+  Both the ``--user-config-json`` and ``-c`` flags provide a way to customise the service integration using different methods. Only one of the flag is allowed per command. When when using both in the same command, the following error will appear
   ::
 
     ERROR	command failed: UserError: -c (user config) and --user-config-json parameters can not be used at the same time

--- a/docs/tools/cli/service/topic.rst
+++ b/docs/tools/cli/service/topic.rst
@@ -10,24 +10,175 @@ Manage Aiven for Apache Kafka topics
 ``avn service topic-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a Kafka topic.
+Creates a new Kafka topic on the specified Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``topic``
+    - The name of the topic
+  * - ``partitions``
+    - The number of topic partitions
+  * - ``--replication``
+    - The topic replication factor
+  * - ``--min-insync-replicas``
+    - The minimum required nodes In Sync Replicas (ISR) for the topic/partition (default: 1)
+  * - ``--retention``
+    - The retention period in hours (default: unlimited)
+  * - ``--retention-bytes``
+    - The retention limit in bytes (default: unlimited)
+  * - ``--cleanup-policy``
+    - The topic cleanup policy; can be either ``delete`` or ``compact``.
+  * - ``-tag KEY[=VALUE]``
+    - Topic tagging
+
+**Example:** Create a new topic named ``invoices`` with ``3`` partitions and ``2`` as replication factor in the ``demo-kafka`` service. Furthermore tag the topic with ``BU=FINANCE`` tag.
+
+::
+
+  avn service topic-create demo-kafka invoices  \
+    --partitions 3                              \
+    --replication 2                             \
+    --tag BU=FINANCE
 
 ``avn service topic-delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Deletes a Kafka topic.
+Deletes a Kafka topic on the specified Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``topic``
+    - The name of the topic
+
+**Example:** Delete the topic named ``invoices`` in the ``demo-kafka`` service.
+
+::
+
+    avn service topic-delete demo-kafka invoices
 
 ``avn service topic-get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves Kafka topic.
+Retrieves Kafka topic on the specified Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``topic``
+    - The name of the topic
+
+**Example:** Retrieve the information about a topic named ``invoices`` in the ``demo-kafka`` service.
+
+::
+
+    avn service topic-get demo-kafka invoices
+
+An example of ``avn service topic-get`` output:
+
+.. code:: text
+
+    PARTITION  ISR  SIZE  EARLIEST_OFFSET  LATEST_OFFSET  GROUPS
+    =========  ===  ====  ===============  =============  ======
+    0          2    0     0                0              0
+    1          2    null  0                0              0
+    2          2    0     0                0              0
+
+    (No consumer groups)
 
 ``avn service topic-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists Kafka service topics.
+Lists Kafka topics on the specified Aiven for Apache Kafka service together with the following information:
+
+* partitions
+* replication
+* min in-sync replicas
+* retention bytes
+* retention hours
+* cleanup policy
+* tags
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Retrieve list of topics available in the ``demo-kafka`` service.
+
+::
+
+    avn service topic-list demo-kafka
+
+An example of ``avn service topic-get`` output:
+
+.. code:: text
+
+    TOPIC_NAME  PARTITIONS  REPLICATION  MIN_INSYNC_REPLICAS  RETENTION_BYTES  RETENTION_HOURS  CLEANUP_POLICY  TAGS
+    ==========  ==========  ===========  ===================  ===============  ===============  ==============  ==========
+    bills       3           2            1                    -1               unlimited        delete
+    invoices    3           2            1                    -1               168              delete          BU=FINANCE
+    orders      2           3            1                    -1               unlimited        delete
+
 
 ``avn service topic-update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Updates a Kafka topic.
+Updates a Kafka topic on the specified Aiven for Apache Kafka service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``topic``
+    - The name of the topic
+  * - ``partitions``
+    - The number of topic partitions
+  * - ``--replication``
+    - The topic replication factor
+  * - ``--min-insync-replicas``
+    - The minimum required nodes In Sync Replicas (ISR) for the topic/partition (default: 1)
+  * - ``--retention``
+    - The retention period in hours (default: unlimited)
+  * - ``--retention-bytes``
+    - The retention limit in bytes (default: unlimited)
+  * - ``--cleanup-policy``
+    - The topic cleanup policy; can be either ``delete`` or ``compact``.
+  * - ``-tag KEY[=VALUE]``
+    - Topic tagging
+  * - ``--untag KEY``
+    - Topic tag to remove
+
+**Example:** Update the topic named ``invoices`` in the ``demo-kafka`` service. Set ``4`` partitions and ``3`` as replication factor. Furthermore remove the ``BU`` tag and add a new ``CC=FINANCE_DE`` tag.
+
+::
+
+  avn service topic-update demo-kafka invoices  \
+    --partitions 4                              \
+    --replication 3                             \
+    --tag CC=FINANCE_DE                         \
+    --untag BU

--- a/docs/tools/cli/service/topic.rst
+++ b/docs/tools/cli/service/topic.rst
@@ -1,0 +1,33 @@
+Command reference: ``avn service topic``
+==================================================
+
+Here you’ll find the full list of commands for ``avn service topic``.
+
+
+Manage Aiven for Apache Kafka topics
+--------------------------------------------------------
+
+``avn service topic-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a Kafka topic.
+
+``avn service topic-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Deletes a Kafka topic.
+
+``avn service topic-get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves Kafka topic.
+
+``avn service topic-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists Kafka service topics.
+
+``avn service topic-update``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Updates a Kafka topic.

--- a/docs/tools/cli/service/user.rst
+++ b/docs/tools/cli/service/user.rst
@@ -1,0 +1,200 @@
+Command reference: ``avn service user``
+==================================================
+
+Here you’ll find the full list of commands for ``avn service user``.
+
+
+Manage Aiven users and credentials
+--------------------------------------------------------
+
+``avn service user-create``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Creates a new user for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The new username to be created
+  * - ``--m3-group``
+    - The name of the group the user belongs to (for Aiven for M3 services only)
+  * - ``--redis-acl-keys``
+    - The ACL rules for keys (Aiven for Redis services only)
+  * - ``--redis-acl-commands``
+    - The ACL rules for commands (Aiven for Redis services only)
+  * - ``--redis-acl-categories``
+    - The ACL rules for categories (Aiven for Redis services only)
+  * - ``--redis-acl-channels``
+    - The ACL rules for channels (Aiven for Redis services only)
+
+**Example:** Create a new user named ``janedoe`` for a service named ``pg-demo``.
+
+::
+
+  avn service user-create pg-demo --username janedoe
+
+``avn service user-creds-download``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Downloads the SSL certificate, key and CA certificate for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to download the certificates
+  * - ``-d``
+    - The target directory where certificates will be stored
+
+**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``.
+
+::
+
+  avn service user-creds-download kafka-demo --username janedoe -d /tmp/certs
+
+``avn service user-delete``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Delete a service in a given Aiven service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username to delete
+
+**Example:** Delete the user ``janedoe`` defined in a service named ``kafka-demo``.
+
+::
+
+  avn service user-delete kafka-demo --username janedoe
+
+``avn service user-get``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the details for a single user in a given Aiven service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to retrieve the details
+
+**Example:** Retrieve the details for the user ``janedoe`` defined for a service named ``kafka-demo``.
+
+::
+
+  avn service user-get kafka-demo --username janedoe
+
+.. Tip::
+
+    Use the ``--json`` parameter to retrieve all the service specific information for a specific user.
+
+``avn service user-kafka-java-creds``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Download user certificate/key/CA certificate and create a Java keystore/truststore/properties from them 
+
+Downloads the SSL certificate, key and CA certificate and creates a Java keystore and truststore for the selected service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username for which to download the certificates
+  * - ``-d``
+    - The target directory where certificates will be stored
+  * - ``--password``
+    - The Java keystore and truststore password (default: ``changeit``)
+
+**Example:** Download the SSL certificate, key and CA certificate in a folder named ``/tmp/certs`` for the user ``janedoe`` belonging to a service named ``kafka-demo``. Furthermore, secure the Java keystore and truststore with the password ``safePassword123``.
+
+::
+
+  avn service user-kafka-java-creds kafka-demo --username janedoe -d /tmp/certs --password safePassword123
+
+``avn service user-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Lists the users defined for the selected service, and the related type (``primary`` or ``normal``).
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** List the users defined for a service named ``pg-doc``.
+
+::
+
+  avn service user-list pg-doc
+
+
+An example of ``account service user-list`` output:
+
+.. code:: text
+
+    USERNAME   TYPE
+    =========  =======
+    analytics  normal
+    avnadmin   primary
+
+``avn service user-password-reset``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Resets or changes the service user password.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--username``
+    - The username to change the password for
+  * - ``--new-password``
+    - The new password for the user
+
+**Example:** Change the password for the ``avnadmin`` user of the service named ``pg-doc`` to ``VerySecurePwd123``.
+
+::
+
+  avn service user-password-reset pg-doc --username avnadmin --new-password VerySecurePwd123
+
+
+``avn service user-set-access-control``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Set Redis service user access control 


### PR DESCRIPTION
The existing PR #244 has some issues and can't be rebased due to many simultaneous changes to the same files, and repeated commit/rebase/merge changes since the branch has been open for some time. This branch is an attempt to get all the commits, once, on the tip of current `main`. We should check it builds, and see which commands are now missing.

- initial set of docs
- basic set of commands
- fixed sstableloader
- Added avn service user*
- Fixed subpages and content
- fixed wording for connector
- Added content for avn service topic
- added update and service types
- added terminate and plans
- Added link
- Fixed OpenSearch
- Add service types config info, and minor copy tweaks
- Added avn service integration docs
- Fixed dbeech comments
- fixed wording
- Minor wording fix
- added basic flink cli
- added flink cli commands
- changed job cancel
- fixed tex to text
- Fixed Flink in accpeted terms
- fixed SQL uppercase
- fixed list of commands
- fixed ordering
- Fixed Olena's comments
- added metrics,  and query docs
- Fixed Lorna's comments
- Fixed minor comments from Lorna
