### PR TITLE
Add GitHub with correct capitalisation to accepted words list

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -29,6 +29,7 @@ fileset[s]?
 Flink
 Geomap
 geospatial
+GitHub
 [Gg]o
 Gradle
 Grafana


### PR DESCRIPTION
# What changed, and why it matters

We're getting a warning on the `make check` build step, because the robot doesn't know that "GitHub" is spelt correctly. This adds it, to remove the warning.


