### PR TITLE
migrate/redis: warning overcommit_memory

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -116,4 +116,3 @@ Workbench
 Zabbix
 Zipkin
 ZooKeeper
-overcommit

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -116,3 +116,4 @@ Workbench
 Zabbix
 Zipkin
 ZooKeeper
+overcommit

--- a/_toc.yml
+++ b/_toc.yml
@@ -269,6 +269,7 @@ entries:
               - file: docs/products/redis/howto/configure-acl-permissions
               - file: docs/products/redis/howto/migrate-aiven-redis
           - file: docs/products/redis/howto/estimate-max-number-of-connections
+          - file: docs/products/redis/howto/warning-overcommit_memory
 
   - file: docs/products/grafana/index
     title: Grafana

--- a/docs/products/redis/concepts/warning-overcommit_memory.rst
+++ b/docs/products/redis/concepts/warning-overcommit_memory.rst
@@ -1,0 +1,8 @@
+Warning ``overcommit_memory``
+=============================
+
+By starting a Redis service on `Aiven console <https://console.aiven.io/>`_, you may notice on **Logs** the following **warning** ``overcommit_memory``::
+
+    # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
+
+This warning can be safely ignored. Aiven for Redis limits the memory usage differently from how the software is deployed, which means the available memory will never drop low enough to hit this particular failure case.

--- a/docs/products/redis/concepts/warning-overcommit_memory.rst
+++ b/docs/products/redis/concepts/warning-overcommit_memory.rst
@@ -1,8 +1,0 @@
-Warning ``overcommit_memory``
-=============================
-
-By starting a Redis service on `Aiven console <https://console.aiven.io/>`_, you may notice on **Logs** the following **warning** ``overcommit_memory``::
-
-    # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
-
-This warning can be safely ignored. Aiven for Redis limits the memory usage differently from how the software is deployed, which means the available memory will never drop low enough to hit this particular failure case.

--- a/docs/products/redis/howto/warning-overcommit_memory.rst
+++ b/docs/products/redis/howto/warning-overcommit_memory.rst
@@ -5,4 +5,4 @@ When starting a Redis service on `Aiven console <https://console.aiven.io/>`_, y
 
     # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
 
-This warning can be safely ignored as the available memory will never drop low enough to hit this particular failure case.
+This warning can be safely ignored as Aiven for Redis ensures that the available memory will never drop low enough to hit this particular failure case.

--- a/docs/products/redis/howto/warning-overcommit_memory.rst
+++ b/docs/products/redis/howto/warning-overcommit_memory.rst
@@ -1,0 +1,8 @@
+Handle warning ``overcommit_memory``
+====================================
+
+When starting a Redis service on `Aiven console <https://console.aiven.io/>`_, you may notice on **Logs** the following **warning** ``overcommit_memory``::
+
+    # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
+
+This warning can be safely ignored as the available memory will never drop low enough to hit this particular failure case.


### PR DESCRIPTION
Original URL:
https://help.aiven.io/en/articles/5157337-redis-overcommit_memory-warning

Devportal:
https://developer.aiven.io/docs/products/redis/howto/warning-overcommit_memory.html

Fixes: https://github.com/aiven/devportal/issues/435


