### PR TITLE
Virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ __pycache__
 .netlify
 node_modules
 
-# ignore common virtual environment names
+
 venv
 env

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ _build/*
 __pycache__
 .netlify
 node_modules
+
+# ignore common virtual environment names
+venv
+env

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Running locally
 ---------------
 
+We recommend using a virtual environment like `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ or `venv <https://docs.python.org/3/library/venv.html>`_.
+
 Install the dependencies::
 
     pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ We recommend using a virtual environment like `venv <https://docs.python.org/3/l
 
 If you call it something other than `venv` or `env`, make sure to add your preferred name to `<.gitignore>`_.
 
+Activate your virtual environment using the `activate` script for your environment.
+
 Install the dependencies::
 
     pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Running locally
 ---------------
 
-We recommend using a virtual environment like `venv <https://docs.python.org/3/library/venv.html>`_:
+We recommend using a virtual environment like `venv <https://docs.python.org/3/library/venv.html>`_::
 
     python3 -m venv /path/to/new/virtual/environment
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ We recommend using a virtual environment like `venv <https://docs.python.org/3/l
 
     python3 -m venv /path/to/new/virtual/environment
 
-If you call it something other than `venv`, add your preferred name to `<.gitignore>`_.
+If you call it something other than `venv` or `env`, make sure to add your preferred name to `<.gitignore>`_.
 
 Install the dependencies::
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Running locally
 ---------------
 
-We recommend using a virtual environment like `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ or `venv <https://docs.python.org/3/library/venv.html>`_.
+We recommend using a virtual environment like `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ or `venv <https://docs.python.org/3/library/venv.html>`_. Call your virtual environment `env` or `venv`, or add you preferred name to `<.gitignore>`_.
 
 Install the dependencies::
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,11 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Running locally
 ---------------
 
-We recommend using a virtual environment like `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ or `venv <https://docs.python.org/3/library/venv.html>`_. Call your virtual environment `env` or `venv`, or add you preferred name to `<.gitignore>`_.
+We recommend using a virtual environment like `venv <https://docs.python.org/3/library/venv.html>`_:
+
+    python3 -m venv /path/to/new/virtual/environment
+
+If you call it something other than `venv`, add your preferred name to `<.gitignore>`_.
 
 Install the dependencies::
 


### PR DESCRIPTION
Added the following:

- `env` and `venv` to `.gitignore`. These are commonly-used names for Python virtual environments.
- Added a recommendation to the README, advising people to use virtualenv or venv.

Using a virtual environment is generally a best practice ([explanation](https://towardsdatascience.com/why-you-should-use-a-virtual-environment-for-every-python-project-c17dab3b0fd0)), and also a convenience. I'm not suggesting enforcing use if people don't want to, but helping folks _not_ commit their venv folder by accident might save the occasional headache.

