### PR TITLE
Migrated remove topic prefix MM2

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -125,6 +125,7 @@ entries:
             - file: docs/products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster
             - file: docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow
             - file: docs/products/kafka/kafka-mirrormaker/howto/setup-mirrormaker-monitoring
+            - file: docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix
         - file: docs/products/kafka/kafka-mirrormaker/reference
           title: Reference
           entries:

--- a/docs/products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster.rst
@@ -1,7 +1,7 @@
 Integrate an external Apache Kafka® cluster in Aiven
 ====================================================
 
-Aiven for Apache Kafka® MirrorMaker2 enables the cross-cluster topic replication between any two Apache Kafka® clusters, which can be deployed as Aiven or external services. To enable :doc:`replication flows <setup-replication-flow>` with an external Apache Kafka® cluster you need to define a service integration.
+Aiven for Apache Kafka MirrorMaker 2® enables the cross-cluster topic replication between any two Apache Kafka® clusters, which can be deployed as Aiven or external services. To enable :doc:`replication flows <setup-replication-flow>` with an external Apache Kafka® cluster you need to define a service integration.
 
 Define an external Apache Kafka® service integration via Aiven console
 ----------------------------------------------------------------------

--- a/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
@@ -8,7 +8,7 @@ For most use cases, the extra prefix is not an issue. However, you might be usin
 
 In such cases, to remove the topic prefix, you'll need to change the replication flow ``replication_policy_class`` parameter from the default ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy`` value which includes the source cluster alias in the target topic name to ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy``.
 
-The change can be performed via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli>`. 
+The change can be performed via the `Aiven console <https://console.aiven.io/>`_ by modifying the flow details in the service page "Replication Flow" tab, or via  :doc:`Aiven CLI </docs/tools/cli>` as described in the following section. 
 
 Remove topic prefix from a replication flow
 --------------------------------------------------
@@ -26,6 +26,6 @@ In case you need to revert the policy and include the source cluster alias as to
 
 .. Warning::
 
-    The ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy`` replication policy will **NOT support active-active replication** as the topics will keep the same name and offsets can not be accurately tracked. Creating the same replication flows between a source and a destination will create an infinite loop. 
+    The ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy`` replication policy **doesn't support active-active replication** as the topics keep the same name and offsets can not be accurately tracked. Creating the same replication flows between a source and a destination with ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy`` policy creates an infinite loop. 
     
     For active-active, please use the ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy``.

--- a/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
@@ -1,0 +1,31 @@
+Remove topic prefix when replicating with Apache Kafka MirrorMaker 2®
+======================================================================
+
+When using Apache Kafka MirrorMaker 2® to replicate topics across Apache Kafka® clusters, the default target topic name is in the form ``<SOURCE_CLUSTER_ALIAS>.<TOPIC_NAME>``. 
+E.g. if the source Apache Kafka® clusters alias is ``src-kafka``, replicating the source topic named ``orders`` via Apache Kafka MirrorMaker 2® creates a target topic named ``src-kafka.orders``. 
+
+For most use cases, the extra prefix is not an issue. However, you might be using a backup Apache Kafka® cluster for Disaster Recovery. In this scenario, you want your consumers and producers to be able to switch with minimal downtime; without needing to modify the topic names in their configuration.
+
+In such cases, to remove the topic prefix, you'll need to change the replication flow ``replication_policy_class`` parameter from the default ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy`` value which includes the source cluster alias in the target topic name to ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy``.
+
+The change can be performed via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli>`. 
+
+Remove topic prefix from a replication flow
+--------------------------------------------------
+
+To remove the source cluster alias as topic prefix in an existing replication flow via the :doc:`Aiven CLI </docs/tools/cli>` execute the following command, replacing the ``<MIRRORMAKER_SERVICE_NAME>``, ``<SOURCE_CLUSTER_ALIAS>`` and ``<TARGET_CLUSTER_ALIAS>`` placeholders:
+
+::
+
+    avn MirrorMaker replication-flow update <MIRRORMAKER_SERVICE_NAME> \
+        --source-cluster <SOURCE_CLUSTER_ALIAS>                         \
+        --target-cluster <TARGET_CLUSTER_ALIAS>                         \
+        "{\"replication_policy_class\": \"org.apache.kafka.connect.mirror.IdentityReplicationPolicy\"}"    
+
+In case you need to revert the policy and include the source cluster alias as topic prefix, execute the above command passing the ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy`` value.
+
+.. Warning::
+
+    The ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy`` replication policy will **NOT support active-active replication** as the topics will keep the same name and offsets can not be accurately tracked. Creating the same replication flows between a source and a destination will create an infinite loop. 
+    
+    For active-active, please use the ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy``.

--- a/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/remove-mirrormaker-prefix.rst
@@ -4,7 +4,7 @@ Remove topic prefix when replicating with Apache Kafka MirrorMaker 2®
 When using Apache Kafka MirrorMaker 2® to replicate topics across Apache Kafka® clusters, the default target topic name is in the form ``<SOURCE_CLUSTER_ALIAS>.<TOPIC_NAME>``. 
 E.g. if the source Apache Kafka® clusters alias is ``src-kafka``, replicating the source topic named ``orders`` via Apache Kafka MirrorMaker 2® creates a target topic named ``src-kafka.orders``. 
 
-For most use cases, the extra prefix is not an issue. However, you might be using a backup Apache Kafka® cluster for Disaster Recovery. In this scenario, you want your consumers and producers to be able to switch with minimal downtime; without needing to modify the topic names in their configuration.
+For most use cases, the extra prefix is not an issue. However, you might be using a backup Apache Kafka® cluster for Disaster Recovery. In this scenario, you want your consumers and producers to be able to switch with minimal downtime and without needing to modify the topic names in their configuration.
 
 In such cases, to remove the topic prefix, you'll need to change the replication flow ``replication_policy_class`` parameter from the default ``org.apache.kafka.connect.mirror.DefaultReplicationPolicy`` value which includes the source cluster alias in the target topic name to ``org.apache.kafka.connect.mirror.IdentityReplicationPolicy``.
 

--- a/docs/products/kafka/kafka-mirrormaker/howto/setup-mirrormaker-monitoring.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/setup-mirrormaker-monitoring.rst
@@ -1,14 +1,14 @@
-Setup MirrorMaker2 monitoring
-=============================
+Setup Apache Kafka MirrorMaker 2® monitoring
+============================================
 
-The metrics about replication flows run by Aiven for Apache Kafka® MirrorMaker2 are collected and can be exported via a metric integration.
+The metrics about replication flows run by Aiven for Apache Kafka MirrorMaker 2® are collected and can be exported via a metric integration.
 
 Setup a metric integration to an Aiven for InfluxDB service
 -----------------------------------------------------------
 
-The setup of an integration pushing the Aiven for Apache Kafka® MirrorMaker2 metrics into an existing Aiven for InfluxDB service can be performed via both the `Aiven console <https://console.aiven.io/>`_ or the :ref:`Aiven CLI <avn_service_integration_create>`.
+The setup of an integration pushing the Aiven for Apache Kafka MirrorMaker 2® metrics into an existing Aiven for InfluxDB service can be performed via both the `Aiven console <https://console.aiven.io/>`_ or the :ref:`Aiven CLI <avn_service_integration_create>`.
 
-The following example demonstrate how to push the metrics of an Aiven for Apache Kafka® MirrorMaker2 service named ``mirrormaker-demo`` into an Aiven for InfluxDB® service named ``influxdb-demo`` via the :ref:`Aiven CLI <avn_service_integration_create>`.
+The following example demonstrate how to push the metrics of an Aiven for Apache Kafka MirrorMaker 2® service named ``mirrormaker-demo`` into an Aiven for InfluxDB® service named ``influxdb-demo`` via the :ref:`Aiven CLI <avn_service_integration_create>`.
 
 ::
 
@@ -17,7 +17,7 @@ The following example demonstrate how to push the metrics of an Aiven for Apache
             -s mirrormaker-demo         \
             -d influxdb
 
-Once the integration is created the Apache Kafka® MirrorMaker2 metrics will flow into the Aiven for InfluxDB® service in the measurement named ``kafka_mirrormaker_summary`` and can, for example, be visualised using :doc:`Aiven for Grafana® </docs/products/grafana/index>`
+Once the integration is created the Apache Kafka MirrorMaker 2® metrics will flow into the Aiven for InfluxDB® service in the measurement named ``kafka_mirrormaker_summary`` and can, for example, be visualised using :doc:`Aiven for Grafana® </docs/products/grafana/index>`
 
 .. image:: /images/products/kafka/kafka-mirrormaker/grafana-mirrormaker2-lag.png
    :alt: Grafana Dashboard showing MirrorMaker2 replica lag per topic

--- a/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/setup-replication-flow.rst
@@ -1,19 +1,19 @@
-Set up a MirrorMaker2 replication flow
-======================================
+Set up a Apache Kafka MirrorMaker 2® replication flow
+=====================================================
 
-MirrorMaker2 **replication flows** enable the topics sync from a source Apache Kafka® cluster to a target Apache Kafka® cluster deployed anywhere in the world. Replication flows can be defined against Aiven for Apache Kafka® services or external :doc:`Apache Kafka® clusters <integrate-external-kafka-cluster>`.
+Apache Kafka MirrorMaker 2® **replication flows** enable the topics sync from a source Apache Kafka® cluster to a target Apache Kafka® cluster deployed anywhere in the world. Replication flows can be defined against Aiven for Apache Kafka® services or external :doc:`Apache Kafka® clusters <integrate-external-kafka-cluster>`.
 
 
-Set up a MirrorMaker2 replication flow using Aiven console
-----------------------------------------------------------
+Set up a Apache Kafka MirrorMaker 2® replication flow using Aiven console
+-------------------------------------------------------------------------
 
 To define a replication flow between a source Apache Kafka® cluster and a target cluster:
 
-1. Navigate to the `Aiven Console <https://console.aiven.io/>`_ and select the Aiven for Apache Kafka® MirrorMaker2 service where the replication flow needs to be defined.
+1. Navigate to the `Aiven Console <https://console.aiven.io/>`_ and select the Aiven for Apache Kafka MirrorMaker 2® service where the replication flow needs to be defined.
 
 .. Note::
 
-    If no Aiven for Apache Kafka® MirrorMaker2 are already defined, :doc:`you can create one in the Aiven console <../getting-started>`.
+    If no Aiven for Apache Kafka MirrorMaker 2® are already defined, :doc:`you can create one in the Aiven console <../getting-started>`.
 
 2. In the **Overview** tab scroll to the **Service Integrations** section and click on **Manage integrations**.
 


### PR DESCRIPTION
# What changed, and why it matters

Migrated https://help.aiven.io/en/articles/5411861-removing-kafka-topic-prefix-when-replicating-with-aiven-for-mirrormaker-2 article about MirrorMaker2 topic prefix in replication flows

Fix #504
