### PR TITLE
Redis: add generated config docs and clean up `Getting Started`

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -271,6 +271,10 @@ entries:
               - file: docs/products/redis/howto/migrate-aiven-redis
           - file: docs/products/redis/howto/estimate-max-number-of-connections
           - file: docs/products/redis/howto/warning-overcommit_memory
+      - file: docs/products/redis/reference
+        title: Reference
+        entries:
+          - glob: docs/products/redis/reference/*
 
   - file: docs/products/grafana/index
     title: Grafana

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -4,17 +4,13 @@ Get started with Aiven for Redis
 Aiven for Redis services are managed from the `Aiven
 Console <https://console.aiven.io/>`__. Create a new Aiven for Redis service by following the steps laid out in :doc:`this article </docs/platform/howto/create_new_service>`.
 
-Once the service creation is initiated, you can go to its dedicated service page where the new service is shown
-with an indicator that it is being created.
+Once the service creation is initiated, you can go to its dedicated service page where the new service is shown with an indicator that it is being created.
 
-Click the service name in the list to go to the "**Overview**" page. The "**Overview**" tab shows the connection parameters for your Redis service and its
-current status. You can make changes to the service configuration in "*Advanced configuration*",
-even while the service is being built. You can find the available
-configuration options on the :doc:`reference page <reference/advanced-params>`.
+Click the service name in the list to go to the **Overview** page. The **Overview** tab shows the connection parameters for your Redis service and its current status. You can make changes to the service configuration in **Overview** > **Advanced configuration**, even while the service is being built. You can find the available configuration options on the :doc:`reference page <reference/advanced-params>`.
 
-The "Status" indicator says "**REBUILDING**" while the service is
+The "Status" indicator says **REBUILDING** while the service is
 being created. Once the service is up and running, the light changes to
-green and the indicator says "**RUNNING**".
+green and the indicator says **RUNNING**.
 
 .. note::
    Services typically start in a couple of minutes, the performance between clouds varies and it can take longer under some circumstances.

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -2,23 +2,20 @@ Get started with Aiven for Redis
 ================================
 
 Aiven for Redis services are managed from the `Aiven
-Console <https://console.aiven.io/>`__ .
+Console <https://console.aiven.io/>`__. Create an Aiven for Redis service by following the steps laid out in :doc:`this article </docs/platform/howto/create_new_service>`.
 
-You can start an Aiven for Redis service by following the steps laid out
-in :doc:`this article </docs/platform/howto/create_new_service>`.
-
-The view returns to the service list, where the new service is shown
+Once the service creation is initiated, you can go to its dedicated service page where the new service is shown
 with an indicator that it is being created.
 
-Click the service name in the list to go to the " **Overview** " page.
+Click the service name in the list to go to the "**Overview**" page.
 This view shows the connection parameters for your Redis service and its
 current status. You can make changes to the service configuration here,
 even while the service is being built. You can find the available
 configuration options on the :doc:`reference page <reference/advanced-params>`.
 
-The "Status" indicator says " **REBUILDING** " while the service is
+The "Status" indicator says "**REBUILDING**" while the service is
 being created. Once the service is up and running, the light changes to
-green and the indicator says " **RUNNING** ".
+green and the indicator says "**RUNNING**".
 
 .. note::
    Services typically start in a couple of minutes, the performance between clouds varies and it can take longer under some circumstances.
@@ -26,7 +23,7 @@ green and the indicator says " **RUNNING** ".
 Next steps
 ----------
 
-* Learn how to connect to Aiven for Redis:
+* Learn how to connect to Aiven for Redis by using different programming languages:
    - :doc:`Go <howto/connect-go>`
    - :doc:`Node <howto/connect-node>`
    - :doc:`PHP <howto/connect-php>`

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -2,14 +2,13 @@ Get started with Aiven for Redis
 ================================
 
 Aiven for Redis services are managed from the `Aiven
-Console <https://console.aiven.io/>`__. Create an Aiven for Redis service by following the steps laid out in :doc:`this article </docs/platform/howto/create_new_service>`.
+Console <https://console.aiven.io/>`__. Create a new Aiven for Redis service by following the steps laid out in :doc:`this article </docs/platform/howto/create_new_service>`.
 
 Once the service creation is initiated, you can go to its dedicated service page where the new service is shown
 with an indicator that it is being created.
 
-Click the service name in the list to go to the "**Overview**" page.
-This view shows the connection parameters for your Redis service and its
-current status. You can make changes to the service configuration here,
+Click the service name in the list to go to the "**Overview**" page. The "**Overview**" tab shows the connection parameters for your Redis service and its
+current status. You can make changes to the service configuration in "*Advanced configuration*",
 even while the service is being built. You can find the available
 configuration options on the :doc:`reference page <reference/advanced-params>`.
 

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -1,59 +1,38 @@
-Get Started with Aiven for Redis
+Get started with Aiven for Redis
 ================================
 
-Get up and running with Aiven for Redis. This article shows you how to set up a Redis service in Aiven and learn more about the platform.
+Aiven for Redis services are managed from the `Aiven
+Console <https://console.aiven.io/>`__ .
 
-Create a new Aiven service
---------------------------
+You can start an Aiven for Redis service by following the steps laid out
+in :doc:`this article </docs/platform/howto/create_new_service>`.
 
-To create a new Aiven for Redis service:
+The view returns to the service list, where the new service is shown
+with an indicator that it is being created.
 
-1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+Click the service name in the list to go to the " **Overview** " page.
+This view shows the connection parameters for your Redis service and its
+current status. You can make changes to the service configuration here,
+even while the service is being built. You can find the available
+configuration options on the :doc:`reference page <reference/advanced-params>`.
 
-2. On the *Services* page, click **Create a new service**.
+The "Status" indicator says " **REBUILDING** " while the service is
+being created. Once the service is up and running, the light changes to
+green and the indicator says " **RUNNING** ".
 
-   This opens a new page with the available service options.
-
-3. Select the main properties for your service:
-
-   a. Select the service type.
-
-      If there are several versions available, select the version that you want to use. By default, the latest available version is selected.
-
-   b. Select the cloud provider and region that you want to run your service on.
-
-      .. Note::
-          The pricing for the same service may vary between different providers and regions. The service summary on the right side of the console shows you the pricing for your selected options.
-          
-   c. Select a service plan.
-
-      This defines the number of servers and what kind of memory, CPU, and disk resources are allocated to your service.
-
-   d. Enter a name for your service.
-
-      A random name is provided by default, but you can enter a more recognizable name to distinguish it from other services.
-
-
-4. Click **Create Service** under the summary on the right side of the console.
-
-   This brings you back to the **Services** view. Your new service is listed with a status indicator to show that it is being created.
-
-5. Click the service name.
-
-   The *Overview* page for the service opens. This view shows you the connection parameters for your service, its current status, and the configuration options.
-
-   The status is *Rebuilding* while the service is being created for you. Once the service is ready, the status changes to *Running*. While services typically start up in a couple of minutes, the performance varies between cloud providers and regions, and it may take longer in some circumstances.
+.. note::
+   Services typically start in a couple of minutes, the performance between clouds varies and it can take longer under some circumstances.
 
 Next steps
 ----------
 
-Code examples for connecting to Redis from your application:
-   * :doc:`Go <howto/connect-go>`
-   * :doc:`Node <howto/connect-node>`
-   * :doc:`PHP <howto/connect-php>`
-   * :doc:`Python <howto/connect-python>`
+* Learn how to connect to Aiven for Redis:
+   - :doc:`Go <howto/connect-go>`
+   - :doc:`Node <howto/connect-node>`
+   - :doc:`PHP <howto/connect-php>`
+   - :doc:`Python <howto/connect-python>`
 
-Check out our other resources for more technical information:
+Check out more technical information:
 
 * :doc:`High availability in Aiven for Redis <concepts/high-availability-redis>`.
 

--- a/docs/products/redis/reference.rst
+++ b/docs/products/redis/reference.rst
@@ -1,0 +1,6 @@
+Reference
+=========
+
+Additional reference information for Aiven for Redis:
+
+.. tableofcontents::

--- a/docs/products/redis/reference/advanced-params.rst
+++ b/docs/products/redis/reference/advanced-params.rst
@@ -1,0 +1,6 @@
+List of advanced parameters
+============================
+
+When creating or working with an Aiven for Redis service, several configuration options are available. They are summarized below:
+
+.. include:: /includes/config-redis.rst

--- a/includes/config-redis.rst
+++ b/includes/config-redis.rst
@@ -1,0 +1,117 @@
+
+``ip_filter`` => *array*
+  **IP filter** Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+
+
+
+``static_ips`` => *boolean*
+  **Static IP addresses** Use static public IP addresses
+
+
+
+``migration`` => *['object', 'null']*
+  **Migrate data from existing server** 
+
+
+
+``private_access`` => *object*
+  **Allow access to selected service ports from private networks** 
+
+  ``prometheus`` => *boolean*
+    **Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations** None
+
+  ``redis`` => *boolean*
+    **Allow clients to connect to redis with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations** None
+
+
+
+``privatelink_access`` => *object*
+  **Allow access to selected service components through Privatelink** 
+
+  ``redis`` => *boolean*
+    **Enable redis** None
+
+
+
+``public_access`` => *object*
+  **Allow access to selected service ports from the public Internet** 
+
+  ``prometheus`` => *boolean*
+    **Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+  ``redis`` => *boolean*
+    **Allow clients to connect to redis from the public internet for service nodes that are in a project VPC or another type of private network** None
+
+
+
+``recovery_basebackup_name`` => *string*
+  **Name of the basebackup to restore in forked service** 
+
+
+
+``redis_maxmemory_policy`` => *['string', 'null']*
+  **Redis maxmemory-policy** 
+
+
+
+``redis_pubsub_client_output_buffer_limit`` => *integer*
+  **Pub/sub client output buffer hard limit in MB** Set output buffer limit for pub / sub clients in MB. The value is the hard limit, the soft limit is 1/4 of the hard limit. When setting the limit, be mindful of the available memory in the selected service plan.
+
+
+
+``redis_number_of_databases`` => *integer*
+  **Number of redis databases** Set number of redis databases. Changing this will cause a restart of redis service.
+
+
+
+``redis_io_threads`` => *integer*
+  **Redis IO thread count** 
+
+
+
+``redis_lfu_log_factor`` => *integer*
+  **Counter logarithm factor for volatile-lfu and allkeys-lfu maxmemory-policies** 
+
+
+
+``redis_lfu_decay_time`` => *integer*
+  **LFU maxmemory-policy counter decay time in minutes** 
+
+
+
+``redis_ssl`` => *boolean*
+  **Require SSL to access Redis** 
+
+
+
+``redis_timeout`` => *integer*
+  **Redis idle connection timeout** 
+
+
+
+``redis_notify_keyspace_events`` => *string*
+  **Set notify-keyspace-events option** 
+
+
+
+``redis_persistence`` => *string*
+  **Redis persistence** When persistence is 'rdb', Redis does RDB dumps each 10 minutes if any key is changed. Also RDB dumps are done according to backup schedule for backup purposes. When persistence is 'off', no RDB dumps and backups are done, so data can be lost at any moment if service is restarted for any reason, or if service is powered off. Also service can't be forked.
+
+
+
+``redis_acl_channels_default`` => *string*
+  **Default ACL for pub/sub channels used when Redis user is created** Determines default pub/sub channels' ACL for new users if ACL is not supplied. When this option is not defined, all_channels is assumed to keep backward compatibility. This option doesn't affect Redis configuration acl-pubsub-default.
+
+
+
+``service_to_fork_from`` => *['string', 'null']*
+  **Name of another service to fork from. This has effect only when a new service is being created.** 
+
+
+
+``project_to_fork_from`` => *['string', 'null']*
+  **Name of another project to fork a service from. This has effect only when a new service is being created.** 
+
+
+
+


### PR DESCRIPTION
# What changed, and why it matters

Clean up getting started page
Generated config docs for Redis

