### PR TITLE
add/redis: ssl connectivity

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -88,7 +88,8 @@ Postman
 Protobuf
 psql
 Python
-[Rr]edis
+Redis
+Redli
 refcard
 reindexing
 Sakila
@@ -121,3 +122,4 @@ Workbench
 Zabbix
 Zipkin
 ZooKeeper
+Stunnel

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -88,7 +88,7 @@ Postman
 Protobuf
 psql
 Python
-Redis
+[Rr]edis
 refcard
 reindexing
 Sakila

--- a/_toc.yml
+++ b/_toc.yml
@@ -314,6 +314,7 @@ entries:
               - file: docs/products/redis/howto/configure-acl-permissions
               - file: docs/products/redis/howto/migrate-aiven-redis
           - file: docs/products/redis/howto/estimate-max-number-of-connections
+          - file: docs/products/redis/howto/manage-ssl-connectivity
           - file: docs/products/redis/howto/warning-overcommit_memory
       - file: docs/products/redis/reference
         title: Reference

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -11,25 +11,25 @@ Aiven for Redis uses SSL encrypted connections by default. This is shown by the 
 .. Tip::
     You can find the ``Service URI`` on `Aiven console <https://console.aiven.io/>`_.
 
-Since **Redis 6**, the redis-cli tool itself supports SSL connections; therefore, you can connect directly to your service using::
+Since **Redis 6**, the ``redis-cli`` tool itself supports SSL connections; therefore, you can connect directly to your service using::
 
     redis-cli -u rediss://username:password@host:port
 
-Alternatively, you can use the third-party `redli tool <https://github.com/IBM-Cloud/redli>`_::
+Alternatively, you can use the third-party `Redli tool <https://github.com/IBM-Cloud/redli>`_::
 
     redli -u rediss://username:password@host:port
 
 
 Not every Redis client supports SSL-encrypted connections.
-In such cases, you would have to turn off SSL to use these clients, which is allowed but not recommended. In those cases, you have some options:
+In such cases, you would have to turn off SSL to use these clients, which is allowed but **not recommended**. You can use one of the following option to disable SSL
 
 
-Set up stunnel process
-~~~~~~~~~~~~~~~~~~~~~~
+Set up ``stunnel`` process
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-One workaround for this, it is to set up a `stunnel process <https://www.stunnel.org/index.html>`_ on the client side to handle encryption for the clients that do not support SSL connections. 
+If you want to keep SSL settings on database side, but hide it from the client side, you can set up a `Stunnel process <https://www.stunnel.org/index.html>`_ on the client to handle encryption. 
 
-You can use the following stunnel configuration, for example ``stunnel.conf``, to set up a stunnel process.
+You can use the following ``stunnel`` configuration, for example ``stunnel.conf``, to set up a ``stunnel`` process.
 ::
 
     client = yes
@@ -46,7 +46,7 @@ You can use the following stunnel configuration, for example ``stunnel.conf``, t
     ; Let's Encrypt by default without any explicit CAfile config.
     ; CAfile = /path/to/optional/project/cacert/that/you/can/download/from/aiven/console
 
-To understand the global options of the stunnel configuration, please check `Stunnel Global Options <https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS>`_.
+To understand the global options of the ``stunnel`` configuration, please check `Stunnel Global Options <https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS>`_.
 
 For ``service-level option``, the following parameters are configured:  
 
@@ -70,16 +70,17 @@ Note that when SSL is in use we have a separate service terminating the SSL conn
 Allow plain-text connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Another alternative is to actually allow plain-text connections. To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
+An alternative is disable database SSL allowing allow plain-text connections. To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
 
 .. Warning::
     Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven for Redis service.
 
-Alternatively, once installed, you should run::
+To disable SSL on an existing Redis instance use the following Aiven CLI command (with link to avn update command)
 
-    avn login  # if you haven't logged in previously
+.. code-block:: console
+
     avn service update myredis -c "redis_ssl=false"
 
-After this, the ``Service URI`` will change and point at the new location, it will also start with the ``redis://`` prefix denoting that it's a direct Redis connection which does not use SSL.
+After executing the command, the ``Service URI`` will change and point at the new location, it will also start with the ``redis://`` (removing the extra s) prefix denoting that it's a direct Redis connection which does not use SSL.
 
 

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -1,18 +1,28 @@
 SSL connectivity
 ================
 
+Client support for SSL-encrypted connections
+--------------------------------------------
+
 Aiven for Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
 
 .. Tip::
     You can find the ``Service URI`` on `Aiven console <https://console.aiven.io/>`_.
 
-Since **Redis 6**, the redis-cli tool itself supports SSL connections; therefore, you can access connect directly to your service using::
+Since **Redis 6**, the redis-cli tool itself supports SSL connections; therefore, you can connect directly to your service using::
 
     redis-cli -u rediss://username:password@host:port
 
 Alternatively, you can use the third-party `redli tool <https://github.com/IBM-Cloud/redli>`_::
 
     redli -u rediss://username:password@host:port
+
+
+Not every Redis client supports SSL-encrypted connections. In those cases, you have some options:
+
+
+Set up stunnel process
+~~~~~~~~~~~~~~~~~~~~~~
 
 Not every Redis client supports SSL-encrypted connections. In such cases, you would have to turn off SSL to use these clients, which is allowed but not recommended. One workaround for this, it is to set up a stunnel process on the client side to handle encryption for the clients that do not support SSL connections. 
 
@@ -32,9 +42,13 @@ You can use the following stunnel configuration, for example ``example-stunnel.c
     ; CA cert available from Aiven console. Most environments trust
     ; Let's Encrypt by default without any explicit CAfile config.
     ; CAfile = /path/to/optional/project/cacert/that/you/can/download/from/aiven/console
+
 Note that when SSL is in use we have a separate service terminating the SSL connections before they are forwarded to Redis. This process has a connection timeout of its own independent of Redis' connection timeout. If you allow very long Redis timeouts this frontend service may end up closing the connection before the Redis timeout has expired. By the time of writing this timeout is set to 12 hours.
 
-Another alternative is to allow plain-text connections. You can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
+Allow plain-text connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
 
 .. Warning::
     Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven for Redis service.

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -1,0 +1,49 @@
+SSL connectivity
+================
+
+Aiven Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
+
+.. Tip::
+    You can find the ``Service URI`` on `Aiven console <https://console.aiven.io/>`_.
+
+Since **Redis 6**, the redis-cli tool itself supports SSL connections; therefore, you can access connect directly to your service using::
+
+    redis-cli -u rediss://username:password@host:port
+
+Alternatively, you can use the third-party `redli tool <https://github.com/IBM-Cloud/redli>`_::
+
+    redli -u rediss://username:password@host:port
+
+Not every Redis client supports SSL-encrypted connections. In such cases, you would have to turn off SSL to use these clients, which is allowed but not recommended. One workaround for this, it is to set up a stunnel process on the client side to handle encryption for the clients that do not support SSL connections. 
+
+You can use the following stunnel configuration, for example ``example-stunnel.conf``, to set up a stunnel process.
+::
+
+    client = yes
+    foreground = yes
+    debug = info
+    delay = yes
+
+    [redis]
+    accept = 127.0.0.1:6380
+    connect = myredis.testproject.aivencloud.com:28173
+    TIMEOUTclose = 0
+    ; For old services only. New ones use Let's Encrypt and there's no
+    ; CA cert available from Aiven console. Most environments trust
+    ; Let's Encrypt by default without any explicit CAfile config.
+    ; CAfile = /path/to/optional/project/cacert/that/you/can/download/from/aiven/console
+Note that when SSL is in use we have a separate service terminating the SSL connections before they are forwarded to Redis. This process has a connection timeout of its own independent of Redis' connection timeout. If you allow very long Redis timeouts this frontend service may end up closing the connection before the Redis timeout has expired. By the time of writing this timeout is set to 12 hours.
+
+Another alternative is to allow plain-text connections. You can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
+
+.. Warning::
+    Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven Redis service.
+
+Alternatively, once installed, you should run::
+
+    avn login  # if you haven't logged in previously
+    avn service update myredis -c "redis_ssl=false"
+
+After this, the ``Service URI`` will change and point at the new location, it will also start with the ``redis://`` prefix denoting that it's a direct Redis connection which does not use SSL.
+
+

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -4,6 +4,8 @@ SSL connectivity
 Client support for SSL-encrypted connections
 --------------------------------------------
 
+Default support
+~~~~~~~~~~~~~~~
 Aiven for Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
 
 .. Tip::
@@ -18,15 +20,16 @@ Alternatively, you can use the third-party `redli tool <https://github.com/IBM-C
     redli -u rediss://username:password@host:port
 
 
-Not every Redis client supports SSL-encrypted connections. In those cases, you have some options:
+Not every Redis client supports SSL-encrypted connections.
+In such cases, you would have to turn off SSL to use these clients, which is allowed but not recommended. In those cases, you have some options:
 
 
 Set up stunnel process
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Not every Redis client supports SSL-encrypted connections. In such cases, you would have to turn off SSL to use these clients, which is allowed but not recommended. One workaround for this, it is to set up a stunnel process on the client side to handle encryption for the clients that do not support SSL connections. 
+One workaround for this, it is to set up a `stunnel process <https://www.stunnel.org/index.html>`_ on the client side to handle encryption for the clients that do not support SSL connections. 
 
-You can use the following stunnel configuration, for example ``example-stunnel.conf``, to set up a stunnel process.
+You can use the following stunnel configuration, for example ``stunnel.conf``, to set up a stunnel process.
 ::
 
     client = yes
@@ -43,12 +46,31 @@ You can use the following stunnel configuration, for example ``example-stunnel.c
     ; Let's Encrypt by default without any explicit CAfile config.
     ; CAfile = /path/to/optional/project/cacert/that/you/can/download/from/aiven/console
 
-Note that when SSL is in use we have a separate service terminating the SSL connections before they are forwarded to Redis. This process has a connection timeout of its own independent of Redis' connection timeout. If you allow very long Redis timeouts this frontend service may end up closing the connection before the Redis timeout has expired. By the time of writing this timeout is set to 12 hours.
+To understand the global options of the stunnel configuration, please check `Stunnel Global Options <https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS>`_.
+
+For ``service-level option``, the following parameters are configured:  
+
+``accept`` => *[host:]port*
+  **Accept connections on specified address**
+
+
+
+``connect`` => *[host:]port*
+  **Connect to a remote address** 
+
+
+
+``TIMEOUTclose`` => *seconds*
+  **Time to wait for close_notify**
+
+.. note:: It is important to make changes accordingly to your service. On the *Overview* page you can find your **Overview** > **Host** and **Overview** > **Port** to configure the ``connect`` parameter.
+
+Note that when SSL is in use we have a separate service terminating the SSL connections before they are forwarded to Redis. This process has a connection timeout of its own independent of Redis' connection timeout. If you allow very long Redis timeouts, this frontend service may end up closing the connection before the Redis timeout has expired. By the time of writing this, timeout is set to 12 hours.
 
 Allow plain-text connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
+Another alternative is to actually allow plain-text connections. To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
 
 .. Warning::
     Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven for Redis service.

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -1,7 +1,7 @@
 SSL connectivity
 ================
 
-Aiven Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
+Aiven for Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
 
 .. Tip::
     You can find the ``Service URI`` on `Aiven console <https://console.aiven.io/>`_.
@@ -37,7 +37,7 @@ Note that when SSL is in use we have a separate service terminating the SSL conn
 Another alternative is to allow plain-text connections. You can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
 
 .. Warning::
-    Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven Redis service.
+    Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven for Redis service.
 
 Alternatively, once installed, you should run::
 

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -21,13 +21,13 @@ Alternatively, you can use the third-party `Redli tool <https://github.com/IBM-C
 
 
 Not every Redis client supports SSL-encrypted connections.
-In such cases, you would have to turn off SSL to use these clients, which is allowed but **not recommended**. You can use one of the following option to disable SSL
+In such cases, you would have to turn off SSL to use these clients, which is allowed but **not recommended**. You can use one of the following option to disable SSL.
 
 
 Set up ``stunnel`` process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to keep SSL settings on database side, but hide it from the client side, you can set up a `Stunnel process <https://www.stunnel.org/index.html>`_ on the client to handle encryption. 
+If you want to keep SSL settings on database side, but hide it from the client side, you can set up a ``stunnel`` process on the client to handle encryption.
 
 You can use the following ``stunnel`` configuration, for example ``stunnel.conf``, to set up a ``stunnel`` process.
 ::
@@ -46,7 +46,7 @@ You can use the following ``stunnel`` configuration, for example ``stunnel.conf`
     ; Let's Encrypt by default without any explicit CAfile config.
     ; CAfile = /path/to/optional/project/cacert/that/you/can/download/from/aiven/console
 
-To understand the global options of the ``stunnel`` configuration, please check `Stunnel Global Options <https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS>`_.
+To understand the global options of the ``stunnel`` configuration, please check `Stunnel Global Options <https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS>`_. Also, you can find out more details about how to setup such a process on the `Stunnel website page <https://www.stunnel.org/index.html>`_.
 
 For ``service-level option``, the following parameters are configured:  
 
@@ -65,7 +65,7 @@ For ``service-level option``, the following parameters are configured:
 
 .. note:: It is important to make changes accordingly to your service. On the *Overview* page you can find your **Overview** > **Host** and **Overview** > **Port** to configure the ``connect`` parameter.
 
-Note that when SSL is in use we have a separate service terminating the SSL connections before they are forwarded to Redis. This process has a connection timeout of its own independent of Redis' connection timeout. If you allow very long Redis timeouts, this frontend service may end up closing the connection before the Redis timeout has expired. By the time of writing this, timeout is set to 12 hours.
+It is important to note that when SSL is in use, HAProxy will be responsible for terminating the SSL connections before they get forwarded to Redis. This process has a connection timeout set to 12 hours which is not configurable by the customer. If you allow very long Redis timeouts, this SSL-terminating HAProxy may end up closing the connection before the Redis timeout has expired. This timeout is independent of Redis timeout.
 
 Allow plain-text connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/products/redis/concepts/ssl-connectivity.rst
+++ b/docs/products/redis/concepts/ssl-connectivity.rst
@@ -6,7 +6,7 @@ Client support for SSL-encrypted connections
 
 Default support
 ~~~~~~~~~~~~~~~
-Aiven for Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI``. 
+Aiven for Redis uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI`` on the `Aiven Console <https://console.aiven.io/>`_.
 
 .. Tip::
     You can find the ``Service URI`` on `Aiven console <https://console.aiven.io/>`_.
@@ -21,7 +21,7 @@ Alternatively, you can use the third-party `Redli tool <https://github.com/IBM-C
 
 
 Not every Redis client supports SSL-encrypted connections.
-In such cases, you would have to turn off SSL to use these clients, which is allowed but **not recommended**. You can use one of the following option to disable SSL.
+In such cases, you would have to turn off or bypass the SSL to use these clients, which is allowed but **not recommended**. You can use one of the following option to achieve this.
 
 
 Set up ``stunnel`` process
@@ -70,16 +70,16 @@ It is important to note that when SSL is in use, HAProxy will be responsible for
 Allow plain-text connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An alternative is disable database SSL allowing allow plain-text connections. To allow plain-text connections, you can change this setting with **Overview** > **Advanced configuration**, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
+An alternative is disable database SSL allowing allow plain-text connections. To allow plain-text connections, you can change this setting on **Overview** in the **Advanced configuration** section, or using the :doc:`Aiven Command Line interface<../../../tools/cli>`.
 
 .. Warning::
-    Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic will be able to potentially connect and access your Aiven for Redis service.
+    Allowing plain-text connections can have some implications regarding the security of your Redis service. If SSL is turned off, anyone who can eavesdrop on the traffic can potentially have access to your credentials; therefore, your Aiven for Redis service.
 
-To disable SSL on an existing Redis instance use the following Aiven CLI command (with link to avn update command)
+To disable SSL on an existing Redis instance use the following Aiven CLI command substituting the ``<my-redis>`` with your Redis the name service chosen by you when the service was created.
 
 .. code-block:: console
 
-    avn service update myredis -c "redis_ssl=false"
+    avn service update <my-redis> -c "redis_ssl=false"
 
 After executing the command, the ``Service URI`` will change and point at the new location, it will also start with the ``redis://`` (removing the extra s) prefix denoting that it's a direct Redis connection which does not use SSL.
 

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -30,7 +30,7 @@ Check out more technical information:
 
   Learn about how Aiven for Redis supports high availability.
 
-* :doc:`SSL connectivity <concepts/ssl-connectivity>`.
+* :doc:`Manage SSL connectivity <howto/manage-ssl-connectivity>`.
 
   Check how Aiven for Redis supports SSL connections and how can be configured.
 

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -30,6 +30,10 @@ Check out more technical information:
 
   Learn about how Aiven for Redis supports high availability.
 
+* :doc:`SSL connectivity <concepts/ssl-connectivity>`.
+
+  Check how Aiven for Redis supports SSL connections and how can be configured.
+
 * :doc:`Memory usage, on-disk persistence and replication in Aiven for Redis <concepts/memory-usage>`.
 
   See how Aiven for Redis solves the challenges related to high memory usage and high change rate.

--- a/docs/products/redis/howto/manage-ssl-connectivity.rst
+++ b/docs/products/redis/howto/manage-ssl-connectivity.rst
@@ -1,5 +1,5 @@
-SSL connectivity
-================
+Manage SSL connectivity
+=======================
 
 Client support for SSL-encrypted connections
 --------------------------------------------


### PR DESCRIPTION
### Migration of Redis content.

Original URL:
https://help.aiven.io/en/articles/489559-redis-ssl-connectivity

Dev Portal:
https://developer.aiven.io/docs/products/redis/concepts/howto/manage-ssl-connectivity.html

Add relevant information about how to run the stunnel process and relevant documentation links.
I have ran the stunnel process myself and seems to be fine. 

Alternatively, this can be saved on tree as: `how to setup ssl  connectivity`

Fix: https://github.com/aiven/devportal/issues/433