### PR TITLE
Added JDBC source pg and JDBC connector modes

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -77,11 +77,13 @@ entries:
         - file: docs/products/kafka/kafka-connect/concepts
           entries:
           - file: docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins
+          - file: docs/products/kafka/kafka-connect/concepts/jdbc-source-modes
         - file: docs/products/kafka/kafka-connect/howto
           title: HowTo
           entries:
           - file: docs/products/kafka/kafka-connect/howto/enable-connect
           - file: docs/products/kafka/kafka-connect/howto/enable-automatic-restart
+          - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg
 
 
   - file: docs/products/postgresql/index

--- a/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
+++ b/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
@@ -1,0 +1,22 @@
+JDBC source connector modes
+===========================
+
+
+JDBC source connector extracts data from a relational database, such as PostgreSQL or MySQL, and pushes it to Apache Kafka where can be transformed and read by multiple consumers. 
+
+This connector type periodically queries the table(s) to extract the data, and can be configured in four main **modes**:
+
+* ``bulk``: the connector will query the full table every time retrieving all rows and publishing them into the Apache Kafka topic
+* ``incrementing``: the connector will query the table appending a `WHERE` condition based on a **incrementing column**. This requires the presence of a column containing an always growing number (like a series). The incrementing column is used to check which rows have been added since last query. 
+  
+  The column name will be passed via the ``incrementing.column.name`` parameter
+
+* ``timestamp``: the connector will query the table appending a ``WHERE`` condition based on a **timestamp column(s)**. This requires the presence of one or more columns containing the row's creation date and modification date. 
+
+  In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the polling query will apply the ``COALESCENCE`` function, parsing the value of the second column only when the first column is null. 
+  
+  The timestamp column(s) can be passed via the ``timestamp.column.name parameter``.
+
+* ``timestamp+incrementing``: this last mode uses both the incrementing and timestamp functionalities with ``incrementing.column.name`` selecting the incremental column and ``timestamp.column.name`` the timestamp one(s).
+
+Check out the `Aiven JDBC source connector documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md#query-modes>`_ for more information.

--- a/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
+++ b/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
@@ -19,7 +19,7 @@ Thus, if the source table contains ``100.000`` rows, the connector will insert `
 Incrementing mode
 -----------------
 
-Using the ``incrementing`` mode, the connector will query the table appending a `WHERE` condition based on a **incrementing column** to fetch the new rows. The incrementing mode requires the presence in the source table of a column containing an always growing number (like a series). The incrementing column is used to check which rows have been added since last query. 
+Using the ``incrementing`` mode, the connector will query the table and append a `WHERE` condition based on an **incrementing column** in order to fetch new rows. The incrementing mode requires that a column containing an always growing number (like a series) is present in the source table. The incrementing column is used to check which rows have been added since last query. 
 
 .. Note::
 
@@ -40,9 +40,9 @@ If for example the database ``students`` table contains the following entries:
   * - 3
     - ``Carol Tunder``
 
-The column ``student_id`` can be used as incremental column. On the first poll, the Kafka connector will select all rows from the table and record the maximum ``student_id`` value in the table, ``3`` in the above example. 
+The column ``student_id`` can be used as an incremental column. On the first poll, the Apache Kafka connector will select all rows from the table and record the maximum ``student_id`` value in the table (``3`` in the above example). 
 
-The following polls will append a ``WHERE`` condition to the query selecting only rows with ``student_id`` greater than the previously recorded maximum value. In the example below, the condition will be ``WHERE student_id > 3``. If new records are available in the table, then the highest value for the incremental column is stored, and used as filter for the following polls. 
+The following polls will append a ``WHERE`` condition to the query selecting only rows with ``student_id`` greater than the previously recorded maximum value. In the example below, the condition will be ``WHERE student_id > 3``. If the new records are available in the table, then the highest value for the incremental column is stored, and used as filter for the following polls. 
 
 .. list-table::
   :header-rows: 1
@@ -59,7 +59,7 @@ The following polls will append a ``WHERE`` condition to the query selecting onl
   * - **6**
     - ``Sam Cricket``
 
-In the case above, where a new row for ``Sam Cricket`` is added, a new record will be sent to the Apache Kafka topic, and the maximum ``student_id`` value will be updated to ``6`` and used as where condition in the following polls.
+In the case above, where a new row for ``Sam Cricket`` is added, a new record will be sent to the Apache Kafka topic, and the maximum ``student_id`` value will be updated to ``6`` and used in ``WHERE`` condition in the next polls.
 
 .. Warning::
 
@@ -68,7 +68,7 @@ In the case above, where a new row for ``Sam Cricket`` is added, a new record wi
 Timestamp mode
 --------------
 
-Using the ``timestamp`` mode, the connector will query the table appending a ``WHERE`` condition based one or more **timestamp columns**. This requires the presence of one or more columns containing the row's creation date and modification date. 
+Using the ``timestamp`` mode, the connector will query the table appending a ``WHERE`` condition based on one or more **timestamp columns**. This requires that creation date and modification date are present for every row. 
 
 In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the polling query will apply the ``COALESCENCE`` function, parsing the value of the second column only when the first column is null. 
 
@@ -76,7 +76,7 @@ In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the p
   
   The timestamp column(s) is passed via the ``timestamp.column.name parameter``.
 
-If for example the database ``students`` table contains the following entries:
+If, for example, the database ``students`` table contains the following entries:
 
 .. list-table::
   :header-rows: 1
@@ -99,7 +99,7 @@ If for example the database ``students`` table contains the following entries:
     - 2021-03-02
     - 2021-04-06
 
-The columns ``created_date`` and ``modified_date`` can be used as timestamp columns. On the first poll, the Kafka connector will select all rows from the table and record the value in the ``modified_date`` and ``created_date`` columns, ``2021-04-06`` in the above example. 
+The columns ``created_date`` and ``modified_date`` can be used as timestamp columns. On the first poll, the Kafka connector will select all rows from the table and record the value in the ``modified_date`` and ``created_date`` columns (``2021-04-06`` in the above example). 
 
 The following polls will append a ``WHERE`` condition to the query selecting only rows with ``modified_date`` or ``created_date`` greater than the previously recorded maximum value using the ``COALESCENCE`` function. In the example below, the condition will be:
 

--- a/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
+++ b/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
@@ -68,7 +68,7 @@ In the case above, where a new row for ``Sam Cricket`` is added, a new record wi
 Timestamp mode
 --------------
 
-Using the ``timestamp`` mode, the connector will query the table appending a ``WHERE`` condition based on one or more **timestamp columns**. This requires that creation date and modification date are present for every row. 
+Using the ``timestamp`` mode, the connector will query the table appending a ``WHERE`` condition based on one or more **timestamp columns**. This requires that timestamps columns (like creation date and modification date) are present for every row. 
 
 In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the polling query will apply the ``COALESCENCE`` function, parsing the value of the second column only when the first column is null. 
 

--- a/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
+++ b/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
@@ -19,4 +19,4 @@ This connector type periodically queries the table(s) to extract the data, and c
 
 * ``timestamp+incrementing``: this last mode uses both the incrementing and timestamp functionalities with ``incrementing.column.name`` selecting the incremental column and ``timestamp.column.name`` the timestamp one(s).
 
-Check out the `Aiven JDBC source connector documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md#query-modes>`_ for more information.
+Check out the `Aiven JDBC source connector documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md>`_ for more information.

--- a/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
+++ b/docs/products/kafka/kafka-connect/concepts/jdbc-source-modes.rst
@@ -2,21 +2,124 @@ JDBC source connector modes
 ===========================
 
 
-JDBC source connector extracts data from a relational database, such as PostgreSQL or MySQL, and pushes it to Apache Kafka where can be transformed and read by multiple consumers. 
+JDBC source connector extracts data from a relational database, such as PostgreSQL or MySQL, and pushes it to Apache Kafka where can be transformed and read by multiple consumers. The details of the connector are covered in the `Aiven JDBC source connector GitHub documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md>`_. 
 
-This connector type periodically queries the table(s) to extract the data, and can be configured in four main **modes**:
+This connector type periodically queries the table(s) to extract the data, and can be configured in four **modes**.
 
-* ``bulk``: the connector will query the full table every time retrieving all rows and publishing them into the Apache Kafka topic
-* ``incrementing``: the connector will query the table appending a `WHERE` condition based on a **incrementing column**. This requires the presence of a column containing an always growing number (like a series). The incrementing column is used to check which rows have been added since last query. 
+Bulk mode
+---------
+
+In ``bulk`` mode the connector will periodically query the full table retrieving all the rows and publishing them into the Apache Kafka topic.
+Thus, if the source table contains ``100.000`` rows, the connector will insert ``100.000`` new messages in the Apache Kafka topic for every poll, no matter how many rows in the database are new or stale.
+
+.. Tip::
+
+  Since the bulk mode replicates the whole table content into the Apache Kafka topic at every poll, it's a suitable option only for tables with limited amount of data which don't have any incremental or timestamp column.
+
+Incrementing mode
+-----------------
+
+Using the ``incrementing`` mode, the connector will query the table appending a `WHERE` condition based on a **incrementing column** to fetch the new rows. The incrementing mode requires the presence in the source table of a column containing an always growing number (like a series). The incrementing column is used to check which rows have been added since last query. 
+
+.. Note::
+
+  The column name is passed via the ``incrementing.column.name`` parameter
+
+If for example the database ``students`` table contains the following entries:
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - ``student_id``
+    - ``student_name``
+  * - 1
+    - ``Jon Doe``
+  * - 2
+    - ``Mary English``
+  * - 3
+    - ``Carol Tunder``
+
+The column ``student_id`` can be used as incremental column. On the first poll, the Kafka connector will select all rows from the table and record the maximum ``student_id`` value in the table, ``3`` in the above example. 
+
+The following polls will append a ``WHERE`` condition to the query selecting only rows with ``student_id`` greater than the previously recorded maximum value. In the example below, the condition will be ``WHERE student_id > 3``. If new records are available in the table, then the highest value for the incremental column is stored, and used as filter for the following polls. 
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - ``student_id``
+    - ``student_name``
+  * - 1
+    - ``Jon Doe``
+  * - 2
+    - ``Mary English``
+  * - 3
+    - ``Carol Tunder``
+  * - **6**
+    - ``Sam Cricket``
+
+In the case above, where a new row for ``Sam Cricket`` is added, a new record will be sent to the Apache Kafka topic, and the maximum ``student_id`` value will be updated to ``6`` and used as where condition in the following polls.
+
+.. Warning::
+
+  With the incremental mode, any change which doesn't generate rows with an id higher than the maximum recorded in the previous poll will **not** be detected. E.g. updating the ``student_name`` without changing the ``student_id`` will not generate any new records in Apache Kafka. 
+
+Timestamp mode
+--------------
+
+Using the ``timestamp`` mode, the connector will query the table appending a ``WHERE`` condition based one or more **timestamp columns**. This requires the presence of one or more columns containing the row's creation date and modification date. 
+
+In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the polling query will apply the ``COALESCENCE`` function, parsing the value of the second column only when the first column is null. 
+
+.. Tip::
   
-  The column name will be passed via the ``incrementing.column.name`` parameter
+  The timestamp column(s) is passed via the ``timestamp.column.name parameter``.
 
-* ``timestamp``: the connector will query the table appending a ``WHERE`` condition based on a **timestamp column(s)**. This requires the presence of one or more columns containing the row's creation date and modification date. 
+If for example the database ``students`` table contains the following entries:
 
-  In cases of two columns (e.g. ``creation_date`` and ``modification_date``) the polling query will apply the ``COALESCENCE`` function, parsing the value of the second column only when the first column is null. 
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - ``student_id``
+    - ``student_name``
+    - ``created_date``
+    - ``modified_date``
+  * - 1
+    - ``Jon Doe``
+    - 2021-01-01
+    -
+  * - 2
+    - ``Mary English``
+    - 2021-03-01
+    - 2021-04-05
+  * - 3
+    - ``Carol Tunder``
+    - 2021-03-02
+    - 2021-04-06
+
+The columns ``created_date`` and ``modified_date`` can be used as timestamp columns. On the first poll, the Kafka connector will select all rows from the table and record the value in the ``modified_date`` and ``created_date`` columns, ``2021-04-06`` in the above example. 
+
+The following polls will append a ``WHERE`` condition to the query selecting only rows with ``modified_date`` or ``created_date`` greater than the previously recorded maximum value using the ``COALESCENCE`` function. In the example below, the condition will be:
+
+::
+ 
+  WHERE COALESCENCE(modified_date, created_date) > '2021-04-06'
   
-  The timestamp column(s) can be passed via the ``timestamp.column.name parameter``.
+If new records with more recent ``modified_date`` or ``created_date`` are available in the table, then the highest value for the timestamp columns is stored, and used as filter for the following polls. 
 
-* ``timestamp+incrementing``: this last mode uses both the incrementing and timestamp functionalities with ``incrementing.column.name`` selecting the incremental column and ``timestamp.column.name`` the timestamp one(s).
+.. Warning::
 
-Check out the `Aiven JDBC source connector documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md>`_ for more information.
+  With the timestamp mode, any change which doesn't generate a more recent timestamp than the maximum recorded in the previous poll will **not** be detected. E.g. updating the ``Jon Doe``'s ``modified_date`` to ``2021-04-03`` will not be captured since a more recent date (``2021-04-06``) was already recorded in the previous poll. 
+
+Timestamp and incrementing mode
+-------------------------------
+
+Using the ``timestamp+incrementing`` mode, Kafka connect implements both the incrementing and timestamp functionalities described above. 
+
+.. Tip:: 
+  
+  The incremental column name is passed via the ``incrementing.column.name`` and the timestamp column(s) is passed via the ``timestamp.column.name parameter``. 
+
+Check out the `Aiven JDBC source connector GitHub documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md>`_ for more information.

--- a/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg.rst
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg.rst
@@ -1,0 +1,113 @@
+JDBC source connector with PostgreSQL
+=====================================
+
+The JDBC source connector pushes data from a relational database, such as PostgreSQL, to Apache Kafka where can be transformed and read by multiple consumers. 
+
+.. Tip::
+
+    Sourcing data from a database into Apache Kafka decouples the database from the set of consumers, enabling multiple applications to access the data without adding a per-consumer query overhead to the source database.
+
+.. _connect_jdbc_pg_source_prereq:
+
+Prerequisites
+-------------
+
+To setup a JDBC source connector pointing to PostgreSQL, you need an Aiven for Apache Kafka service :doc:`with Kafka Connect enabled <enable-connect>` or a :ref:`dedicated Aiven for Apache Kafka Connect cluster <apache_kafka_connect_dedicated_cluster>`. 
+Furthermore you need to collect the following information about the source PostgreSQL database upfront:
+
+* ``PG_HOST``: The database hostname
+* ``PG_PORT``: The database port
+* ``PG_USER``: The database user to connect
+* ``PG_PASSWORD``: The database password for the ``PG_USER``
+* ``PG_DATABASE_NAME``: the database name
+* ``SSL_MODE``: the `SSL mode <https://www.postgresql.org/docs/current/libpq-ssl.html>`_
+* ``PG_TABLES``: the list of database tables to be included in Apache Kafka; the list must be in the form of ``schema_name1.table_name1,schema_name2.table_name2``
+
+.. Note::
+
+    If you're using Aiven for PostgreSQL the above details are available in the `Aiven console <https://console.aiven.io/>`_ service Overview tab or via the dedicated ``avn service get`` command with the :ref:`Aiven CLI <avn_service_get>`.
+
+Setup a PostgreSQL JDBC source connector with Aiven CLI
+-------------------------------------------------------
+
+The following example demonstrates how to setup an Apache Kafka JDBC source connector to a PostgreSQL database using the :ref:`Aiven CLI dedicated command <avn_service_connector_create>`:
+
+1. In a file named ``jdbc_source_pg.json`` define the connector configuration with the following content:
+
+::
+
+    {
+        "name":"CONNECTOR_NAME",
+        "connector.class":"io.aiven.connect.jdbc.JdbcSourceConnector",
+        "connection.url":"jdbc:postgresql://PG_HOST:PG_PORT/PG_DATABASE_NAME?sslmode=SSL_MODE",
+        "connection.user":"PG_USER",
+        "connection.password":"PG_PASSWORD",
+        "table.whitelist":"PG_TABLES",
+        "mode":"JDBC_MODE",
+        "topic.prefix":"KAFKA_TOPIC_PREFIX",
+        "tasks.max":"NR_TASKS",
+        "poll.interval.ms":"POLL_INTERVAL"
+    }
+
+.. Note::
+
+    The ``PG_HOST``, ``PG_PORT``, ``PG_DATABASE_NAME``, ``SSL_MODE``, ``PG_USER``, ``PG_PASSWORD`` and ``PG_TABLES`` are the parameters collected in the :ref:`prerequisite <connect_jdbc_pg_source_prereq>` phase. 
+    The following additional parameters need to be set:
+
+    * ``name``: the connector name
+    * ``mode``: the query mode, more information in the :doc:`dedicated page <../concepts/jdbc-source-modes>`; depending on the selected mode, additional configuration entries might be required.
+    * ``topic.prefix``: the prefix that will be used for topic names; the resulting topic name is the concatenation of the ``topic.prefix`` and the table name.
+    * ``tasks.max``: maximum number of tasks to execute in parallel
+    * ``poll.interval.ms``: query frequency
+
+    Check out the `dedicated documentation <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector-config-options.rst>`_ for the full list of parameters.
+
+2. Execute the following :ref:`Aiven CLI command <avn_service_connector_create>` to create the connector, replacing the ``SERVICE_NAME`` with the name of the Aiven service where the connector needs to run:
+
+:: 
+
+    avn service connector create SERVICE_NAME @jdbc_source_pg.json
+
+3. Check the connector status with the following command, replacing the ``SERVICE_NAME`` with the Aiven service and the ``CONNECTOR_NAME`` with the name of the connector defined before:
+
+::
+
+    avn service connector status SERVICE_NAME CONNECTOR_NAME
+
+4. Verify in the Aiven for Apache Kafka target instance, the presence of the topic and the data
+
+Example: define a JDBC incremental connector
+--------------------------------------------
+
+The example creates an :doc:`incremental <../concepts/jdbc-source-modes>` JDBC connector with the following properties:
+
+* connector name: ``jdbc_source_pg_increment``
+* source tables: ``students`` and ``exams`` from the ``public`` schema, available in an Aiven for PostgreSQL database 
+* :doc:`incremental column name <../concepts/jdbc-source-modes>`: ``id``
+* topic prefix: ``jdbc_source_pg_increment.``
+* maximum number of concurrent tasks: ``1``
+* time interval between queries: 5 seconds
+
+The connector configuration is the following:
+
+::
+
+    {
+        "name":"jdbc_source_pg_increment",
+        "connector.class":"io.aiven.connect.jdbc.JdbcSourceConnector",
+        "connection.url":"jdbc:postgresql://demo-pg-myproject.aivencloud.com:13039/defaultdb?sslmode=require",
+        "connection.user":"avnadmin",
+        "connection.password":"mypassword123",
+        "table.whitelist":"public.students,public.exams",
+        "mode":"incrementing",
+        "incrementing.column.name":"id",
+        "topic.prefix":"jdbc_source_pg_increment.",
+        "tasks.max":"1",
+        "poll.interval.ms":"5000"
+    }
+
+With the above configuration stored in a ``jdbc_incremental_source_pg.json`` file, you can create the connector in the ``demo-kafka`` instance with:
+
+::
+
+    avn service connector create demo-kafka @jdbc_incremental_source_pg.json

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -180,6 +180,8 @@ Manages Aiven for Apache Flink tables and jobs.
 
 More info on ``flink table create``, ``flink table delete``, ``flink table get``, ``flink table list``, ``flink job create``, ``flink job cancel``, ``flink job get`` and ``flink job list`` can be found in :doc:`the dedicated page <service/flink>`.
 
+.. _avn_service_get:
+
 ``avn service get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/docs/tools/cli/service/connector.rst
+++ b/docs/tools/cli/service/connector.rst
@@ -30,6 +30,8 @@ Lists Kafka Connect connector plugins available in a given Aiven for Apache Kafk
 
   avn service connector available kafka-demo
 
+.. _avn_service_connector_create:
+
 ``avn service connector create``
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
# What changed, and why it matters

Added two articles: 
- JDBC source for PostgreSQL (howto) -> Migrated from https://help.aiven.io/en/articles/3416789-jdbc-source-connector-with-postgresql
- JDBC source connection modes (concept)

To test if it's working:
- Create a kafka instance named `demo-kafka` -> enable auto topic creation
- Create a pg instance named `demo-pg`
- connect to `demo-pg`
- execute
```
create table students (id serial primary key, name varchar);
create table exams (id serial primary key, exam_name varchar);
insert into students (name) values ('Francesco');
insert into students (name) values ('Olena');
insert into exams (exam_name) values ('Math');
insert into exams (exam_name) values ('English');
```
Then create the connector and verify the topics being created in Kafka

Fixes #387 