### PR TITLE
postgresql: concepts: link TimescaleDB getting started guide

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -40,6 +40,7 @@ Heatmap
 Hillyer
 httpie
 hyperloglogs
+hypertable
 Instana
 Java
 jq

--- a/docs/products/postgresql/concepts/timescaledb.rst
+++ b/docs/products/postgresql/concepts/timescaledb.rst
@@ -17,6 +17,9 @@ TimescaleDB is available as an extension; you can enable it by running::
 
      CREATE EXTENSION timescaledb CASCADE;
 
+After enabling the extension, you can create TimescaleDB hypertables and make use of its features for working with time-series data.
+For further information, have a look at the `Getting Started <https://docs.timescale.com/timescaledb/latest/getting-started/create-hypertable/>`_ guide from Timescale.
+
 More information about :doc:`how to install and manage extensions <../howto/manage-extensions>` is also available.
 
 TSL-licensed features


### PR DESCRIPTION
# What changed, and why it matters

Adds a link to TimescaleDB's getting started guide to the TimescaleDB page. After creating the extension, it'd be nice to point people to the next steps on using TimescaleDB if they aren't familiar. We can link to step 3 (creating a hypertable) of the upstream getting started guide, as steps 1 and 2 are just creating and accessing the DB, if they've enabled the extension assume they've done this already.
