### PR TITLE
Kafka sample data

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -89,6 +89,7 @@ entries:
           - file: docs/products/kafka/howto/manage-acls
           - file: docs/products/kafka/howto/monitor-logs-acl-failure
           - file: docs/products/kafka/howto/kafdrop
+      - file: docs/products/kafka/howto/fake-sample-data
       - file: docs/products/kafka/reference
         title: Reference
         entries:

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -7,7 +7,7 @@ Learning streaming is way more fun with data, so to get you started on your Apac
 
     The following example is based on `Docker <https://www.docker.com/>`_ images, which require `Docker <https://www.docker.com/>`_ or `Podman <https://podman.io/>`_ to be executed.
 
-The following example assumes you have an Aiven for Apache Kafka® service running. You can create one following the :doc:`dedicated istructions <../getting-started>`.
+The following example assumes you have an Aiven for Apache Kafka® service running. You can create one following the :doc:`dedicated instructions <../getting-started>`.
 
 
 Fake data generator on Docker
@@ -41,7 +41,7 @@ To learn data streaming, you need a continuous flow of data and for that you can
 * ``my_project_name``: the name of your Aiven project
 * ``my_kafka_service_name``: the name of your Aiven for Apache Kafka instance
 * ``my_topic_name``: the name of the target topic, can be any name
-* ``my_aiven_email``: the email address used as username to log in Aiven services
+* ``my_aiven_email``: the email address used as username to log in to Aiven services
 * ``my_aiven_token``: the access token generated during the previous step
 
 5. Build the Docker image with:
@@ -52,7 +52,7 @@ To learn data streaming, you need a continuous flow of data and for that you can
 
 .. Tip::
 
-    Every time you change any parameters in the ``conf/env.conf`` file, you need to rebuild the Docker image to take them into use.
+    Every time you change any parameters in the ``conf/env.conf`` file, you need to rebuild the Docker image to start using them.
 
 6. Start the streaming data flow with:
 

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -1,7 +1,7 @@
 Fake sample dataset
 ===================
 
-Learning streaming is way more fun with data, so to get you started on your Apache Kafka® journey we help you creating fake streaming data to a topic.
+Learning streaming is way more fun with data, so to get you started on your Apache Kafka® journey we help you create fake streaming data to a topic.
 
 .. Note::
 
@@ -13,7 +13,7 @@ The following example assumes you have an Aiven for Apache Kafka® service runni
 Fake data generator on Docker
 -----------------------------
 
-To learn data streaming, you need a continuous flow of data and for that you can use the `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_. To take the generator into use:
+To learn data streaming, you need a continuous flow of data and for that you can use the `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_. To start using the generator:
 
 1. Clone the repository:
 
@@ -60,4 +60,4 @@ To learn data streaming, you need a continuous flow of data and for that you can
 
     docker run fake-data-producer-for-apache-kafka-docker
 
-7. Once the Docker image is running, check in the target Aiven for Apache Kafka® service that the topic is populated. This can be done with the `Aiven console <https://console.aiven.io/>`_ or using tools like :doc:`kcat <kcat>`.
+7. Once the Docker image is running, check in the target Aiven for Apache Kafka® service that the topic is populated. This can be done with the `Aiven console <https://console.aiven.io/>`_, if the Kafka REST option is enabled, in the *Topics* tab. Alternatively you can use tools like :doc:`kcat <kcat>` to achieve the same.

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -46,6 +46,10 @@ To learn data streaming, you need a continuous flow of data and for that you can
 
     docker build -t fake-data-producer-for-apache-kafka-docker .
 
+.. Tip::
+
+    Every time you change any parameters in the ``conf/env.conf`` file, you need to rebuild the Docker image to take them into use.
+
 6. Start the streaming data flow with:
 
 ::

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -32,6 +32,10 @@ To learn data streaming, you need a continuous flow of data and for that you can
     --max-age-seconds 3600                                  \
     --json | jq -r '.[].full_token'
 
+.. Tip::
+
+    The above command uses `jq <https://stedolan.github.io/jq/>`_ to parse the result of the Aiven CLI command. If you don't have jq installed, you can remove the ``| jq -r '.[].full_token'`` section from the above command and parse the JSON result manually to extract the access token.
+
 4. Edit the ``conf/env.conf`` file filling the following placeholders:
 
 * ``my_project_name``: the name of your Aiven project

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -1,0 +1,55 @@
+Fake sample dataset
+===================
+
+Learning streaming is way more fun with data, so to get you started on your Apache Kafka® journey we help you creating fake streaming data to a topic.
+
+.. Note::
+
+    The following example is based on `Docker <https://www.docker.com/>`_ images, which require `Docker <https://www.docker.com/>`_ or `Podman <https://podman.io/>`_ to be executed.
+
+The following example assumes you have an Aiven for Apache Kafka® service running. You can create one following the :doc:`dedicated istructions <../getting-started>`.
+
+
+Fake data generator on Docker
+-----------------------------
+
+To learn data streaming, you need a continuous flow of data and for that you can use the `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_. To take the generator into use:
+
+1. Clone the repository:
+
+::
+
+    git clone https://github.com/aiven/fake-data-producer-for-apache-kafka-docker
+
+2. Copy the file ``conf/env.conf.sample`` to ``conf/env.conf``
+
+3. Create a new access token via the `Aiven console <https://console.aiven.io/>`_ or the following command in the :doc:`Aiven CLI </docs/tools/cli/account>`, changing the ``max-age-seconds`` appropriately for the duration of your test:
+
+::
+
+    avn user access-token create                            \
+    --description "Token used by Fake data generator"       \
+    --max-age-seconds 3600                                  \
+    --json | jq -r '.[].full_token'
+
+4. Edit the ``conf/env.conf`` file filling the following placeholders:
+
+* ``my_project_name``: the name of your Aiven project
+* ``my_kafka_service_name``: the name of your Aiven for Apache Kafka instance
+* ``my_topic_name``: the name of the target topic, can be any name
+* ``my_aiven_email``: the email address used as username to log in Aiven services
+* ``my_aiven_token``: the access token generated during the previous step
+
+5. Build the Docker image with:
+
+::
+
+    docker build -t fake-data-producer-for-apache-kafka-docker .
+
+6. Start the streaming data flow with:
+
+::
+
+    docker run fake-data-producer-for-apache-kafka-docker
+
+7. Once the Docker image is running, check in the target Aiven for Apache Kafka® service that the topic is populated. This can be done with the `Aiven console <https://console.aiven.io/>`_ or using tools like :doc:`kcat <kcat>`.


### PR DESCRIPTION
# What changed, and why it matters

Tiny new branch to add documentation in devportal to fake datagen for Apache Kafka, so we can refer to it instead of always rewriting the full effort

@TibsAtWork @anelook the steps are the same as in the latest blog draft, we can assume they are working
