### PR TITLE
fix/redis and kafka: missing links for Reference

### DIFF
--- a/docs/products/kafka/index.rst
+++ b/docs/products/kafka/index.rst
@@ -38,6 +38,10 @@ Take your first steps with Aiven for Apache Kafka by following our :doc:`getting
 
     💻 :doc:`HowTo <howto>`
 
+    ---
+
+    📖 :doc:`reference`
+
 
 Apache Kafka resources
 ----------------------

--- a/docs/products/kafka/reference/advanced-params.rst
+++ b/docs/products/kafka/reference/advanced-params.rst
@@ -1,6 +1,6 @@
 List of advanced parameters
 ============================
 
-When creating or working with an Aiven for Apache Kafka service, several configuration options are available. They are summarized below:
+When working with an Aiven for Apache Kafka service, many configuration options are available. They are summarized below:
 
 .. include:: /includes/config-kafka.rst

--- a/docs/products/kafka/reference/advanced-params.rst
+++ b/docs/products/kafka/reference/advanced-params.rst
@@ -1,6 +1,6 @@
 List of advanced parameters
 ============================
 
-When working with an Aiven for Apache Kafka service, many configuration options are available. They are summarized below:
+Below you can find a summary of every configuration option available for Aiven for Apache Kafka service:
 
 .. include:: /includes/config-kafka.rst

--- a/docs/products/mysql/reference/advanced-params.rst
+++ b/docs/products/mysql/reference/advanced-params.rst
@@ -1,6 +1,6 @@
 List of advanced parameters
 ============================
 
-When creating or working with an Aiven for MySQL service, several configuration options are available. They are summarized below:
+Below you can find a summary of every configuration option available for Aiven for MySQL service:
 
 .. include:: /includes/config-mysql.rst

--- a/docs/products/redis/index.rst
+++ b/docs/products/redis/index.rst
@@ -31,6 +31,10 @@ Take your first steps with Aiven for Redis by following our :doc:`get-started` a
 
     ---
 
+    📖 :doc:`reference`
+
+    ---
+
     🧰 :doc:`howto/list-code-samples`
 
 

--- a/docs/products/redis/reference/advanced-params.rst
+++ b/docs/products/redis/reference/advanced-params.rst
@@ -1,6 +1,6 @@
 List of advanced parameters
 ============================
 
-When working with an Aiven for Redis service, many configuration options are available. They are summarized below:
+Below you can find a summary of every configuration option available for Aiven for Redis service:
 
 .. include:: /includes/config-redis.rst

--- a/docs/products/redis/reference/advanced-params.rst
+++ b/docs/products/redis/reference/advanced-params.rst
@@ -1,6 +1,6 @@
 List of advanced parameters
 ============================
 
-When creating or working with an Aiven for Redis service, several configuration options are available. They are summarized below:
+When working with an Aiven for Redis service, many configuration options are available. They are summarized below:
 
 .. include:: /includes/config-redis.rst


### PR DESCRIPTION
Add missing links for reference in index

Fix: https://github.com/aiven/devportal/issues/452