### PR TITLE
fix/cli: missing links to the commands

### DIFF
--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -43,6 +43,8 @@ Handle the accounts you have access to, and also configure the teams for the acc
 
 Find more info on the help article about `Accounts, Teams, Members and Roles <https://help.aiven.io/en/articles/4206498-accounts-teams-members-and-roles>`_
 
+:doc:`See detailed command information <cli/account>`.
+
 
 ``billing-group``
 '''''''''''''''''
@@ -92,6 +94,8 @@ Detailed help on using the CLI.
 
 Manage the replication flows for MirrorMaker2.
 
+:doc:`See detailed command information <cli/mirrormaker>`.
+
 
 ``project``
 '''''''''''
@@ -106,12 +110,14 @@ Download the CA cert for this project (CA certs are common for all services in a
 '''''''''''
 
 The kitchen sink! All the commands specific to a service are available here.
-
+:doc:`See detailed command information <cli/service>`.
 
 ``ticket``
 ''''''''''
 
-An alternative support ticket interface to either email or the chat widget found on our web console. Create or list tickets.
+Create or list tickets. An alternative support ticket interface to either email or the chat widget found on our web console. 
+
+:doc:`See detailed command information <cli/ticket>`.
 
 ``user``
 ''''''''

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -110,6 +110,7 @@ Download the CA cert for this project (CA certs are common for all services in a
 '''''''''''
 
 The kitchen sink! All the commands specific to a service are available here.
+
 :doc:`See detailed command information <cli/service>`.
 
 ``ticket``

--- a/docs/tools/cli/ticket.rst
+++ b/docs/tools/cli/ticket.rst
@@ -1,11 +1,11 @@
-Command reference: ``avn ticket``
-==================================
+``avn ticket``
+==============
 
 Here you'll find the full list of commands for ``avn ticket``.
 
 
 Create and manage support tickets
-------------------------------------
+---------------------------------
 
 Commands for managing Aiven support tickets. 
 
@@ -14,7 +14,7 @@ Commands for managing Aiven support tickets.
   To be able to create support tickets your project should be covered by a support contract.
 
 ``avn ticket create``
-'''''''''''''''''''''''''
+'''''''''''''''''''''
 
 Creates a new ticket.
 


### PR DESCRIPTION
On https://developer.aiven.io/docs/tools/cli there are a couple of commands
that are missing links to further information. Fix by adding the right
links.


Fix: https://github.com/aiven/devportal/issues/450