### PR TITLE
Kafka Topic Partition Info: Adding `--project` to the example shell script

### DIFF
--- a/docs/products/kafka/howto/get-topic-partition-details.rst
+++ b/docs/products/kafka/howto/get-topic-partition-details.rst
@@ -29,14 +29,15 @@ For example, this bash script, with a help of ``jq`` utility, lists topics and t
 
 .. code:: bash
 
-    #!/bin/bash
-    serv=YOUR-KAFKA-SERVICE-NAME
-    cloud=$(avn service get $serv --json | jq -r '.cloud_name')
-    topics=$(avn service topic-list $serv --json | jq -r '.[] | .topic_name')
+   #!/bin/bash
+   proj=${1:-YOUR-AIVEN-PROJECT-NAME}
+   serv="${2:-YOUR-KAFKA-SERVICE-NAME}"
+   cloud=$(avn service get --project $proj $serv --json | jq -r '.cloud_name')
+   topics=$(avn service topic-list --project $proj $serv --json | jq -r '.[] | .topic_name')
 
-    echo "Cloud: $cloud Service: $serv"
-    for topic in $topics
-    do
-       echo "Topic: $topic"
-       avn service topic-get $serv $topic
-    done
+   echo "Cloud: $cloud Service: $serv"
+   for topic in $topics
+   do
+      echo "Topic: $topic"
+      avn service topic-get --project $proj $serv $topic
+   done


### PR DESCRIPTION
Adding project parameter so we won't assume user has just one project and use it as default.

Usage: `./script.sh <PROJ> <SVC>`



