### PR TITLE
Add make commands to generate configuration docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,35 @@ index-helpcenter:
 create-feedback-table:
 	python "$(SOURCEDIR)/scripts/create_feedback_table.py" \
 		--pg-url="$(PG_URL)"
+
+# (Re)Generate config listing for a service type
+service-type-config-pg:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "pg" > includes/config-pg.rst
+
+service-type-config-kafka:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "kafka" > includes/config-kafka.rst
+
+service-type-config-cassandra:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "cassandra" > includes/config-cassandra.rst
+
+service-type-config-opensearch:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "opensearch" > includes/config-opensearch.rst
+
+service-type-config-mysql:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "mysql" > includes/config-mysql.rst
+
+service-type-config-m3db:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "m3db" > includes/config-m3db.rst
+
+service-type-config-redis:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "redis" > includes/config-redis.rst
+
+service-type-config-flink:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "flink" > includes/config-flink.rst
+
+service-type-config-grafana:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "grafana" > includes/config-grafana.rst
+
+service-type-config-influxdb:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "influxdb" > includes/config-influxdb.rst
+

--- a/_toc.yml
+++ b/_toc.yml
@@ -75,7 +75,11 @@ entries:
           - file: docs/products/kafka/howto/kcat.rst
           - file: docs/products/kafka/howto/integrate-service-logs-into-kafka-topic
           - file: docs/products/kafka/howto/kafka-conduktor
-      
+      - file: docs/products/kafka/reference
+        title: Reference
+        entries:
+          - glob: docs/products/kafka/reference/*
+
       - file: docs/products/kafka/kafka-connect/index
         title: Apache Kafka Connect
         entries:

--- a/docs/products/kafka/reference.rst
+++ b/docs/products/kafka/reference.rst
@@ -1,0 +1,7 @@
+Reference
+=========
+
+References for PostgreSQL:
+
+.. tableofcontents::
+

--- a/docs/products/kafka/reference.rst
+++ b/docs/products/kafka/reference.rst
@@ -1,7 +1,7 @@
 Reference
 =========
 
-References for PostgreSQL:
+Useful reference materials for working with Aiven for Apache Kafka.
 
 .. tableofcontents::
 

--- a/docs/products/kafka/reference/advanced-params.rst
+++ b/docs/products/kafka/reference/advanced-params.rst
@@ -1,0 +1,6 @@
+List of advanced parameters
+============================
+
+When creating or working with an Aiven for Apache Kafka service, several configuration options are available. They are summarized below:
+
+.. include:: /includes/config-kafka.rst

--- a/includes/config-kafka.rst
+++ b/includes/config-kafka.rst
@@ -1,0 +1,53 @@
+
+.. list-table::
+  :header-rows: 1
+
+  * - Parameter
+    - Value Type
+    - Description
+  * - ``custom_domain``
+    - ['string', 'null']
+    - Custom domain Serve the web frontend using a custom CNAME pointing to the Aiven DNS name
+  * - ``ip_filter``
+    - array
+    - IP filter Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+  * - ``static_ips``
+    - boolean
+    - Static IP addresses Use static public IP addresses
+  * - ``private_access``
+    - object
+    - Allow access to selected service ports from private networks 
+  * - ``public_access``
+    - object
+    - Allow access to selected service ports from the public Internet 
+  * - ``privatelink_access``
+    - object
+    - Allow access to selected service components through Privatelink 
+  * - ``kafka``
+    - object
+    - Kafka broker configuration values 
+  * - ``kafka_authentication_methods``
+    - object
+    - Kafka authentication methods 
+  * - ``kafka_connect``
+    - boolean
+    - Enable Kafka Connect service 
+  * - ``kafka_connect_config``
+    - object
+    - Kafka Connect configuration values 
+  * - ``kafka_rest``
+    - boolean
+    - Enable Kafka-REST service 
+  * - ``kafka_version``
+    - ['string', 'null']
+    - Kafka major version 
+  * - ``schema_registry``
+    - boolean
+    - Enable Schema-Registry service 
+  * - ``kafka_rest_config``
+    - object
+    - Kafka REST configuration 
+  * - ``schema_registry_config``
+    - object
+    - Schema Registry configuration 
+

--- a/includes/config-kafka.rst
+++ b/includes/config-kafka.rst
@@ -1,287 +1,282 @@
+``custom_domain`` => *['string', 'null']*
+  **Custom domain** Serve the web frontend using a custom CNAME pointing to the Aiven DNS name
 
-``custom_domain``  *['string', 'null']*
-  - **Custom domain** Serve the web frontend using a custom CNAME pointing to the Aiven DNS name
 
 
+``ip_filter`` => *array*
+  **IP filter** Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
 
-``ip_filter``  *array*
-  - **IP filter** Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
 
 
+``static_ips`` => *boolean*
+  **Static IP addresses** Use static public IP addresses
 
-``static_ips``  *boolean*
-  - **Static IP addresses** Use static public IP addresses
 
 
+``private_access`` => *object*
+  **Allow access to selected service ports from private networks**
 
-``private_access``  *object*
-  - **Allow access to selected service ports from private networks** 
+  ``prometheus`` => *boolean*
+    **Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations** None
 
-  ``prometheus``  *boolean*
-    - **Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations** None
 
 
+``public_access`` => *object*
+  **Allow access to selected service ports from the public Internet**
 
-``public_access``  *object*
-  - **Allow access to selected service ports from the public Internet** 
+  ``kafka`` => *boolean*
+    **Allow clients to connect to kafka from the public internet for service nodes that are in a project VPC or another type of private network** None
 
-  ``kafka``  *boolean*
-    - **Allow clients to connect to kafka from the public internet for service nodes that are in a project VPC or another type of private network** None
+  ``kafka_connect`` => *boolean*
+    **Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network** None
 
-  ``kafka_connect``  *boolean*
-    - **Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network** None
+  ``kafka_rest`` => *boolean*
+    **Allow clients to connect to kafka_rest from the public internet for service nodes that are in a project VPC or another type of private network** None
 
-  ``kafka_rest``  *boolean*
-    - **Allow clients to connect to kafka_rest from the public internet for service nodes that are in a project VPC or another type of private network** None
+  ``prometheus`` => *boolean*
+    **Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network** None
 
-  ``prometheus``  *boolean*
-    - **Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network** None
+  ``schema_registry`` => *boolean*
+    **Allow clients to connect to schema_registry from the public internet for service nodes that are in a project VPC or another type of private network** None
 
-  ``schema_registry``  *boolean*
-    - **Allow clients to connect to schema_registry from the public internet for service nodes that are in a project VPC or another type of private network** None
 
 
+``privatelink_access`` => *object*
+  **Allow access to selected service components through Privatelink**
 
-``privatelink_access``  *object*
-  - **Allow access to selected service components through Privatelink** 
+  ``kafka`` => *boolean*
+    **Enable kafka** None
 
-  ``kafka``  *boolean*
-    - **Enable kafka** None
+  ``kafka_connect`` => *boolean*
+    **Enable kafka_connect** None
 
-  ``kafka_connect``  *boolean*
-    - **Enable kafka_connect** None
+  ``kafka_rest`` => *boolean*
+    **Enable kafka_rest** None
 
-  ``kafka_rest``  *boolean*
-    - **Enable kafka_rest** None
+  ``schema_registry`` => *boolean*
+    **Enable schema_registry** None
 
-  ``schema_registry``  *boolean*
-    - **Enable schema_registry** None
 
 
+``kafka`` => *object*
+  **Kafka broker configuration values**
 
-``kafka``  *object*
-  - **Kafka broker configuration values** 
+  ``compression_type`` => *string*
+    **compression.type** Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
 
-  ``compression_type``  *string*
-    - **compression.type** Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
+  ``group_initial_rebalance_delay_ms`` => *integer*
+    **group.initial.rebalance.delay.ms** The amount of time, in milliseconds, the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins. The default value for this is 3 seconds. During development and testing it might be desirable to set this to 0 in order to not delay test execution time.
 
-  ``group_initial_rebalance_delay_ms``  *integer*
-    - **group.initial.rebalance.delay.ms** The amount of time, in milliseconds, the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins. The default value for this is 3 seconds. During development and testing it might be desirable to set this to 0 in order to not delay test execution time.
+  ``group_min_session_timeout_ms`` => *integer*
+    **group.min.session.timeout.ms** The minimum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
 
-  ``group_min_session_timeout_ms``  *integer*
-    - **group.min.session.timeout.ms** The minimum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+  ``group_max_session_timeout_ms`` => *integer*
+    **group.max.session.timeout.ms** The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
 
-  ``group_max_session_timeout_ms``  *integer*
-    - **group.max.session.timeout.ms** The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+  ``connections_max_idle_ms`` => *integer*
+    **connections.max.idle.ms** Idle connections timeout: the server socket processor threads close the connections that idle for longer than this.
 
-  ``connections_max_idle_ms``  *integer*
-    - **connections.max.idle.ms** Idle connections timeout: the server socket processor threads close the connections that idle for longer than this.
+  ``max_incremental_fetch_session_cache_slots`` => *integer*
+    **max.incremental.fetch.session.cache.slots** The maximum number of incremental fetch sessions that the broker will maintain.
 
-  ``max_incremental_fetch_session_cache_slots``  *integer*
-    - **max.incremental.fetch.session.cache.slots** The maximum number of incremental fetch sessions that the broker will maintain.
+  ``message_max_bytes`` => *integer*
+    **message.max.bytes** The maximum size of message that the server can receive.
 
-  ``message_max_bytes``  *integer*
-    - **message.max.bytes** The maximum size of message that the server can receive.
+  ``offsets_retention_minutes`` => *integer*
+    **offsets.retention.minutes** Log retention window in minutes for offsets topic
 
-  ``offsets_retention_minutes``  *integer*
-    - **offsets.retention.minutes** Log retention window in minutes for offsets topic
+  ``log_cleaner_delete_retention_ms`` => *integer*
+    **log.cleaner.delete.retention.ms** How long are delete records retained?
 
-  ``log_cleaner_delete_retention_ms``  *integer*
-    - **log.cleaner.delete.retention.ms** How long are delete records retained?
+  ``log_cleaner_min_cleanable_ratio`` => *number*
+    **log.cleaner.min.cleanable.ratio** Controls log compactor frequency. Larger value means more frequent compactions but also more space wasted for logs. Consider setting log.cleaner.max.compaction.lag.ms to enforce compactions sooner, instead of setting a very high value for this option.
 
-  ``log_cleaner_min_cleanable_ratio``  *number*
-    - **log.cleaner.min.cleanable.ratio** Controls log compactor frequency. Larger value means more frequent compactions but also more space wasted for logs. Consider setting log.cleaner.max.compaction.lag.ms to enforce compactions sooner, instead of setting a very high value for this option.
+  ``log_cleaner_max_compaction_lag_ms`` => *integer*
+    **log.cleaner.max.compaction.lag.ms** The maximum amount of time message will remain uncompacted. Only applicable for logs that are being compacted
 
-  ``log_cleaner_max_compaction_lag_ms``  *integer*
-    - **log.cleaner.max.compaction.lag.ms** The maximum amount of time message will remain uncompacted. Only applicable for logs that are being compacted
+  ``log_cleaner_min_compaction_lag_ms`` => *integer*
+    **log.cleaner.min.compaction.lag.ms** The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
 
-  ``log_cleaner_min_compaction_lag_ms``  *integer*
-    - **log.cleaner.min.compaction.lag.ms** The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
+  ``log_cleanup_policy`` => *string*
+    **log.cleanup.policy** The default cleanup policy for segments beyond the retention window
 
-  ``log_cleanup_policy``  *string*
-    - **log.cleanup.policy** The default cleanup policy for segments beyond the retention window
+  ``log_flush_interval_messages`` => *integer*
+    **log.flush.interval.messages** The number of messages accumulated on a log partition before messages are flushed to disk
 
-  ``log_flush_interval_messages``  *integer*
-    - **log.flush.interval.messages** The number of messages accumulated on a log partition before messages are flushed to disk
+  ``log_flush_interval_ms`` => *integer*
+    **log.flush.interval.ms** The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used
 
-  ``log_flush_interval_ms``  *integer*
-    - **log.flush.interval.ms** The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used
+  ``log_index_interval_bytes`` => *integer*
+    **log.index.interval.bytes** The interval with which Kafka adds an entry to the offset index
 
-  ``log_index_interval_bytes``  *integer*
-    - **log.index.interval.bytes** The interval with which Kafka adds an entry to the offset index
+  ``log_index_size_max_bytes`` => *integer*
+    **log.index.size.max.bytes** The maximum size in bytes of the offset index
 
-  ``log_index_size_max_bytes``  *integer*
-    - **log.index.size.max.bytes** The maximum size in bytes of the offset index
+  ``log_message_downconversion_enable`` => *boolean*
+    **log.message.downconversion.enable** This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests.
 
-  ``log_message_downconversion_enable``  *boolean*
-    - **log.message.downconversion.enable** This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. 
+  ``log_message_timestamp_type`` => *string*
+    **log.message.timestamp.type** Define whether the timestamp in the message is message create time or log append time.
 
-  ``log_message_timestamp_type``  *string*
-    - **log.message.timestamp.type** Define whether the timestamp in the message is message create time or log append time.
+  ``log_message_timestamp_difference_max_ms`` => *integer*
+    **log.message.timestamp.difference.max.ms** The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message
 
-  ``log_message_timestamp_difference_max_ms``  *integer*
-    - **log.message.timestamp.difference.max.ms** The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message
+  ``log_preallocate`` => *boolean*
+    **log.preallocate** Should pre allocate file when create new segment?
 
-  ``log_preallocate``  *boolean*
-    - **log.preallocate** Should pre allocate file when create new segment?
+  ``log_retention_bytes`` => *integer*
+    **log.retention.bytes** The maximum size of the log before deleting messages
 
-  ``log_retention_bytes``  *integer*
-    - **log.retention.bytes** The maximum size of the log before deleting messages
+  ``log_retention_hours`` => *integer*
+    **log.retention.hours** The number of hours to keep a log file before deleting it
 
-  ``log_retention_hours``  *integer*
-    - **log.retention.hours** The number of hours to keep a log file before deleting it
+  ``log_retention_ms`` => *integer*
+    **log.retention.ms** The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used. If set to -1, no time limit is applied.
 
-  ``log_retention_ms``  *integer*
-    - **log.retention.ms** The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used. If set to -1, no time limit is applied.
+  ``log_roll_jitter_ms`` => *integer*
+    **log.roll.jitter.ms** The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used
 
-  ``log_roll_jitter_ms``  *integer*
-    - **log.roll.jitter.ms** The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used
+  ``log_roll_ms`` => *integer*
+    **log.roll.ms** The maximum time before a new log segment is rolled out (in milliseconds).
 
-  ``log_roll_ms``  *integer*
-    - **log.roll.ms** The maximum time before a new log segment is rolled out (in milliseconds).
+  ``log_segment_bytes`` => *integer*
+    **log.segment.bytes** The maximum size of a single log file
 
-  ``log_segment_bytes``  *integer*
-    - **log.segment.bytes** The maximum size of a single log file
+  ``log_segment_delete_delay_ms`` => *integer*
+    **log.segment.delete.delay.ms** The amount of time to wait before deleting a file from the filesystem
 
-  ``log_segment_delete_delay_ms``  *integer*
-    - **log.segment.delete.delay.ms** The amount of time to wait before deleting a file from the filesystem
+  ``auto_create_topics_enable`` => *boolean*
+    **auto.create.topics.enable** Enable auto creation of topics
 
-  ``auto_create_topics_enable``  *boolean*
-    - **auto.create.topics.enable** Enable auto creation of topics
+  ``min_insync_replicas`` => *integer*
+    **min.insync.replicas** When a producer sets acks to 'all' (or '-1'), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful.
 
-  ``min_insync_replicas``  *integer*
-    - **min.insync.replicas** When a producer sets acks to 'all' (or '-1'), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful.
+  ``num_partitions`` => *integer*
+    **num.partitions** Number of partitions for autocreated topics
 
-  ``num_partitions``  *integer*
-    - **num.partitions** Number of partitions for autocreated topics
+  ``default_replication_factor`` => *integer*
+    **default.replication.factor** Replication factor for autocreated topics
 
-  ``default_replication_factor``  *integer*
-    - **default.replication.factor** Replication factor for autocreated topics
+  ``replica_fetch_max_bytes`` => *integer*
+    **replica.fetch.max.bytes** The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.
 
-  ``replica_fetch_max_bytes``  *integer*
-    - **replica.fetch.max.bytes** The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.
+  ``replica_fetch_response_max_bytes`` => *integer*
+    **replica.fetch.response.max.bytes** Maximum bytes expected for the entire fetch response (defaults to 10485760). Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum.
 
-  ``replica_fetch_response_max_bytes``  *integer*
-    - **replica.fetch.response.max.bytes** Maximum bytes expected for the entire fetch response (defaults to 10485760). Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum.
+  ``max_connections_per_ip`` => *integer*
+    **max.connections.per.ip** The maximum number of connections allowed from each ip address (defaults to 2147483647).
 
-  ``max_connections_per_ip``  *integer*
-    - **max.connections.per.ip** The maximum number of connections allowed from each ip address (defaults to 2147483647).
+  ``producer_purgatory_purge_interval_requests`` => *integer*
+    **producer.purgatory.purge.interval.requests** The purge interval (in number of requests) of the producer request purgatory(defaults to 1000).
 
-  ``producer_purgatory_purge_interval_requests``  *integer*
-    - **producer.purgatory.purge.interval.requests** The purge interval (in number of requests) of the producer request purgatory(defaults to 1000).
+  ``socket_request_max_bytes`` => *integer*
+    **socket.request.max.bytes** The maximum number of bytes in a socket request (defaults to 104857600).
 
-  ``socket_request_max_bytes``  *integer*
-    - **socket.request.max.bytes** The maximum number of bytes in a socket request (defaults to 104857600).
+  ``transaction_state_log_segment_bytes`` => *integer*
+    **transaction.state.log.segment.bytes** The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads (defaults to 104857600 (100 mebibytes)).
 
-  ``transaction_state_log_segment_bytes``  *integer*
-    - **transaction.state.log.segment.bytes** The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads (defaults to 104857600 (100 mebibytes)).
+  ``transaction_remove_expired_transaction_cleanup_interval_ms`` => *integer*
+    **transaction.remove.expired.transaction.cleanup.interval.ms** The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing (defaults to 3600000 (1 hour)).
 
-  ``transaction_remove_expired_transaction_cleanup_interval_ms``  *integer*
-    - **transaction.remove.expired.transaction.cleanup.interval.ms** The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing (defaults to 3600000 (1 hour)).
 
 
+``kafka_authentication_methods`` => *object*
+  **Kafka authentication methods**
 
-``kafka_authentication_methods``  *object*
-  - **Kafka authentication methods** 
+  ``certificate`` => *boolean*
+    **Enable certificate/SSL authentication** None
 
-  ``certificate``  *boolean*
-    - **Enable certificate/SSL authentication** None
+  ``sasl`` => *boolean*
+    **Enable SASL authentication** None
 
-  ``sasl``  *boolean*
-    - **Enable SASL authentication** None
 
 
+``kafka_connect`` => *boolean*
+  **Enable Kafka Connect service**
 
-``kafka_connect``  *boolean*
-  - **Enable Kafka Connect service** 
 
 
+``kafka_connect_config`` => *object*
+  **Kafka Connect configuration values**
 
-``kafka_connect_config``  *object*
-  - **Kafka Connect configuration values** 
+  ``connector_client_config_override_policy`` => *string*
+    **Client config override policy** Defines what client configurations can be overridden by the connector. Default is None
 
-  ``connector_client_config_override_policy``  *string*
-    - **Client config override policy** Defines what client configurations can be overridden by the connector. Default is None
+  ``consumer_auto_offset_reset`` => *string*
+    **Consumer auto offset reset** What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Default is earliest
 
-  ``consumer_auto_offset_reset``  *string*
-    - **Consumer auto offset reset** What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Default is earliest
+  ``consumer_fetch_max_bytes`` => *integer*
+    **The maximum amount of data the server should return for a fetch request** Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum.
 
-  ``consumer_fetch_max_bytes``  *integer*
-    - **The maximum amount of data the server should return for a fetch request** Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum.
+  ``consumer_isolation_level`` => *string*
+    **Consumer isolation level** Transaction read isolation level. read_uncommitted is the default, but read_committed can be used if consume-exactly-once behavior is desired.
 
-  ``consumer_isolation_level``  *string*
-    - **Consumer isolation level** Transaction read isolation level. read_uncommitted is the default, but read_committed can be used if consume-exactly-once behavior is desired.
+  ``consumer_max_partition_fetch_bytes`` => *integer*
+    **The maximum amount of data per-partition the server will return.** Records are fetched in batches by the consumer.If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress.
 
-  ``consumer_max_partition_fetch_bytes``  *integer*
-    - **The maximum amount of data per-partition the server will return.** Records are fetched in batches by the consumer.If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. 
+  ``consumer_max_poll_interval_ms`` => *integer*
+    **The maximum delay between polls when using consumer group management** The maximum delay in milliseconds between invocations of poll() when using consumer group management (defaults to 300000).
 
-  ``consumer_max_poll_interval_ms``  *integer*
-    - **The maximum delay between polls when using consumer group management** The maximum delay in milliseconds between invocations of poll() when using consumer group management (defaults to 300000).
+  ``consumer_max_poll_records`` => *integer*
+    **The maximum number of records returned by a single poll** The maximum number of records returned in a single call to poll() (defaults to 500).
 
-  ``consumer_max_poll_records``  *integer*
-    - **The maximum number of records returned by a single poll** The maximum number of records returned in a single call to poll() (defaults to 500).
+  ``offset_flush_interval_ms`` => *integer*
+    **The interval at which to try committing offsets for tasks** The interval at which to try committing offsets for tasks (defaults to 60000).
 
-  ``offset_flush_interval_ms``  *integer*
-    - **The interval at which to try committing offsets for tasks** The interval at which to try committing offsets for tasks (defaults to 60000).
+  ``offset_flush_timeout_ms`` => *integer*
+    **Offset flush timeout** Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt (defaults to 5000).
 
-  ``offset_flush_timeout_ms``  *integer*
-    - **Offset flush timeout** Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt (defaults to 5000).
+  ``producer_max_request_size`` => *integer*
+    **The maximum size of a request in bytes** This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests.
 
-  ``producer_max_request_size``  *integer*
-    - **The maximum size of a request in bytes** This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests.
+  ``session_timeout_ms`` => *integer*
+    **The timeout used to detect failures when using Kafka’s group management facilities** The timeout in milliseconds used to detect failures when using Kafka’s group management facilities (defaults to 10000).
 
-  ``session_timeout_ms``  *integer*
-    - **The timeout used to detect failures when using Kafka’s group management facilities** The timeout in milliseconds used to detect failures when using Kafka’s group management facilities (defaults to 10000).
 
 
+``kafka_rest`` => *boolean*
+  **Enable Kafka-REST service**
 
-``kafka_rest``  *boolean*
-  - **Enable Kafka-REST service** 
 
 
+``kafka_version`` => *['string', 'null']*
+  **Kafka major version**
 
-``kafka_version``  *['string', 'null']*
-  - **Kafka major version** 
 
 
+``schema_registry`` => *boolean*
+  **Enable Schema-Registry service**
 
-``schema_registry``  *boolean*
-  - **Enable Schema-Registry service** 
 
 
+``kafka_rest_config`` => *object*
+  **Kafka REST configuration**
 
-``kafka_rest_config``  *object*
-  - **Kafka REST configuration** 
+  ``producer_acks`` => *string*
+    **producer.acks** The number of acknowledgments the producer requires the leader to have received before considering a request complete. If set to 'all' or '-1', the leader will wait for the full set of in-sync replicas to acknowledge the record.
 
-  ``producer_acks``  *string*
-    - **producer.acks** The number of acknowledgments the producer requires the leader to have received before considering a request complete. If set to 'all' or '-1', the leader will wait for the full set of in-sync replicas to acknowledge the record.
+  ``producer_linger_ms`` => *integer*
+    **producer.linger.ms** Wait for up to the given delay to allow batching records together
 
-  ``producer_linger_ms``  *integer*
-    - **producer.linger.ms** Wait for up to the given delay to allow batching records together
+  ``consumer_enable_auto_commit`` => *boolean*
+    **consumer.enable.auto.commit** If true the consumer's offset will be periodically committed to Kafka in the background
 
-  ``consumer_enable_auto_commit``  *boolean*
-    - **consumer.enable.auto.commit** If true the consumer's offset will be periodically committed to Kafka in the background
+  ``consumer_request_max_bytes`` => *integer*
+    **consumer.request.max.bytes** Maximum number of bytes in unencoded message keys and values by a single request
 
-  ``consumer_request_max_bytes``  *integer*
-    - **consumer.request.max.bytes** Maximum number of bytes in unencoded message keys and values by a single request
+  ``consumer_request_timeout_ms`` => *integer*
+    **consumer.request.timeout.ms** The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached
 
-  ``consumer_request_timeout_ms``  *integer*
-    - **consumer.request.timeout.ms** The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached
+  ``simpleconsumer_pool_size_max`` => *integer*
+    **simpleconsumer.pool.size.max** Maximum number of SimpleConsumers that can be instantiated per broker
 
-  ``simpleconsumer_pool_size_max``  *integer*
-    - **simpleconsumer.pool.size.max** Maximum number of SimpleConsumers that can be instantiated per broker
 
 
+``schema_registry_config`` => *object*
+  **Schema Registry configuration**
 
-``schema_registry_config``  *object*
-  - **Schema Registry configuration** 
+  ``topic_name`` => *string*
+    **topic_name** The durable single partition topic that acts as the durable log for the data. This topic must be compacted to avoid losing data due to retention policy. Please note that changing this configuration in an existing Schema Registry / Karapace setup leads to previous schemas being inaccessible, data encoded with them potentially unreadable and schema ID sequence put out of order. It's only possible to do the switch while Schema Registry / Karapace is disabled. Defaults to `_schemas`.
 
-  ``topic_name``  *string*
-    - **topic_name** The durable single partition topic that acts as the durable log for the data. This topic must be compacted to avoid losing data due to retention policy. Please note that changing this configuration in an existing Schema Registry / Karapace setup leads to previous schemas being inaccessible, data encoded with them potentially unreadable and schema ID sequence put out of order. It's only possible to do the switch while Schema Registry / Karapace is disabled. Defaults to `_schemas`.
-
-  ``leader_eligibility``  *boolean*
-    - **leader_eligibility** If true, Karapace / Schema Registry on the service nodes can participate in leader election. It might be needed to disable this when the schemas topic is replicated to a secondary cluster and Karapace / Schema Registry there must not participate in leader election. Defaults to `true`.
-
-
-
-
+  ``leader_eligibility`` => *boolean*
+    **leader_eligibility** If true, Karapace / Schema Registry on the service nodes can participate in leader election. It might be needed to disable this when the schemas topic is replicated to a secondary cluster and Karapace / Schema Registry there must not participate in leader election. Defaults to `true`.

--- a/includes/config-kafka.rst
+++ b/includes/config-kafka.rst
@@ -1,53 +1,287 @@
 
-.. list-table::
-  :header-rows: 1
+``custom_domain``  *['string', 'null']*
+  - **Custom domain** Serve the web frontend using a custom CNAME pointing to the Aiven DNS name
 
-  * - Parameter
-    - Value Type
-    - Description
-  * - ``custom_domain``
-    - ['string', 'null']
-    - Custom domain Serve the web frontend using a custom CNAME pointing to the Aiven DNS name
-  * - ``ip_filter``
-    - array
-    - IP filter Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
-  * - ``static_ips``
-    - boolean
-    - Static IP addresses Use static public IP addresses
-  * - ``private_access``
-    - object
-    - Allow access to selected service ports from private networks 
-  * - ``public_access``
-    - object
-    - Allow access to selected service ports from the public Internet 
-  * - ``privatelink_access``
-    - object
-    - Allow access to selected service components through Privatelink 
-  * - ``kafka``
-    - object
-    - Kafka broker configuration values 
-  * - ``kafka_authentication_methods``
-    - object
-    - Kafka authentication methods 
-  * - ``kafka_connect``
-    - boolean
-    - Enable Kafka Connect service 
-  * - ``kafka_connect_config``
-    - object
-    - Kafka Connect configuration values 
-  * - ``kafka_rest``
-    - boolean
-    - Enable Kafka-REST service 
-  * - ``kafka_version``
-    - ['string', 'null']
-    - Kafka major version 
-  * - ``schema_registry``
-    - boolean
-    - Enable Schema-Registry service 
-  * - ``kafka_rest_config``
-    - object
-    - Kafka REST configuration 
-  * - ``schema_registry_config``
-    - object
-    - Schema Registry configuration 
+
+
+``ip_filter``  *array*
+  - **IP filter** Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+
+
+
+``static_ips``  *boolean*
+  - **Static IP addresses** Use static public IP addresses
+
+
+
+``private_access``  *object*
+  - **Allow access to selected service ports from private networks** 
+
+  ``prometheus``  *boolean*
+    - **Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations** None
+
+
+
+``public_access``  *object*
+  - **Allow access to selected service ports from the public Internet** 
+
+  ``kafka``  *boolean*
+    - **Allow clients to connect to kafka from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+  ``kafka_connect``  *boolean*
+    - **Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+  ``kafka_rest``  *boolean*
+    - **Allow clients to connect to kafka_rest from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+  ``prometheus``  *boolean*
+    - **Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+  ``schema_registry``  *boolean*
+    - **Allow clients to connect to schema_registry from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+
+
+``privatelink_access``  *object*
+  - **Allow access to selected service components through Privatelink** 
+
+  ``kafka``  *boolean*
+    - **Enable kafka** None
+
+  ``kafka_connect``  *boolean*
+    - **Enable kafka_connect** None
+
+  ``kafka_rest``  *boolean*
+    - **Enable kafka_rest** None
+
+  ``schema_registry``  *boolean*
+    - **Enable schema_registry** None
+
+
+
+``kafka``  *object*
+  - **Kafka broker configuration values** 
+
+  ``compression_type``  *string*
+    - **compression.type** Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
+
+  ``group_initial_rebalance_delay_ms``  *integer*
+    - **group.initial.rebalance.delay.ms** The amount of time, in milliseconds, the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins. The default value for this is 3 seconds. During development and testing it might be desirable to set this to 0 in order to not delay test execution time.
+
+  ``group_min_session_timeout_ms``  *integer*
+    - **group.min.session.timeout.ms** The minimum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+
+  ``group_max_session_timeout_ms``  *integer*
+    - **group.max.session.timeout.ms** The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.
+
+  ``connections_max_idle_ms``  *integer*
+    - **connections.max.idle.ms** Idle connections timeout: the server socket processor threads close the connections that idle for longer than this.
+
+  ``max_incremental_fetch_session_cache_slots``  *integer*
+    - **max.incremental.fetch.session.cache.slots** The maximum number of incremental fetch sessions that the broker will maintain.
+
+  ``message_max_bytes``  *integer*
+    - **message.max.bytes** The maximum size of message that the server can receive.
+
+  ``offsets_retention_minutes``  *integer*
+    - **offsets.retention.minutes** Log retention window in minutes for offsets topic
+
+  ``log_cleaner_delete_retention_ms``  *integer*
+    - **log.cleaner.delete.retention.ms** How long are delete records retained?
+
+  ``log_cleaner_min_cleanable_ratio``  *number*
+    - **log.cleaner.min.cleanable.ratio** Controls log compactor frequency. Larger value means more frequent compactions but also more space wasted for logs. Consider setting log.cleaner.max.compaction.lag.ms to enforce compactions sooner, instead of setting a very high value for this option.
+
+  ``log_cleaner_max_compaction_lag_ms``  *integer*
+    - **log.cleaner.max.compaction.lag.ms** The maximum amount of time message will remain uncompacted. Only applicable for logs that are being compacted
+
+  ``log_cleaner_min_compaction_lag_ms``  *integer*
+    - **log.cleaner.min.compaction.lag.ms** The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.
+
+  ``log_cleanup_policy``  *string*
+    - **log.cleanup.policy** The default cleanup policy for segments beyond the retention window
+
+  ``log_flush_interval_messages``  *integer*
+    - **log.flush.interval.messages** The number of messages accumulated on a log partition before messages are flushed to disk
+
+  ``log_flush_interval_ms``  *integer*
+    - **log.flush.interval.ms** The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used
+
+  ``log_index_interval_bytes``  *integer*
+    - **log.index.interval.bytes** The interval with which Kafka adds an entry to the offset index
+
+  ``log_index_size_max_bytes``  *integer*
+    - **log.index.size.max.bytes** The maximum size in bytes of the offset index
+
+  ``log_message_downconversion_enable``  *boolean*
+    - **log.message.downconversion.enable** This configuration controls whether down-conversion of message formats is enabled to satisfy consume requests. 
+
+  ``log_message_timestamp_type``  *string*
+    - **log.message.timestamp.type** Define whether the timestamp in the message is message create time or log append time.
+
+  ``log_message_timestamp_difference_max_ms``  *integer*
+    - **log.message.timestamp.difference.max.ms** The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message
+
+  ``log_preallocate``  *boolean*
+    - **log.preallocate** Should pre allocate file when create new segment?
+
+  ``log_retention_bytes``  *integer*
+    - **log.retention.bytes** The maximum size of the log before deleting messages
+
+  ``log_retention_hours``  *integer*
+    - **log.retention.hours** The number of hours to keep a log file before deleting it
+
+  ``log_retention_ms``  *integer*
+    - **log.retention.ms** The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used. If set to -1, no time limit is applied.
+
+  ``log_roll_jitter_ms``  *integer*
+    - **log.roll.jitter.ms** The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used
+
+  ``log_roll_ms``  *integer*
+    - **log.roll.ms** The maximum time before a new log segment is rolled out (in milliseconds).
+
+  ``log_segment_bytes``  *integer*
+    - **log.segment.bytes** The maximum size of a single log file
+
+  ``log_segment_delete_delay_ms``  *integer*
+    - **log.segment.delete.delay.ms** The amount of time to wait before deleting a file from the filesystem
+
+  ``auto_create_topics_enable``  *boolean*
+    - **auto.create.topics.enable** Enable auto creation of topics
+
+  ``min_insync_replicas``  *integer*
+    - **min.insync.replicas** When a producer sets acks to 'all' (or '-1'), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful.
+
+  ``num_partitions``  *integer*
+    - **num.partitions** Number of partitions for autocreated topics
+
+  ``default_replication_factor``  *integer*
+    - **default.replication.factor** Replication factor for autocreated topics
+
+  ``replica_fetch_max_bytes``  *integer*
+    - **replica.fetch.max.bytes** The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.
+
+  ``replica_fetch_response_max_bytes``  *integer*
+    - **replica.fetch.response.max.bytes** Maximum bytes expected for the entire fetch response (defaults to 10485760). Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum.
+
+  ``max_connections_per_ip``  *integer*
+    - **max.connections.per.ip** The maximum number of connections allowed from each ip address (defaults to 2147483647).
+
+  ``producer_purgatory_purge_interval_requests``  *integer*
+    - **producer.purgatory.purge.interval.requests** The purge interval (in number of requests) of the producer request purgatory(defaults to 1000).
+
+  ``socket_request_max_bytes``  *integer*
+    - **socket.request.max.bytes** The maximum number of bytes in a socket request (defaults to 104857600).
+
+  ``transaction_state_log_segment_bytes``  *integer*
+    - **transaction.state.log.segment.bytes** The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads (defaults to 104857600 (100 mebibytes)).
+
+  ``transaction_remove_expired_transaction_cleanup_interval_ms``  *integer*
+    - **transaction.remove.expired.transaction.cleanup.interval.ms** The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing (defaults to 3600000 (1 hour)).
+
+
+
+``kafka_authentication_methods``  *object*
+  - **Kafka authentication methods** 
+
+  ``certificate``  *boolean*
+    - **Enable certificate/SSL authentication** None
+
+  ``sasl``  *boolean*
+    - **Enable SASL authentication** None
+
+
+
+``kafka_connect``  *boolean*
+  - **Enable Kafka Connect service** 
+
+
+
+``kafka_connect_config``  *object*
+  - **Kafka Connect configuration values** 
+
+  ``connector_client_config_override_policy``  *string*
+    - **Client config override policy** Defines what client configurations can be overridden by the connector. Default is None
+
+  ``consumer_auto_offset_reset``  *string*
+    - **Consumer auto offset reset** What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Default is earliest
+
+  ``consumer_fetch_max_bytes``  *integer*
+    - **The maximum amount of data the server should return for a fetch request** Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum.
+
+  ``consumer_isolation_level``  *string*
+    - **Consumer isolation level** Transaction read isolation level. read_uncommitted is the default, but read_committed can be used if consume-exactly-once behavior is desired.
+
+  ``consumer_max_partition_fetch_bytes``  *integer*
+    - **The maximum amount of data per-partition the server will return.** Records are fetched in batches by the consumer.If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. 
+
+  ``consumer_max_poll_interval_ms``  *integer*
+    - **The maximum delay between polls when using consumer group management** The maximum delay in milliseconds between invocations of poll() when using consumer group management (defaults to 300000).
+
+  ``consumer_max_poll_records``  *integer*
+    - **The maximum number of records returned by a single poll** The maximum number of records returned in a single call to poll() (defaults to 500).
+
+  ``offset_flush_interval_ms``  *integer*
+    - **The interval at which to try committing offsets for tasks** The interval at which to try committing offsets for tasks (defaults to 60000).
+
+  ``offset_flush_timeout_ms``  *integer*
+    - **Offset flush timeout** Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt (defaults to 5000).
+
+  ``producer_max_request_size``  *integer*
+    - **The maximum size of a request in bytes** This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests.
+
+  ``session_timeout_ms``  *integer*
+    - **The timeout used to detect failures when using Kafka’s group management facilities** The timeout in milliseconds used to detect failures when using Kafka’s group management facilities (defaults to 10000).
+
+
+
+``kafka_rest``  *boolean*
+  - **Enable Kafka-REST service** 
+
+
+
+``kafka_version``  *['string', 'null']*
+  - **Kafka major version** 
+
+
+
+``schema_registry``  *boolean*
+  - **Enable Schema-Registry service** 
+
+
+
+``kafka_rest_config``  *object*
+  - **Kafka REST configuration** 
+
+  ``producer_acks``  *string*
+    - **producer.acks** The number of acknowledgments the producer requires the leader to have received before considering a request complete. If set to 'all' or '-1', the leader will wait for the full set of in-sync replicas to acknowledge the record.
+
+  ``producer_linger_ms``  *integer*
+    - **producer.linger.ms** Wait for up to the given delay to allow batching records together
+
+  ``consumer_enable_auto_commit``  *boolean*
+    - **consumer.enable.auto.commit** If true the consumer's offset will be periodically committed to Kafka in the background
+
+  ``consumer_request_max_bytes``  *integer*
+    - **consumer.request.max.bytes** Maximum number of bytes in unencoded message keys and values by a single request
+
+  ``consumer_request_timeout_ms``  *integer*
+    - **consumer.request.timeout.ms** The maximum total time to wait for messages for a request if the maximum number of messages has not yet been reached
+
+  ``simpleconsumer_pool_size_max``  *integer*
+    - **simpleconsumer.pool.size.max** Maximum number of SimpleConsumers that can be instantiated per broker
+
+
+
+``schema_registry_config``  *object*
+  - **Schema Registry configuration** 
+
+  ``topic_name``  *string*
+    - **topic_name** The durable single partition topic that acts as the durable log for the data. This topic must be compacted to avoid losing data due to retention policy. Please note that changing this configuration in an existing Schema Registry / Karapace setup leads to previous schemas being inaccessible, data encoded with them potentially unreadable and schema ID sequence put out of order. It's only possible to do the switch while Schema Registry / Karapace is disabled. Defaults to `_schemas`.
+
+  ``leader_eligibility``  *boolean*
+    - **leader_eligibility** If true, Karapace / Schema Registry on the service nodes can participate in leader election. It might be needed to disable this when the schemas topic is replicated to a secondary cluster and Karapace / Schema Registry there must not participate in leader election. Defaults to `true`.
+
+
+
 

--- a/scripts/aiven/service_type_config.py
+++ b/scripts/aiven/service_type_config.py
@@ -2,29 +2,43 @@ import requests
 import argparse
 
 
-def print_row(param, value_type, desc):
-    print(f"  * - {param}")
-    print(f"    - {value_type}")
-    print(f"    - {desc}")
+def print_row(param, value_type, title, desc, indent=0):
+    preamble = ''
+    for i in range(indent):
+        preamble = preamble + '  '
+
+    print(f"{preamble}{param}  *{value_type}*")
+    print(f"{preamble}  - **{title}** {desc}")
+    print("")
 
 
 def print_service_type_docs(service_type, data):
     schema = data['service_types'][service_type]['user_config_schema']
 
     print("")
-    # Table header
-    print(".. list-table::")
-    print("  :header-rows: 1")
-    print("")
-    print_row("Parameter", "Value Type", "Description")
 
     # Rows
     for key, value in schema['properties'].items():
         print_row(
             f"``{key}``",
             value.get('type', ''),
-            value.get('title') + " " + value.get("description", '')
+            value.get('title'),
+            value.get("description", '')
             )
+
+        # handle any nested properties
+        if value.get('type', '') == "object":
+            for nested_key, nested_value in value.get('properties').items():
+                print_row(
+                    f"``{nested_key}``",
+                    nested_value.get('type', ''),
+                    nested_value.get('title'),
+                    nested_value.get('description'),
+                    1
+                    )
+
+        print("")
+        print("")
         pass
     # Empty row to end
     print("")

--- a/scripts/aiven/service_type_config.py
+++ b/scripts/aiven/service_type_config.py
@@ -1,0 +1,47 @@
+import requests
+import argparse
+
+
+def print_row(param, value_type, desc):
+    print(f"  * - {param}")
+    print(f"    - {value_type}")
+    print(f"    - {desc}")
+
+
+def print_service_type_docs(service_type, data):
+    schema = data['service_types'][service_type]['user_config_schema']
+
+    print("")
+    # Table header
+    print(".. list-table::")
+    print("  :header-rows: 1")
+    print("")
+    print_row("Parameter", "Value Type", "Description")
+
+    # Rows
+    for key, value in schema['properties'].items():
+        print_row(
+            f"``{key}``",
+            value.get('type', ''),
+            value.get('title') + " " + value.get("description", '')
+            )
+        pass
+    # Empty row to end
+    print("")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+                        description='Get config for service type.')
+    parser.add_argument('service_type', metavar='service_type',
+                        help='which service type to get config for')
+    args = parser.parse_args()
+    response = requests.get("https://api.aiven.io/v1/service_types")
+    data = response.json()
+    for service_type in data['service_types']:
+        if(service_type == args.service_type):
+            print_service_type_docs(service_type, data)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/aiven/service_type_config.py
+++ b/scripts/aiven/service_type_config.py
@@ -7,8 +7,8 @@ def print_row(param, value_type, title, desc, indent=0):
     for i in range(indent):
         preamble = preamble + '  '
 
-    print(f"{preamble}{param}  *{value_type}*")
-    print(f"{preamble}  - **{title}** {desc}")
+    print(f"{preamble}{param} => *{value_type}*")
+    print(f"{preamble}  **{title}** {desc}")
     print("")
 
 


### PR DESCRIPTION
Based heavily on https://github.com/aprepo/aiven-doc-generator (thanks @aprepo)
Generates include files that can be referred to from the main content,
and regenerated as needed.


