### PR TITLE
Fixed wording for Aiven for Apache Kafka Connect

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/enable-connect.rst
+++ b/docs/products/kafka/kafka-connect/howto/enable-connect.rst
@@ -5,7 +5,7 @@ To enable Kafka Connect on Aiven for Apache Kafka services, those should be runn
 
 .. Warning::
 
-    Creating a :ref:`dedicated Aiven for Kafka Connect service <apache_kafka_connect_dedicated_cluster>` is Aiven's suggested option. Having Kafka Connect running on the same nodes as Apache Kafka increases the load on the nodes possibly making the cluster more unstable. 
+    Creating a :ref:`dedicated Aiven for Apache Kafka Connect service <apache_kafka_connect_dedicated_cluster>` is Aiven's suggested option. Having Kafka Connect running on the same nodes as Apache Kafka increases the load on the nodes possibly making the cluster more unstable. 
     
     For a better separation of concerns, a dedicated Aiven for Apache Kafka Connect cluster is therefore suggested.
 


### PR DESCRIPTION
# What changed, and why it matters

Fixed page https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/enable-connect.html naming for Aiven for apache Kafka connect
