### PR TITLE
Add beta label to Flink cli header

### DIFF
--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -173,7 +173,7 @@ Manages rules to OpenSearch ACL and extended ACL configuration.
 
 More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl-enable``, ``es-acl-extended-disable``, ``es-acl-extended-enable`` and ``es-acl-extended-list``  can be found in :doc:`the dedicated page <service/es-acl>`.
 
-``avn service flink``
+``avn service flink`` :badge:`beta,cls=badge-secondary badge-pill`
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Manages Aiven for Apache Flink tables and jobs.

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -1,5 +1,5 @@
-``avn service flink``
-============================================
+``avn service flink`` :badge:`beta,cls=badge-secondary badge-pill`
+==================================================================
 
 Here you’ll find the full list of commands for ``avn service flink``.
 


### PR DESCRIPTION
Added Beta label to give a user an indication that the service is still in Beta state.


