### PR TITLE
Update redis_timeout documentation

### DIFF
--- a/includes/config-redis.rst
+++ b/includes/config-redis.rst
@@ -85,7 +85,7 @@
 
 
 ``redis_timeout`` => *integer*
-  **Redis idle connection timeout** 
+  **Redis idle connection timeout in seconds** 
 
 
 


### PR DESCRIPTION
It's now clear that the timeout is in seconds.
