### PR TITLE
Added flex-wrap attribute to search page CSS

### DIFF
--- a/_templates/search.html
+++ b/_templates/search.html
@@ -31,6 +31,7 @@
     list-style: none;
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
   }
 
   #search-results .pagination a {


### PR DESCRIPTION
- Adding "flex-wrap: wrap;" to the CSS for the search page should fix pagination issues with a high number of pages in search results