### PR TITLE
fix/README link to CONTRIBUTING.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Contributing
 ------------
 
-Check the `CONTRIBUTING guide <CONTRIBUTING>`_ for details on how to create content for Aiven Developer. You will find the style guide, pull request process and templates for the various content types there.
+Check the `CONTRIBUTING guide <CONTRIBUTING.rst>`_ for details on how to create content for Aiven Developer. You will find the style guide, pull request process and templates for the various content types there.
 
 Local Development
 -----------------


### PR DESCRIPTION
Fix: #455

# What changed, and why it matters

The link to the CONTRIBUTING page needs to include the `.rst` file extension, or it gives a 404 NOT FOUND.

Tested on the branch, where the fix works.



