### PR TITLE
Fixed PG business backup retention period

### DIFF
--- a/docs/products/postgresql/concepts/pg-backups.rst
+++ b/docs/products/postgresql/concepts/pg-backups.rst
@@ -20,7 +20,7 @@ The number of stored backups and the backup retention time depends on the servic
     * - Startup
       - 2 days
     * - Business
-      - 15 days
+      - 14 days
     * - Premium
       - 30 days
 


### PR DESCRIPTION
# What changed, and why it matters

Fixed PG backup retention period (14 days instead of the 15 mentioned in the existing doc)

Fixes #374 