### PR TITLE
fix/warning: initial capital letter only spell

### DIFF
--- a/docs/products/opensearch/dashboards/howto/opensearch-alerting-dashboard.rst
+++ b/docs/products/opensearch/dashboards/howto/opensearch-alerting-dashboard.rst
@@ -116,7 +116,7 @@ Triggers is a defined conditions from the queries results from monitor.  If cond
 .. note::
    Multiple Actions can be defined, in this example we will define one action to send notification to destination we have defined in step 4
 
-Alert Message
+Alert message
 *************
 
 **Message** can be adjusted as needed, check **Message Preview** to see the sample and use **Send test message** to validate notification delivery


### PR DESCRIPTION
# What changed, and why it matters

By running, `make spell` we have spotted a warning.
The warning has not stopped to merge to main.
However, we can spot the warning appearing in future PR's.

With filename as `Unchanged files with check annotations`.

The fix is to take the main branch and make branch out of it.
Fix the spell and merge to main branch again.

The current open PRs should rebase and this warning shall disappear.


