### PR TITLE
Removed `Command reference` from page title

### DIFF
--- a/docs/tools/cli/account.rst
+++ b/docs/tools/cli/account.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn account``
+``avn account``
 ==================================
 
 Here you’ll find the full list of commands for ``avn account``.

--- a/docs/tools/cli/account/account-authentication-method.rst
+++ b/docs/tools/cli/account/account-authentication-method.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn account authentication-method``
+``avn account authentication-method``
 ========================================================
 
 Here you’ll find the full list of commands for ``avn account authentication-method``.

--- a/docs/tools/cli/account/account-team.rst
+++ b/docs/tools/cli/account/account-team.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn account team``
+``avn account team``
 =======================================
 
 Here you’ll find the full list of commands for ``avn account team``.

--- a/docs/tools/cli/card.rst
+++ b/docs/tools/cli/card.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn card``
+``avn card``
 ===============================
 
 Here you’ll find the full list of commands for ``avn card``.

--- a/docs/tools/cli/cloud.rst
+++ b/docs/tools/cli/cloud.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn cloud``
+``avn cloud``
 ==================================
 
 Here you’ll find the full list of commands for ``avn cloud``.

--- a/docs/tools/cli/credits.rst
+++ b/docs/tools/cli/credits.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn credits``
+``avn credits``
 ==================================
 
 Here you’ll find the full list of commands for ``avn credits``.

--- a/docs/tools/cli/events.rst
+++ b/docs/tools/cli/events.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn events``
+``avn events``
 ==================================
 
 The ``avn events`` command is an audit log of things that have happened in a particular project, including:

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn project``
+``avn project``
 ==================================
 
 Here you'll find the full list of commands for ``avn project``.

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service``
+``avn service``
 ==================================
 
 Here you’ll find the full list of commands for ``avn service``.

--- a/docs/tools/cli/service/acl.rst
+++ b/docs/tools/cli/service/acl.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service acl``
+``avn service acl``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service acl``.
@@ -29,7 +29,7 @@ Adds an Aiven for Apache Kafka ACL entry.
   * - ``--username``
     - The username pattern: accepts ``*`` and ``?`` as wildcard characters
 
-**Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service``kafka-doc``.
+**Example:** Add an ACLs for users with username ending with ``userA`` to ``readwrite`` on topics having name starting with ``topic2020`` in the service ``kafka-doc``.
 
 ::
 

--- a/docs/tools/cli/service/connection-pool.rst
+++ b/docs/tools/cli/service/connection-pool.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service connection-pool``
+``avn service connection-pool``
 ==================================================
 
 Here you’ll find the full list of commands for ``avn service connection-pool``.

--- a/docs/tools/cli/service/connector.rst
+++ b/docs/tools/cli/service/connector.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service connector``
+``avn service connector``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service connector``.

--- a/docs/tools/cli/service/database.rst
+++ b/docs/tools/cli/service/database.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service database``
+``avn service database``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service database``.

--- a/docs/tools/cli/service/es-acl.rst
+++ b/docs/tools/cli/service/es-acl.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service es-acl``
+``avn service es-acl``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service es-acl``.

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service flink``
+``avn service flink``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service flink``.

--- a/docs/tools/cli/service/index.rst
+++ b/docs/tools/cli/service/index.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service index``
+``avn service index``
 ============================================
 
 Here you’ll find the full list of commands for ``avn service index``.

--- a/docs/tools/cli/service/integration.rst
+++ b/docs/tools/cli/service/integration.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service integration``
+``avn service integration``
 ==============================================
 
 Here you’ll find the full list of commands for ``avn service integration``.

--- a/docs/tools/cli/service/topic.rst
+++ b/docs/tools/cli/service/topic.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service topic``
+``avn service topic``
 ==================================================
 
 Here you’ll find the full list of commands for ``avn service topic``.

--- a/docs/tools/cli/service/user.rst
+++ b/docs/tools/cli/service/user.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn service user``
+``avn service user``
 ==================================================
 
 Here you’ll find the full list of commands for ``avn service user``.

--- a/docs/tools/cli/user.rst
+++ b/docs/tools/cli/user.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn user``
+``avn user``
 ==================================
 
 Here you'll find the full list of commands for ``avn user``.

--- a/docs/tools/cli/user/user-access-token.rst
+++ b/docs/tools/cli/user/user-access-token.rst
@@ -1,4 +1,4 @@
-Command reference: ``avn user access-token``
+``avn user access-token``
 ============================================
 
 Here you'll find the full list of commands for ``avn user access-token``.


### PR DESCRIPTION
# What changed, and why it matters

Removed the `Command reference` prefix from page title
