### PR TITLE
Migrate auth token info - from HELP to DevPortal

### DIFF
--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -3,6 +3,10 @@ Concepts
 
 Learn about some of the key concepts for working with Aiven platform:
 
+* :doc:`Authentication tokens </docs/platform/concepts/authentication-tokens>`.
+
+  Learn about authentication tokens and how to use them to programmatically access Aiven resources.
+
 * :doc:`Beta services </docs/platform/concepts/beta_services>`.
 
   What to expect from the early versions of our new services and upgrades.

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -1,8 +1,10 @@
 Authentication tokens
 =====================
 
-An authentication token allows a user to programmatically access resources instead of using their username-password. Unlike the username-password combination that has a longer shelf life (in some case, they never expire); you can limit how long an authentication token is valid for or revoke it completely.
-Unlike a username-password, multiple tokens can be active at the time. This way, you can create a token for a specific use case and revoke the token when the project is finished.
+An authentication token allows a user to programmatically access resources instead of using their username-password. The usage of authentication tokens has the following benefits compared to username and password:
+
+- Multiple tokens can be generated for different apps or use cases unlike a single username-password for everything.
+- Short lifespan of authentication tokens reduce the security risk of being exposed.
 
 .. mermaid::
 

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -5,11 +5,11 @@ An authentication token allows a user to programmatically access resources inste
 
 .. mermaid::
 
-sequenceDiagram
-    Client->>+Server: Here's my username/password. Give me a token.
-    Server-->>-Client: Your username/password is valid. Here's a token. 
-    Client->>+Server: Here's a token. Show me a list of my resources.
-    Server-->>-Client: Your token is valid. Here's a list of your resources.
+    sequenceDiagram 
+        Client->>+Server: Here's my username/password. Give me a token.
+        Server-->>-Client: Your username/password is valid. Here's a token. 
+        Client->>+Server: Here's a token. Show me a list of my resources.
+        Server-->>-Client: Your token is valid. Here's a list of your resources.
 
 How Aiven manages user sessions using authentication tokens
 -----------------------------------------------------------

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -2,6 +2,7 @@ Authentication tokens
 =====================
 
 An authentication token allows a user to programmatically access resources instead of using their username-password. Unlike the username-password combination that has a longer shelf life (in some case, they never expire); you can limit how long an authentication token is valid for or revoke it completely.
+Unlike a username-password, multiple tokens can be active at the time. This way, you can create a token for a specific use case and revoke the token when the project is finished.
 
 .. mermaid::
 
@@ -20,14 +21,9 @@ These tokens are set to expire after 30 days (subject to change) but the expiry 
 Token counts
 ------------
 
-The system has hard limits for how many valid authentication tokens are allowed per user. This limit is different for tokens that are created as a result of sign in operation and for tokens created explicitly; the limit for explicitly created tokens is small but the system never invalidates the tokens unless they expire or they are explicitly revoked. For automatically created tokens the limit is higher but when the limit is reached the system automatically deletes tokens that have been used least recently to avoid going above the limit.
+The system has hard limits for how many valid authentication tokens are allowed per user. This limit is different for tokens that are created as a result of sign in operation and for tokens created explicitly. The max token count is **10** for user created tokens but the system never invalidates the tokens unless they expire or they are explicitly revoked. For automatically created tokens the limit is **1000** but when this limit is reached the system automatically deletes tokens that have been used least recently to avoid going above the limit.
 
 Therefore, an old token can stop working even if it hasn't expired nor been explicitly revoked. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
-
-Note about old authentication tokens
-------------------------------------
-
-The sign in API call used to hand out tokens that were not explicitly tracked and couldn't be individually revoked (prior to 2018-06-25). These old tokens remain valid and become automatically tracked whenever they're used so that they can be revoked. If the tokens have not been used they will not appear in the list of currently valid tokens though they will still work if used unless the revoke all action is used. These tokens, if used, also count towards maximum token quota.
 
 Known limitations
 -----------------

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -1,0 +1,35 @@
+Authentication tokens
+=====================
+
+An authentication token allows a user to programmatically access resources instead of using their username-password. Unlike the username-password combination that has a longer shelf life (in some case, they never expire); you can limit how long an authentication token is valid for or revoke it completely.
+
+.. mermaid::
+
+sequenceDiagram
+    Client->>+Server: Here's my username/password. Give me a token.
+    Server-->>-Client: Your username/password is valid. Here's a token. 
+    Client->>+Server: Here's a token. Show me a list of my resources.
+    Server-->>-Client: Your token is valid. Here's a list of your resources.
+
+How Aiven manages user sessions using authentication tokens
+-----------------------------------------------------------
+
+Each time a user signs in to Aiven either via the web console, Aiven command line client, or direct REST API call, the server creates a new authentication token associated with the user.
+These tokens are set to expire after 30 days (subject to change) but the expiry date is adjusted whenever the token is used so the token may remain valid practically indefinitely if it is used frequently enough.
+
+Token counts
+------------
+
+The system has hard limits for how many valid authentication tokens are allowed per user. This limit is different for tokens that are created as a result of sign in operation and for tokens created explicitly; the limit for explicitly created tokens is small but the system never invalidates the tokens unless they expire or they are explicitly revoked. For automatically created tokens the limit is higher but when the limit is reached the system automatically deletes tokens that have been used least recently to avoid going above the limit.
+
+This behavior for automatically created tokens can result in a token that hasn't expired nor been explicitly revoked to stop working. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
+
+Note about old authentication tokens
+------------------------------------
+
+The sign in API call used to hand out tokens that were not explicitly tracked and couldn't be individually revoked (prior to 2018-06-25). These old tokens remain valid and become automatically tracked whenever they're used so that they can be revoked. If the tokens have not been used they will not appear in the list of currently valid tokens though they will still work if used unless the revoke all action is used. These tokens, if used, also count towards maximum token quota.
+
+Known limitations
+-----------------
+
+Aiven currently only supports authentication tokens that are associated with regular Aiven user accounts and that have the same access level as the user who created the token. There are future plans for allowing tokens that are bound to a project instead and to allow restricting the access scope for tokens.

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -23,7 +23,7 @@ Token counts
 
 The system has hard limits for how many valid authentication tokens are allowed per user. This limit is different for tokens that are created as a result of sign in operation and for tokens created explicitly. The max token count is **10** for user created tokens but the system never invalidates the tokens unless they expire or they are explicitly revoked. For automatically created tokens the limit is **1000** but when this limit is reached the system automatically deletes tokens that have been used least recently to avoid going above the limit.
 
-Therefore, an old token can stop working even if it hasn't expired nor been explicitly revoked. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
+Therefore, an old token can stop working even if it hasn't expired nor been explicitly revoked. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes the current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
 
 Known limitations
 -----------------

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -22,7 +22,7 @@ Token counts
 
 The system has hard limits for how many valid authentication tokens are allowed per user. This limit is different for tokens that are created as a result of sign in operation and for tokens created explicitly; the limit for explicitly created tokens is small but the system never invalidates the tokens unless they expire or they are explicitly revoked. For automatically created tokens the limit is higher but when the limit is reached the system automatically deletes tokens that have been used least recently to avoid going above the limit.
 
-This behavior for automatically created tokens can result in a token that hasn't expired nor been explicitly revoked to stop working. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
+Therefore, an old token can stop working even if it hasn't expired nor been explicitly revoked. To avoid running into problems with this behavior you should always make sure you sign out after sign in instead of just discarding your authentication token. This is mostly relevant for automation which automatically signs in. The Aiven web console automatically revokes current token when signing out and the Aiven command line client also provides a sign out command (avn user logout).
 
 Note about old authentication tokens
 ------------------------------------

--- a/docs/platform/howto/create_authentication_token.rst
+++ b/docs/platform/howto/create_authentication_token.rst
@@ -1,7 +1,8 @@
 Create an authentication token
 ==============================
 
-You can use the Aiven web console to create an authentication token for use with the Aiven command-line interface (CLI) or API.
+You can use the Aiven web console to create an authentication token for use with the Aiven command-line interface (CLI) or API. 
+To learn more about using authentication token for Aiven resources, refer to :doc:`../concepts/authentication-tokens`.
 
 To create an authentication token:
 
@@ -9,11 +10,11 @@ To create an authentication token:
 
 2. Click the user icon in the top-right corner of the page.
 
-3. Click **Authentication** and scroll down to *Authentication tokens*.
+3. Click **Authentication** tab and scroll down to *Authentication tokens*.
 
-4. Click **Generate token**.
+4. Click the **Generate token** button.
 
-5. Enter a description and a time limit for the token. Leave the *Max age hours* field empty if you do not want the token to expire.
+5. Enter a description (optional) and a time limit (optional) for the token. Leave the *Max age hours* field empty if you do not want the token to expire.
 
 6. Click **Generate token**.
 
@@ -22,8 +23,8 @@ To create an authentication token:
    .. note::
        You cannot get the token later after you close this view.
 
-8. Paste the copied token to a text editor.
+8. Store the token safely and treat this just like a password.
 
 9. Click **Close**.
 
-You can now use the authentication token to access your account in the Aiven CLI or API.
+You can now use the authentication token to access your Aiven resources from the CLI or API.


### PR DESCRIPTION
# What changed, and why it matters

[Per this issue](https://github.com/aiven/devportal/issues/189), this PR updates the DevPortal documentation on authentication token concepts and how to create an authentication token on Aiven portal.

Adding the comment from the issue that a redirect from the original article is not necessary:
> Note that there isn't a redirect from the help article to the devportal howto yet, since one doesn't replace the other.
