### PR TITLE
Added opensearch as Apache Flink intergation and fixed trademarks in Flink docs (not in index page)

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -205,6 +205,7 @@ entries:
           - file: docs/products/flink/howto/create-integration
           - file: docs/products/flink/howto/connect-kafka
           - file: docs/products/flink/howto/connect-pg
+          - file: docs/products/flink/howto/connect-opensearch
           - file: docs/products/flink/howto/create-job
           - file: docs/products/flink/howto/real-time-alerting-solution
           - file: docs/products/flink/howto/real-time-alerting-solution-cli

--- a/docs/products/flink/concepts.rst
+++ b/docs/products/flink/concepts.rst
@@ -1,6 +1,6 @@
-Guides for Flink
-================
+Guides for Apache Flink®
+========================
 
-In this section you can find guides for working with Aiven for Apache Flink.
+In this section you can find guides for working with Aiven for Apache Flink®.
 
 .. tableofcontents::

--- a/docs/products/flink/concepts/checkpoints.rst
+++ b/docs/products/flink/concepts/checkpoints.rst
@@ -1,7 +1,7 @@
 Checkpoints
 ===========
 
-To achieve resilience and fault tolerance, Apache Flink uses *checkpoints* with stateful functions. These checkpoints allow Flink to recover the state and position within the stream and provide failure-free execution for applications.
+To achieve resilience and fault tolerance, Apache Flink® uses *checkpoints* with stateful functions. These checkpoints allow Flink to recover the state and position within the stream and provide failure-free execution for applications.
 
 Essentially, a checkpoint creates a snapshot of the data stream and stores it. The snapshots then provide a mechanism to recover from unexpected job failures. Compared to traditional database systems, checkpoints are closer to recovery logs than to backups.
 
@@ -16,6 +16,6 @@ Essentially, a checkpoint creates a snapshot of the data stream and stores it. T
         id3-->id6[(State backend)];
 
 
-For more information, see the `Apache Flink documentation on checkpoints <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/ops/state/checkpoints/>`_.
+For more information, see the `Apache Flink® documentation on checkpoints <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/ops/state/checkpoints/>`_.
 
 

--- a/docs/products/flink/concepts/event-processing-time.rst
+++ b/docs/products/flink/concepts/event-processing-time.rst
@@ -3,8 +3,8 @@ Event and processing times
 
 Event time refers to when events actually happen, while processing time refers to when events are observed within a system. Various factors affect how events are processed, including shared hardware resources and network congestion, distributed system logic, and variances in the data throughput and order. Because of this, there can be significant differences between the event time and processing time for an event, even though ideally they would be equal.
 
-In Apache Flink, the streamed data does not always arrive in the same order as the events occurred. This means that using processing time in your applications can cause issues in system behavior. For this reason, we recommend that you use event time to process data, as it allows your applications to maintain the correct event sequence throughout the data streaming pipeline. In addition, using event time to process your data allows you to reprocess the data later on with consistent results.
+In Apache Flink®, the streamed data does not always arrive in the same order as the events occurred. This means that using processing time in your applications can cause issues in system behavior. For this reason, we recommend that you use event time to process data, as it allows your applications to maintain the correct event sequence throughout the data streaming pipeline. In addition, using event time to process your data allows you to reprocess the data later on with consistent results.
 
-For more information, see the `Apache Flink documentation on event time and processing time <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/time/>`_.
+For more information, see the `Apache Flink® documentation on event time and processing time <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/time/>`_.
 
 

--- a/docs/products/flink/concepts/flink-for-analysts.rst
+++ b/docs/products/flink/concepts/flink-for-analysts.rst
@@ -1,12 +1,12 @@
-Apache Flink for data analysts
-==============================
+Apache Flink® for data analysts
+===============================
 
-We're actively collating advice, tips, and any limitations of working with Aiven for Apache Flink. Please let us know if you have questions.
+We're actively collating advice, tips, and any limitations of working with Aiven for Apache Flink®. Please let us know if you have questions.
 
 Jobs, tables and tasks
 ----------------------
 
-Some key points to know before you start working with Aiven for Apache Flink:
+Some key points to know before you start working with Aiven for Apache Flink®:
 
 * Jobs and tables cannot be edited after they are created.
 * Running jobs must be manually restarted after powering off the cluster or when changing service plans.
@@ -15,12 +15,12 @@ Some key points to know before you start working with Aiven for Apache Flink:
 Limitations
 -----------
 
-In order to run a stable and reliable service, you will see some differences between Aiven for Apache Flink and a Flink service that you run yourself. The main differences are:
+In order to run a stable and reliable service, you will see some differences between Aiven for Apache Flink® and a Flink service that you run yourself. The main differences are:
 
 * User-defined functions are not supported.
-* The Apache Flink CLI tool cannot be used with this service as it requires access to the JobManager in production, which is currently not exposed to customers.
+* The Apache Flink® CLI tool cannot be used with this service as it requires access to the JobManager in production, which is currently not exposed to customers.
 * Job-level settings are not yet supported. Each job inherits the cluster-level settings.
-* Flame graphs, marked as an experimental feature in Apache Flink 1.13, are not currently enabled in the Flink web UI.
+* Flame graphs, marked as an experimental feature in Apache Flink® 1.13, are not currently enabled in the Flink web UI.
 
 Troubleshooting
 ---------------

--- a/docs/products/flink/concepts/flink-for-operators.rst
+++ b/docs/products/flink/concepts/flink-for-operators.rst
@@ -1,7 +1,7 @@
-Apache Flink for operators
-==========================
+Apache Flink® for operators
+===========================
 
-Aiven for Apache Flink is currently available on AWS or GCP cloud environments; all services and infrastructure are single-tenant and dedicated solely to a single customer. Choose between single-node and three-node Apache Flink clusters, depending on your requirements:
+Aiven for Apache Flink® is currently available on AWS or GCP cloud environments; all services and infrastructure are single-tenant and dedicated solely to a single customer. Choose between single-node and three-node Apache Flink® clusters, depending on your requirements:
 
 * Single-node clusters are not highly available, but support automatic failover. They start from 4GB RAM/2 vCPU and extend up to 32GB/8 vCPU. This setup is a good option for proof of concepts and preliminary testing for development purposes.
 
@@ -12,7 +12,7 @@ Our product page provides you detailed information about the available plans and
 Cluster deployment
 ------------------
 
-Aiven for Apache Flink is configured to use the `HashMap state backend <https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.html>`_. This means that `state <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/stateful-stream-processing/#what-is-state>`_ is stored in memory, which can impact the performance of jobs that require keeping a very large state. We recommend you provision your platform accordingly.
+Aiven for Apache Flink® is configured to use the `HashMap state backend <https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.html>`_. This means that `state <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/stateful-stream-processing/#what-is-state>`_ is stored in memory, which can impact the performance of jobs that require keeping a very large state. We recommend you provision your platform accordingly.
 
 The Flink cluster executes applications in `session mode <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/deployment/overview/#session-mode>`_, so you can deploy multiple Flink jobs on the same cluster to use the available resources effectively.
 
@@ -33,7 +33,7 @@ Cluster restart strategy
 
 The cluster’s default restart strategy is configured to Failure Rate. This controls Flink’s restart behaviour in cases of failures during the execution of jobs. Administrators can overwrite this setting in the advanced configuration options for the service.
 
-For more information on the available options, see the `Apache Flink documentation on fault tolerance <https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/config/#fault-tolerance>`_.
+For more information on the available options, see the `Apache Flink® documentation on fault tolerance <https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/config/#fault-tolerance>`_.
 
 Disaster recovery
 '''''''''''''''''

--- a/docs/products/flink/concepts/kafka-connector-requirements.rst
+++ b/docs/products/flink/concepts/kafka-connector-requirements.rst
@@ -1,11 +1,11 @@
-Requirements for Kafka connectors
-=================================
+Requirements for Apache Kafka® connectors
+=========================================
 
-This article outlines the required settings for standard and upsert Kafka connectors in Aiven for Apache Flink.
+This article outlines the required settings for standard and upsert Kafka connectors in Aiven for Apache Flink®.
 
 .. note::
 
-   Aiven for Apache Flink supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+   Aiven for Apache Flink® supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink® documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
 
 .. list-table::
   :header-rows: 1

--- a/docs/products/flink/concepts/kafka-connectors.rst
+++ b/docs/products/flink/concepts/kafka-connectors.rst
@@ -1,9 +1,9 @@
-Standard and upsert Apache Kafka connectors
-===========================================
+Standard and upsert Apache Kafka® connectors
+============================================
 
-In addition to integration with Apache Kafka through a standard connector, Aiven for Apache Flink also supports the use of *upsert* connectors, which allows you to create changelog-type data streams.
+In addition to integration with Apache Kafka® through a standard connector, Aiven for Apache Flink® also supports the use of *upsert* connectors, which allows you to create changelog-type data streams.
 
-When you integrate a standard Apache Kafka with your Aiven for Apache Flink service, you can use the service to read data from one Kafka topic and write the processed data to another Kafka topic. Each message in the source topic that is processed and written to the sink topic is considered unique and is handled as an individual entry.
+When you integrate a standard Apache Kafka® with your Aiven for Apache Flink® service, you can use the service to read data from one Kafka topic and write the processed data to another Kafka topic. Each message in the source topic that is processed and written to the sink topic is considered unique and is handled as an individual entry.
 
 .. mermaid::
 
@@ -15,7 +15,7 @@ When you integrate a standard Apache Kafka with your Aiven for Apache Flink serv
 
 Another integration approach is upsert, or ``INSERT/UPDATE``, which is a method of updating or deleting data based on the message key. When used as a source, Flink interprets a message that has an existing key as an update and replaces the value for that key. If the key does not exist, it is inserted as new data, and if the message data is null, it is interpreted as a ``DELETE`` operation for that key.
 
-When used as a sink, upsert provides a method to create Kafka compacted topics (see the Log Compaction section in the `Apache Kafka documentation <https://kafka.apache.org/documentation/>`_ for details), containing only the latest value for a specific key and pushing a tombstone message on deletion.
+When used as a sink, upsert provides a method to create Kafka compacted topics (see the Log Compaction section in the `Apache Kafka® documentation <https://kafka.apache.org/documentation/>`_ for details), containing only the latest value for a specific key and pushing a tombstone message on deletion.
 
 .. mermaid::
 

--- a/docs/products/flink/concepts/supported-syntax-sql-editor.rst
+++ b/docs/products/flink/concepts/supported-syntax-sql-editor.rst
@@ -1,12 +1,12 @@
 Built-in SQL editor
 ===================
 
-The Aiven web console includes an SQL editor for data tables and jobs in Aiven for Apache Flink services. This editor gives you access to creating the SQL schema for data tables and the job statements directly in the console.
+The Aiven web console includes an SQL editor for data tables and jobs in Aiven for Apache Flink® services. This editor gives you access to creating the SQL schema for data tables and the job statements directly in the console.
 
 .. image:: /images/products/flink/flink_sql_editor.png
-  :alt: Image of the SQL editor in the Aiven for Apache Flink data table view
+  :alt: Image of the SQL editor in the Aiven for Apache Flink® data table view
 
-The SQL editor in the Aiven web console uses standards-compliant SQL validation. However, this means that the editor does not recognize cases where valid SQL is not currently supported by Apache Flink. At the moment, Aiven for Apache Flink services do not support the following SQL syntax:
+The SQL editor in the Aiven web console uses standards-compliant SQL validation. However, this means that the editor does not recognize cases where valid SQL is not currently supported by Apache Flink®. At the moment, Aiven for Apache Flink® services do not support the following SQL syntax:
 
 * SQL comments
 * empty lines

--- a/docs/products/flink/concepts/watermarks.rst
+++ b/docs/products/flink/concepts/watermarks.rst
@@ -1,12 +1,12 @@
 Watermarks
 ==========
 
-Another concept closely related to windows and event time in Apache Flink is *watermarks*. Flink uses watermarks as a mechanism to measure progress in event time; they flow as part of the data stream, carrying a timestamp that declares the minimum event time reached in the data stream.
+Another concept closely related to windows and event time in Apache Flink® is *watermarks*. Flink uses watermarks as a mechanism to measure progress in event time; they flow as part of the data stream, carrying a timestamp that declares the minimum event time reached in the data stream.
 
 This allows Flink to set points in the stream when all events up to a certain timestamp should have arrived, so that operators can set their internal event time to the value of the watermarks that reach them.
 
 Flink uses *watermark strategies* and *watermark generators* to define how the watermark logic is implemented. For example, you can set Flink to generate watermarks either periodically at specific intervals or when triggered by an event or element with a specific marker.
 
-For more information on watermarks, see the `Apache Flink documentation on generating watermarks <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/event-time/generating_watermarks/>`_.
+For more information on watermarks, see the `Apache Flink® documentation on generating watermarks <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/event-time/generating_watermarks/>`_.
 
 

--- a/docs/products/flink/concepts/windows.rst
+++ b/docs/products/flink/concepts/windows.rst
@@ -1,7 +1,7 @@
 Windows
 =======
 
-Apache Flink uses *windows* to split the streamed data into segments that can be processed. Due to the unbounded nature of data streams, there is never a situation where *all* of the data is available, because you would be waiting indefinitely for new data points to arrive - so instead, windowing offers a way to define a subset of data points that you can then process and analyze.
+Apache Flink® uses *windows* to split the streamed data into segments that can be processed. Due to the unbounded nature of data streams, there is never a situation where *all* of the data is available, because you would be waiting indefinitely for new data points to arrive - so instead, windowing offers a way to define a subset of data points that you can then process and analyze.
 
 A window is created when the first element matching the criteria that is set for it appears. The window's trigger defines when the window is considered ready for processing, and the function set for the window specifies how to process the data. Each window also has an allowed lateness value - this indicates how long new events are accepted for inclusion in the window after the trigger closes it.
 
@@ -9,6 +9,6 @@ For example, you can set 15:00 as the start time for a time-based window, with t
 
 Events may still arrive after the allowed lateness for the window, so your application should include a means of handling those events, for example by logging them separately and then discarding them.
 
-For more information, see the `Apache Flink documentation on windows <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/operators/windows/>`_.
+For more information, see the `Apache Flink® documentation on windows <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/operators/windows/>`_.
 
 

--- a/docs/products/flink/getting-started.rst
+++ b/docs/products/flink/getting-started.rst
@@ -1,19 +1,19 @@
 Getting started
 ===============
 
-The first step in using Aiven for Apache Flink is to create a service. You can do this in the `Aiven web console <https://console.aiven.io/>`_ or with the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
+The first step in using Aiven for Apache Flink® is to create a service. You can do this in the `Aiven web console <https://console.aiven.io/>`_ or with the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
 
-In addition to the Flink service, you also need one or more services to use as the data source and targets. To create an Aiven for Apache Kafka or Aiven for PostgreSQL service for this purpose, :doc:`follow these instructions </docs/platform/howto/create_new_service>`. Once you have created the necessary services, you can then create a Flink job to process the data stream.
+In addition to the Flink service, you also need one or more services to use as the data source and targets. To create an Aiven for Apache Kafka®, Aiven for PostgreSQL® or Aiven for OpenSearch® (to be used only as target) service for this purpose, :doc:`follow these instructions </docs/platform/howto/create_new_service>`. Once you have created the necessary services, you can then create a Flink job to process the data stream.
 
-The following video covers an example use case to give you a demonstration of Aiven for Apache Flink:
+The following video covers an example use case to give you a demonstration of Aiven for Apache Flink®:
 
 .. raw:: html
 
     <iframe width="712" height="400" src="https://youtube.com/embed/j1qNGLKdTJg" frameborder="0" allowfullscreen></iframe>
 
 
-Create an Apache Flink service in the Aiven web console
--------------------------------------------------------
+Create an Apache Flink® service in the Aiven web console
+--------------------------------------------------------
 
 
 1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
@@ -54,7 +54,7 @@ Create an Apache Flink service in the Aiven web console
 Next steps
 ----------
 
-* For details on using the Aiven CLI to create and manage Aiven for Apache Flink services, see the :doc:`Aiven CLI documentation </docs/tools/cli>` and the :doc:`Flink-specific command reference </docs/tools/cli/service/flink>`
+* For details on using the Aiven CLI to create and manage Aiven for Apache Flink® services, see the :doc:`Aiven CLI documentation </docs/tools/cli>` and the :doc:`Flink-specific command reference </docs/tools/cli/service/flink>`
 * :doc:`Create integrations <howto/create-integration>` with Aiven for Apache Kafka and Aiven for PostgreSQL services
-* Create source and sink data tables to map the data for :doc:`Apache Kafka <howto/connect-kafka>` or :doc:`PostgreSQL <howto/connect-pg>` services
-* :doc:`Create Apache Flink jobs <howto/create-job>` to implement your data pipelines
+* Create source and sink data tables to map the data for :doc:`Apache Kafka® <howto/connect-kafka>`,  :doc:`PostgreSQL® <howto/connect-pg>` or :doc:`OpenSearch® <howto/connect-opensearch>` services
+* :doc:`Create Apache Flink® jobs <howto/create-job>` to implement your data pipelines

--- a/docs/products/flink/howto.rst
+++ b/docs/products/flink/howto.rst
@@ -1,7 +1,7 @@
 HowTo
 =====
 
-In this section we have collected some step-by-step instructions to get you started with Flink in your own projects. If there's an example you'd find useful that isn't here, please `open an issue <https://github.com/aiven/devportal>`_ and let us know?
+In this section we have collected some step-by-step instructions to get you started with Apache Flink® in your own projects. If there's an example you'd find useful that isn't here, please `open an issue <https://github.com/aiven/devportal>`_ and let us know?
 
 .. tableofcontents::
 

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -1,16 +1,16 @@
-Create a Kafka-based Apache Flink table
-=======================================
+Create and Apache Kafka®-based Apache Flink® table
+==================================================
 
-To build data pipelines, Apache Flink requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
 
-A Flink table can be defined over an existing or new Aiven for Apache Kafka topic to be able to source or sink streaming data. To define a table over an Apache Kafka topic, the topic name, columns data format and connector type need to be defined, together with the Flink table name to use as reference when building data pipelines.
+A Flink table can be defined over an existing or new Aiven for Apache Kafka® topic to be able to source or sink streaming data. To define a table over an Apache Kafka® topic, the topic name, columns data format and connector type need to be defined, together with the Flink table name to use as reference when building data pipelines.
 
 .. Warning::
 
     In order to define Flink's tables an :doc:`existing integration <create-integration>` needs to be available between the Aiven for Flink service and one or more Aiven for Apache Kafka services.
 
-Create a Kafka-based Apache Flink table with Aiven Console
-----------------------------------------------------------
+Create an Apache Kafka-based Apache Flink table with Aiven Console
+------------------------------------------------------------------
 
 To create a Flink table based on an Aiven for Apache Kafka topic via Aiven console:
 
@@ -24,14 +24,14 @@ To create a Flink table based on an Aiven for Apache Kafka topic via Aiven conso
 
     By default Flink will not be able to automatically create Apache Kafka topics while pushing the first record. To change this behaviour, enable in the Aiven for Apache Kafka target service the ``kafka.auto_create_topics_enable`` option in **Advanced configuration** section.
 
-3. Select the **Kafka connector type**, between the **Apache Kafka SQL Connector** for standard topic reads/writes and the **Upsert Kafka SQL Connector** for changelog type of integration based on message key.
+4. Select the **Kafka connector type**, between the **Apache Kafka SQL Connector** for standard topic reads/writes and the **Upsert Kafka SQL Connector** for changelog type of integration based on message key.
 
 .. Note::   
    For more information on the connector types and the requirements for each of them, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka-connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka-connector-requirements>`.
 
-4. Select the **Key Data Format**, if a value other than **Key not used** is selected, specify the fields from the SQL schema to be used as key. This setting is specifically needed to set message keys for topics acting as target of data pipelines.
+5. Select the **Key Data Format**, if a value other than **Key not used** is selected, specify the fields from the SQL schema to be used as key. This setting is specifically needed to set message keys for topics acting as target of data pipelines.
 
-5. Select the **Value Data Format** based on the message format in the Apache Kafka topic.
+6. Select the **Value Data Format** based on the message format in the Apache Kafka topic.
 
 .. Note::
 
@@ -43,9 +43,9 @@ To create a Flink table based on an Aiven for Apache Kafka topic via Aiven conso
     * `Debezium Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
     * `Debezium JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
 
-6. Define the **Flink table name**; this name will represents the Flink reference to the topic and will be used during the data pipeline definition
+7. Define the **Flink table name**; this name will represents the Flink reference to the topic and will be used during the data pipeline definition
 
-7. Define the **SQL schema**: the SQL schema defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`
+8. Define the **SQL schema**: the SQL schema defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`
 
 Example: Define a Flink table using the standard connector over topic in JSON format   
 ------------------------------------------------------------------------------------
@@ -59,14 +59,14 @@ The Aiven for Apache Kafka service named ``demo-kafka`` contains a topic named  
     {'hostname': 'happy', 'cpu': 'cpu2', 'usage': 77.90860728236156, 'occurred_at': 1637775078964}
     {'hostname': 'dopey', 'cpu': 'cpu4', 'usage': 81.17372993952847, 'occurred_at': 1637775079054}
 
-We can define a ``metrics-in`` Flink table with:
+We can define a ``metrics_in`` Flink table with:
 
 * ``demo-kafka`` as integration service
 * ``metric-topic`` as Apache Kafka topic name
 * **Apache Kafka SQL Connector** since we want to threat every entry as unique events
 * **Key not used** as Key data format
 * **JSON** as Value data format
-* ``metrics-in`` as Flink table name
+* ``metrics_in`` as Flink table name
 * The following as SQL schema
 
 .. code:: sql 

--- a/docs/products/flink/howto/connect-opensearch.rst
+++ b/docs/products/flink/howto/connect-opensearch.rst
@@ -1,0 +1,56 @@
+Create a OpenSearch®-based Apache Flink® table
+==============================================
+
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+
+A Flink table can be defined over an existing or new Aiven for OpenSearch® index to be able to sink streaming data. To define a table over an OpenSearch® index, the index name and columns data format need to be defined, together with the Flink table name to use as reference when building data pipelines.
+
+.. Warning:: 
+
+    Aiven for OpenSearch® can only be used as **target** of a data pipeline. You'll be able to create jobs that write data to an OpenSearch® index. Read data from an OpenSearch® index is currently not possible.
+
+
+Create an OpenSearch®-based Apache Flink® table with Aiven Console
+------------------------------------------------------------------
+
+To create an Apache Flink table based on an Aiven for OpenSearch® index via Aiven console:
+
+1. Navigate to the Aiven for Apache Flink® service page, and open the **Jobs and Data** tab.
+
+.. Warning::
+
+    In order to define Flink's tables an :doc:`existing integration <create-integration>` needs to be available between the Aiven for Flink® service and one or more Aiven for OpenSearch® services.
+
+2. Select the **Data Tables** sub-tab and select the Aiven for OpenSearch® integration to use
+
+3. Select the Aiven for OpenSearch® service and the **index** to be used as target for the data pipeline. If you want to use a new idex not yet existing, write the index name.
+
+4. Define the **Flink table name**; this name will represents the Flink reference to the topic and will be used during the data pipeline definition
+
+5. Define the **SQL schema**: the SQL schema defines the fields pushed for each message in an index
+
+Example: Define an Apache Flink® table to OpenSearch®   
+-----------------------------------------------------
+
+We want to push the result of an Apache Flink® job to an index named  ``metrics`` in an Aiven for OpenSearch® service named ``demo-opensearch``. The job result should generate the following data:
+
+.. code:: text
+
+    {'hostname': 'sleepy', 'cpu': 'cpu3', 'usage': 93.30629927475789, 'occurred_at': 1637775077782}
+    {'hostname': 'dopey', 'cpu': 'cpu4', 'usage': 88.39531418706092, 'occurred_at': 1637775078369}
+    {'hostname': 'happy', 'cpu': 'cpu2', 'usage': 77.90860728236156, 'occurred_at': 1637775078964}
+    {'hostname': 'dopey', 'cpu': 'cpu4', 'usage': 81.17372993952847, 'occurred_at': 1637775079054}
+
+We can define a ``metrics-out`` Apache Flink® table with:
+
+* ``demo-opensearch`` as integration service
+* ``metrics`` as OpenSearch® index name
+* ``metrics_out`` as Flink table name
+* The following as SQL schema
+
+.. code:: sql 
+
+    cpu VARCHAR,
+    hostname VARCHAR,
+    usage DOUBLE,
+    occurred_at BIGINT

--- a/docs/products/flink/howto/connect-pg.rst
+++ b/docs/products/flink/howto/connect-pg.rst
@@ -1,43 +1,43 @@
-Create a PostgreSQL-based Apache Flink table
+Create a PostgreSQL®-based Apache Flink® table
 ==============================================
 
-To build data pipelines, Apache Flink requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
 
-A Flink table can be defined over an existing or new Aiven for PostgreSQL table to be able to source or sink streaming data. To define a table over an PostgreSQL table, the table name and columns data format need to be defined, together with the Flink table name to use as reference when building data pipelines.
-
-.. Warning::
-
-    In order to define Flink's tables an :doc:`existing integration <create-integration>` needs to be available between the Aiven for Flink service and one or more Aiven for PostgreSQL services. Moreover, the source or target PostgreSQL table need to pre-exist when stating the Flink job.
-
-Create a PostgreSQL-based Apache Flink table with Aiven Console
----------------------------------------------------------------
-
-To create a Flink table based on Aiven for PostgreSQL via Aiven console:
-
-1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab
-
-2. Select the **Data Tables** sub-tab and select the Aiven for PostgreSQL integration to use
-
-3. Select the Aiven for PostgreSQL service where the table is stored 
-
-4. Write the PostgreSQL table name in the **JDBC table** field with the format ``schema_name.table_name``
+A Flink table can be defined over an existing or new Aiven for PostgreSQL® table to be able to source or sink streaming data. To define a table over an PostgreSQL® table, the table name and columns data format need to be defined, together with the Flink table name to use as reference when building data pipelines.
 
 .. Warning::
 
-  When using a PostgreSQL table as target of a Flink data pipeline, the table needs to exist before starting the Flink job otherwise it will fail.
+    In order to define Flink's tables an :doc:`existing integration <create-integration>` needs to be available between the Aiven for Flink service and one or more Aiven for PostgreSQL® services. Moreover, the source or target PostgreSQL® table need to pre-exist when stating the Flink job.
+
+Create a PostgreSQL®-based Apache Flink® table with Aiven Console
+------------------------------------------------------------------
+
+To create a Flink table based on Aiven for PostgreSQL® via Aiven console:
+
+1. Navigate to the Aiven for Apache Flink® service page, and open the **Jobs and Data** tab
+
+2. Select the **Data Tables** sub-tab and select the Aiven for PostgreSQL® integration to use
+
+3. Select the Aiven for PostgreSQL® service where the table is stored 
+
+4. Write the PostgreSQL® table name in the **JDBC table** field with the format ``schema_name.table_name``
+
+.. Warning::
+
+  When using a PostgreSQL® table as target of a Flink data pipeline, the table needs to exist before starting the Flink job otherwise it will fail.
 
 5. Define the **Flink table name**; this name will represents the Flink reference to the topic and will be used during the data pipeline definition
 
-7. Define the **SQL schema**: the SQL schema defines the fields retrieved from the PostgreSQL table and additional transformations such as format casting or timestamp extraction.
+7. Define the **SQL schema**: the SQL schema defines the fields retrieved from the PostgreSQL® table and additional transformations such as format casting or timestamp extraction.
 
 .. Note::
 
-  More details on data types mapping between Apache Flink and PostgreSQL are available at the `dedicated JDBC Apache Flink page <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/jdbc/#data-type-mapping>`_.
+  More details on data types mapping between Apache Flink® and PostgreSQL® are available at the `dedicated JDBC Apache Flink® page <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/jdbc/#data-type-mapping>`_.
 
-Example: Define a Flink table over a PostgreSQL table   
------------------------------------------------------
+Example: Define a Flink table over a PostgreSQL® table   
+-------------------------------------------------------
 
-The Aiven for PostgreSQL service named ``pg-demo`` contains a table named ``students`` in the ``public`` schema with the following structure:
+The Aiven for PostgreSQL® service named ``pg-demo`` contains a table named ``students`` in the ``public`` schema with the following structure:
 
 ::
 
@@ -46,8 +46,8 @@ The Aiven for PostgreSQL service named ``pg-demo`` contains a table named ``stud
 
 We can define a ``students_tbl`` Flink table with:
 
-* ``pg-demo`` as the selected Aiven for PostgreSQL service 
+* ``pg-demo`` as the selected Aiven for PostgreSQL® service 
 * ``public.students`` as **JDBC table**
 * ``students_tbl`` as **Name**
-* ``student_id INT, student_name VARCHAR`` as **SQL schema** `mapping the existing columns <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/jdbc/#data-type-mapping>`_ in the PostgreSQL table
+* ``student_id INT, student_name VARCHAR`` as **SQL schema** `mapping the existing columns <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/jdbc/#data-type-mapping>`_ in the PostgreSQL® table
 

--- a/docs/products/flink/howto/create-integration.rst
+++ b/docs/products/flink/howto/create-integration.rst
@@ -1,22 +1,22 @@
 Create Apache Flink integrations
 ===================================
 
-Apache Flink can create streaming data pipelines across services. Currently Aiven for Apache Flink supports Aiven for Apache Kafka and Aiven for PostgreSQL as source and target for Flink jobs.
+Apache Flink can create streaming data pipelines across services. Currently Aiven for Apache Flink® supports Aiven for Apache Kafka® and Aiven for PostgreSQL® as source and target for Flink jobs. Moreover it supports Aiven for OpenSearch® as target.
 
 To create a Aiven for Apache Flink integration via Aiven console:
 
-1. Navigate to the Aiven for Apache Flink service page
+1. Navigate to the Aiven for Apache Flink® service page
 2. If you're setting up the first integration for the selected Aiven for Apache Flink service,  click on the **Get Started** button available under the **Overview** tab.
 
 .. image:: /images/products/flink/integrations-get-started.png
   :scale: 50 %
   :alt: Image of the Aiven for Apache Flink Overview page with focus on the Get Started Icon
 
-3. Select the Aiven for Apache Kafka or Aiven for PostgreSQL service to integrate, and click on the **Integrate** button
+3. Select the Aiven for Apache Kafka®, Aiven for PostgreSQL or Aiven for OpenSearch® service to integrate, and click on the **Integrate** button
 
 .. image:: /images/products/flink/integrations-select-services.png
    :scale: 50 %
-   :alt: Image of the Aiven for Apache Flink Integration page showing an Aiven for Apache Kafka and an Aiven for PostgreSQL services 
+   :alt: Image of the Aiven for Apache Flink Integration page showing an Aiven for Apache Kafka® and an Aiven for PostgreSQL® services 
 
 4. Additional integrations can be added using the *+* button in the **Data Flow** section
 

--- a/docs/products/flink/howto/create-job.rst
+++ b/docs/products/flink/howto/create-job.rst
@@ -1,27 +1,28 @@
-Create an Apache Flink job
+Create an Apache Flink® job
 =================================
 
 Prerequisites
 '''''''''''''
 
-To build data pipelines, Apache Flink requires source or target data structures to be mapped as Flink tables. 
-Currently Apache Flink tables can be defined over:
+To build data pipelines, Apache Flink® requires source or target data structures to be mapped as Flink tables. 
+Currently Apache Flink® tables can be defined over:
 
-* :doc:`Aiven for Apache Kafka topics <connect-kafka>` 
-* :doc:`Aiven for PostgreSQL tables <connect-pg>`.
+* :doc:`Aiven for Apache Kafka® topics <connect-kafka>` 
+* :doc:`Aiven for PostgreSQL® tables <connect-pg>`.
+* :doc:`Aiven for OpenSearch® tables <connect-pg>`.
 
 Create a Flink job via Aiven Console
 '''''''''''''''''''''''''''''''''''''
 
-To create a new data pipeline defined by an Apache Flink job via the Aiven Console:
+To create a new data pipeline defined by an Apache Flink® job via the Aiven Console:
 
-1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab
+1. Navigate to the Aiven for Apache Flink® service page, and open the **Jobs and Data** tab
 
 2. Select the **Create SQL job** sub-tab
 
-3. Define the Apache Flink **Job Name**, the job name is the main reference to the data pipeline and can be used to manage the job and to view its details in the Apache Flink console
+3. Define the Apache Flink® **Job Name**, the job name is the main reference to the data pipeline and can be used to manage the job and to view its details in the Apache Flink® console
 
-4. Select the list of Apache Flink source and target **tables**. 
+4. Select the list of Apache Flink® source and target **tables**. 
 
 .. Note::
 
@@ -31,25 +32,25 @@ To create a new data pipeline defined by an Apache Flink job via the Aiven Conso
 
 .. Tip::
 
-  Apache Flink SQL is ANSI-SQL 2011 compliant, the following are few links with further SQL reading from the Flink documentation:
+  Apache Flink® SQL is ANSI-SQL 2011 compliant, the following are few links with further SQL reading from the Flink documentation:
 
   * the available `functions and expected parameters <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/functions/systemfunctions/>`_
   * the `Windowing functions <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/window-tvf/>`_ and `windowing aggregation <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/window-agg/>`_
   * the `Joins <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/joins/>`_ and `time window joins <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/window-join/>`_
   * the `with clause <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/with/>`_ helpful to divide a statement in sub-statements
 
-6. Run the job and check the results in the Aiven for Apache Kafka topic or Aiven for PostgreSQL table pointed by the target Apache Flink table.
+6. Run the job and check the results in the Aiven for Apache Kafka topic or Aiven for PostgreSQL table pointed by the target Apache Flink® table.
 
-Example: Define and Apache Flink job for basic data filtering
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Example: Define and Apache Flink® job for basic data filtering
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-In this example we'll define an Apache Flink streaming job, named ``JobExample``, performing a basic filtering of the data available in the Apache Flink table named ``KCpuIn``, and insert the results into the ``KAlert`` table. 
+In this example we'll define an Apache Flink® streaming job, named ``JobExample``, performing a basic filtering of the data available in the Apache Flink® table named ``KCpuIn``, and insert the results into the ``KAlert`` table. 
 
 .. Note::
 
-  When defining Apache Flink jobs, the input and output objects are Apache Flink table, enabling to decouple the data pipeline definition from the source or sink technologies. If a change in the backend technology is needed, it can be handled by redefining the Apache Flink table, without needing to change the job.
+  When defining Apache Flink® jobs, the input and output objects are Apache Flink® table, enabling to decouple the data pipeline definition from the source or sink technologies. If a change in the backend technology is needed, it can be handled by redefining the Apache Flink® table, without needing to change the job.
 
-We can define the Apache Flink job named ``JobExample`` with:
+We can define the Apache Flink® job named ``JobExample`` with:
 
 * ``JobExample`` as **Job Name**
 * ``KCpuIn, KAlert`` as **Tables**
@@ -59,7 +60,7 @@ The image below shows the Aiven console page with the filled details.
 
 .. image:: /images/products/flink/create-job.png
   :scale: 80 %
-  :alt: Image of the Aiven for Apache Flink Jobs and Data tab when creating a Flink job
+  :alt: Image of the Aiven for Apache Flink® Jobs and Data tab when creating a Flink job
 
 The result of the data pipeline is the target table ``KAlert`` being populated with data exceeding the ``70`` threshold. 
-Depending on the Apache Flink table definition the data could either be written to an Apache Kafka topic or a PostgreSQL table where the data pipeline results can be verified.
+Depending on the Apache Flink® table definition the data could either be written to an Apache Kafka topic or a PostgreSQL table where the data pipeline results can be verified.

--- a/docs/products/flink/howto/real-time-alerting-solution-cli.rst
+++ b/docs/products/flink/howto/real-time-alerting-solution-cli.rst
@@ -1,25 +1,25 @@
 Create a real-time alerting solution - Aiven CLI
 ================================================
 
-This Aiven CLI tutorial shows you an example of how to combine Aiven for Apache Flink with Aiven for Apache Kafka and Aiven for PostgreSQL services to create a solution that provides real-time alerting data for CPU loads.
+This Aiven CLI tutorial shows you an example of how to combine Aiven for Apache Flink® with Aiven for Apache Kafka® and Aiven for PostgreSQL® services to create a solution that provides real-time alerting data for CPU loads.
 
 Architecture overview
 ---------------------
 
-This example involves creating an Apache Kafka source topic that provides a stream of metrics data, a PostgreSQL database that contains data on the alerting thresholds, and an Apache Flink service that combines these two services and pushes the filtered data to a separate Apache Kafka topic or PostgreSQL table.
+This example involves creating an Apache Kafka® source topic that provides a stream of metrics data, a PostgreSQL® database that contains data on the alerting thresholds, and an Apache Flink® service that combines these two services and pushes the filtered data to a separate Apache Kafka® topic or PostgreSQL® table.
 
 .. mermaid::
 
     graph LR;
 
         id1(Kafka)-- metrics stream -->id3(Flink);
-        id2(PostgreSQL)-- threshold data -->id3;
+        id2(PostgreSQL®)-- threshold data -->id3;
         id3-. filtered data .->id4(Kafka);
-        id3-. filtered data .->id5(PostgreSQL);
+        id3-. filtered data .->id5(PostgreSQL®);
 
-The article includes the steps that you need when using the `Aiven CLI <https://github.com/aiven/aiven-client>`_ along with a few different samples of how you can set thresholds for alerts. For connecting to your PostgreSQL service, this example uses the Aiven CLI calling `psql <https://www.postgresql.org/docs/current/app-psql.html>`_, but you can also use other tools if you prefer.
+The article includes the steps that you need when using the `Aiven CLI <https://github.com/aiven/aiven-client>`_ along with a few different samples of how you can set thresholds for alerts. For connecting to your PostgreSQL® service, this example uses the Aiven CLI calling `psql <https://www.postgresql.org/docs/current/app-psql.html>`_, but you can also use other tools if you prefer.
 
-In addition, the instructions show you how to use a separate Python-based tool, `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_, to create sample records for your Apache Kafka topic that provides the streamed data.
+In addition, the instructions show you how to use a separate Python-based tool, `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_, to create sample records for your Apache Kafka® topic that provides the streamed data.
 
 
 Requirements
@@ -27,8 +27,8 @@ Requirements
 
 * An Aiven account
 * `Aiven CLI <https://github.com/aiven/aiven-client>`_
-* `psql <https://www.postgresql.org/docs/current/app-psql.html>`_ to connect to PostgreSQL services
-* `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ and `Docker <https://www.docker.com/>`_ to generate sample data (optional)
+* `psql <https://www.postgresql.org/docs/current/app-psql.html>`_ to connect to PostgreSQL® services
+* `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ and `Docker <https://www.docker.com/>`_ to generate sample data (optional)
 
 
 Set up Aiven services
@@ -37,7 +37,7 @@ Set up Aiven services
 .. note::
    The commands given in this example use ``business-4`` service plans, but you can use any other service plan instead if you prefer.
 
-1. Using the `Aiven CLI <https://github.com/aiven/aiven-client>`_, run the following command to create an Aiven for Apache Kafka service named ``demo-kafka``:
+1. Using the `Aiven CLI <https://github.com/aiven/aiven-client>`_, run the following command to create an Aiven for Apache Kafka® service named ``demo-kafka``:
 
    ::
 
@@ -50,7 +50,7 @@ Set up Aiven services
           -c schema_registry=true                 \
           --project PROJECT_NAME
 
-#. Run the following command to create an Aiven for PostgreSQL service named ``demo-postgresql``:
+#. Run the following command to create an Aiven for PostgreSQL® service named ``demo-postgresql``:
 
    ::
 
@@ -60,7 +60,7 @@ Set up Aiven services
           --plan business-4                       \
           --project PROJECT_NAME
 
-#. Run the following command to create an Aiven for Apache Flink service named ``demo-flink``:
+#. Run the following command to create an Aiven for Apache Flink® service named ``demo-flink``:
 
    ::
 
@@ -107,7 +107,7 @@ Set up sample data
 
 These steps show you how to create sample records to provide streamed data that is processed by the data pipelines presented in this tutorial. You can also use other existing data, although many of the examples in this tutorial are based on the use of this sample data.
 
-Before you start, clone the `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ Git repository to your computer.
+Before you start, clone the `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ Git repository to your computer.
 
 1. Follow `these instructions <https://developer.aiven.io/docs/tools/cli/user/user-access-token.html#manage-access-tokens>`_ to create an authentication token for your Aiven account.
 
@@ -319,10 +319,10 @@ This uses the same ``CPU_IN`` Kafka source table that you created in the previou
    When the job is running, you should start to see messages indicating hosts with high CPU loads in the ``cpu_load_stats_agg`` topic of your ``demo-kafka`` service.
 
 
-Create a Flink SQL job using PostgreSQL thresholds
+Create a Flink SQL job using PostgreSQL® thresholds
 --------------------------------------------------
 
-This setup uses host-specific thresholds that are stored in PostgreSQL as a basis for determining instances of high CPU load.
+This setup uses host-specific thresholds that are stored in PostgreSQL® as a basis for determining instances of high CPU load.
 
 .. mermaid::
 
@@ -332,7 +332,7 @@ This setup uses host-specific thresholds that are stored in PostgreSQL as a basi
 		id2(PosgreSQL source)-- host-specific thresholds -->id3;
         id3-- host with high CPU -->id4(Kafka sink);
 
-This uses the same ``CPU_IN`` Kafka source table that you created earlier. In addition, you need a new sink table to send the processed messages to a separate Kafka topic, a PostgreSQL source table to hold the threshold data, and a new Flink job to process the data.
+This uses the same ``CPU_IN`` Kafka source table that you created earlier. In addition, you need a new sink table to send the processed messages to a separate Kafka topic, a PostgreSQL® source table to hold the threshold data, and a new Flink job to process the data.
 
 1. In the Aiven CLI, run the following command to connect to the ``demo-postgresql`` service:
    
@@ -340,7 +340,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 	  
       avn service cli demo-postgresql --project PROJECT_NAME
    
-#. Enter the following commands to set up the PostgreSQL table containing the threshold values:
+#. Enter the following commands to set up the PostgreSQL® table containing the threshold values:
    
    .. literalinclude:: /code/products/flink/pgthresholds_cpu-thresholds_table.md
       :language: sql
@@ -365,7 +365,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
       sneezy   |     80
       dopey    |     90
 
-#. Create a PostgreSQL table named ``SOURCE_THRESHOLDS``.
+#. Create a PostgreSQL® table named ``SOURCE_THRESHOLDS``.
 
    .. list-table::
      :header-rows: 1
@@ -445,13 +445,13 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 
    The new job is added and starts automatically once a task slot is available.
 
-   When the job is running, you should start to see messages indicating CPU loads that exceed the PostgreSQL-defined thresholds in the ``cpu_load_stats_real_filter_pg`` topic of your ``demo-kafka`` service.
+   When the job is running, you should start to see messages indicating CPU loads that exceed the PostgreSQL®-defined thresholds in the ``cpu_load_stats_real_filter_pg`` topic of your ``demo-kafka`` service.
 
 
-Create an aggregated data pipeline with Kafka and PostgreSQL
+Create an aggregated data pipeline with Kafka and PostgreSQL®
 ------------------------------------------------------------
 
-This setup highlights the instances where the average CPU load over a :doc:`windowed interval </docs/products/flink/concepts/windows>` exceeds the threshold and stores the results in PostgreSQL.
+This setup highlights the instances where the average CPU load over a :doc:`windowed interval </docs/products/flink/concepts/windows>` exceeds the threshold and stores the results in PostgreSQL®.
 
 .. mermaid::
 
@@ -459,10 +459,10 @@ This setup highlights the instances where the average CPU load over a :doc:`wind
 
         id1(Kafka source)-- timestamped metrics -->id3(Flink job);
 		id2(PosgreSQL source)-- host-specific thresholds -->id3;
-        id3-- high 30-second average CPU -->id4(PostgreSQL sink);
+        id3-- high 30-second average CPU -->id4(PostgreSQL® sink);
 
 
-This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` PostgreSQL source table that you created earlier. In addition, you need a new sink PostgreSQL table to store the processed data and a new Flink job to process the data.
+This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` PostgreSQL® source table that you created earlier. In addition, you need a new sink PostgreSQL® table to store the processed data and a new Flink job to process the data.
 
 1. In the Aiven CLI, run the following command to connect to the ``demo-postgresql`` service:
    
@@ -470,12 +470,12 @@ This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` Postg
 	  
       avn service cli demo-postgresql --project PROJECT_NAME
    
-#. Enter the following command to set up the PostgreSQL table for storing the results:
+#. Enter the following command to set up the PostgreSQL® table for storing the results:
    
    .. literalinclude:: /code/products/flink/combined_cpu-load-stats-agg-pg_table.md
       :language: sql
    
-#. Create a PostgreSQL table named ``CPU_OUT_AGG_PG``.
+#. Create a PostgreSQL® table named ``CPU_OUT_AGG_PG``.
 
    .. list-table::
      :header-rows: 1

--- a/docs/products/flink/howto/real-time-alerting-solution.rst
+++ b/docs/products/flink/howto/real-time-alerting-solution.rst
@@ -1,33 +1,33 @@
 Create a real-time alerting solution - Aiven console
 ====================================================
 
-This tutorial shows you an example of how to combine Aiven for Apache Flink with Aiven for Apache Kafka and Aiven for PostgreSQL services to create a solution that provides real-time alerting data for CPU loads.
+This tutorial shows you an example of how to combine Aiven for Apache Flink® with Aiven for Apache Kafka® and Aiven for PostgreSQL® services to create a solution that provides real-time alerting data for CPU loads.
 
 Architecture overview
 ---------------------
 
-This example involves creating an Apache Kafka source topic that provides a stream of metrics data, a PostgreSQL database that contains data on the alerting thresholds, and an Apache Flink service that combines these two services and pushes the filtered data to a separate Apache Kafka topic or PostgreSQL table.
+This example involves creating an Apache Kafka® source topic that provides a stream of metrics data, a PostgreSQL® database that contains data on the alerting thresholds, and an Apache Flink® service that combines these two services and pushes the filtered data to a separate Apache Kafka® topic or PostgreSQL® table.
 
 .. mermaid::
 
     graph LR;
 
         id1(Kafka)-- metrics stream -->id3(Flink);
-        id2(PostgreSQL)-- threshold data -->id3;
+        id2(PostgreSQL®)-- threshold data -->id3;
         id3-. filtered data .->id4(Kafka);
-        id3-. filtered data .->id5(PostgreSQL);
+        id3-. filtered data .->id5(PostgreSQL®);
 
-The article includes the steps that you need when using the `Aiven web console <https://console.aiven.io>`_ along with a few different samples of how you can set thresholds for alerts. For connecting to your PostgreSQL service, this example uses the `Aiven CLI <https://github.com/aiven/aiven-client>`_ calling `psql <https://www.postgresql.org/docs/current/app-psql.html>`_, but you can also use other tools if you prefer.
+The article includes the steps that you need when using the `Aiven web console <https://console.aiven.io>`_ along with a few different samples of how you can set thresholds for alerts. For connecting to your PostgreSQL® service, this example uses the `Aiven CLI <https://github.com/aiven/aiven-client>`_ calling `psql <https://www.postgresql.org/docs/current/app-psql.html>`_, but you can also use other tools if you prefer.
 
-In addition, the instructions show you how to use a separate Python-based tool, `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_, to create sample records for your Apache Kafka topic that provides the streamed data.
+In addition, the instructions show you how to use a separate Python-based tool, `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_, to create sample records for your Apache Kafka® topic that provides the streamed data.
 
 
 Requirements
 ------------
 
 * An Aiven account
-* `Aiven CLI <https://github.com/aiven/aiven-client>`_ and `psql <https://www.postgresql.org/docs/current/app-psql.html>`_ to connect to PostgreSQL services
-* `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ and `Docker <https://www.docker.com/>`_ to generate sample data (optional)
+* `Aiven CLI <https://github.com/aiven/aiven-client>`_ and `psql <https://www.postgresql.org/docs/current/app-psql.html>`_ to connect to PostgreSQL® services
+* `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ and `Docker <https://www.docker.com/>`_ to generate sample data (optional)
 
 
 Set up Aiven services
@@ -35,27 +35,27 @@ Set up Aiven services
 
 1. Follow the steps in :doc:`this article </docs/platform/howto/create_new_service>` to create these services:
 
-   - An Aiven for Apache Kafka service with the *Business-4* service plan, named ``demo-kafka`` (this streams the CPU load)
-   - An Aiven for PostgreSQL service with the *Business-4* service plan, named ``demo-postgresql`` (this defines the alerting threshold values)
-   - An Aiven for Apache Flink service with the *Business-4* service plan, named ``demo-flink`` (this analyzes the data stream to find CPUs where the average load exceeds the threshold values)
+   - An Aiven for Apache Kafka® service with the *Business-4* service plan, named ``demo-kafka`` (this streams the CPU load)
+   - An Aiven for PostgreSQL® service with the *Business-4* service plan, named ``demo-postgresql`` (this defines the alerting threshold values)
+   - An Aiven for Apache Flink® service with the *Business-4* service plan, named ``demo-flink`` (this analyzes the data stream to find CPUs where the average load exceeds the threshold values)
 
 #. Select the ``demo-kafka`` service and change the following settings on the *Overview* page:
 
    - **Kafka REST API (Karapace)** > **Enable**
 
-     This setting allows you to integrate your Aiven for Apache Kafka service with Aiven for Apache Flink, and you can also use the API to view the data in your Apache Kafka topics.
+     This setting allows you to integrate your Aiven for Apache Kafka® service with Aiven for Apache Flink®, and you can also use the API to view the data in your Apache Kafka® topics.
 
    - **Advanced configuration** > **Add configuration option** > ``kafka.auto_create_topics_enable``, switch the setting on and then click **Save advanced configuration**
 
-     This setting allows you to create new Apache Kafka topics as you configure your Apache Flink data tables, so that you do not need to create the topics in advance.
+     This setting allows you to create new Apache Kafka® topics as you configure your Apache Flink® data tables, so that you do not need to create the topics in advance.
 
 #. Select the ``demo-flink`` service and add the service integrations:
 
    a. Click **Get started** on the banner at the top of the *Overview* page.
-   b. Select **Aiven for Apache Kafka** and then select the ``demo-kafka`` service.
+   b. Select **Aiven for Apache Kafka®** and then select the ``demo-kafka`` service.
    c. Click **Integrate**.
    d. Click the **+** icon under *Data Flow*.
-   e. Select **Aiven for PostgreSQL** and then select the ``demo-postgresql`` service.
+   e. Select **Aiven for PostgreSQL®** and then select the ``demo-postgresql`` service.
    f. Click **Integrate**.
 
 
@@ -64,7 +64,7 @@ Set up sample data
 
 These steps show you how to create sample records to provide streamed data that is processed by the data pipelines presented in this tutorial. You can also use other existing data, although many of the examples in this tutorial are based on the use of this sample data.
 
-Before you start, clone the `Dockerized fake data producer for Aiven for Apache Kafka <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ Git repository to your computer.
+Before you start, clone the `Dockerized fake data producer for Aiven for Apache Kafka® <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ Git repository to your computer.
 
 1. Follow :doc:`these instructions </docs/platform/howto/create_authentication_token>` to create an authentication token for your Aiven account.
 
@@ -116,7 +116,7 @@ This setup uses a fixed threshold to filter any instances of high CPU load to a 
 
 For this setup, you need to configure a source table to read the metrics data from your Kafka topic, a sink table to send the processed messages to a separate Kafka topic, and a Flink job to process the data.
 
-1. In the Aiven web console, select the **Jobs & Data** tab in your Aiven for Apache Flink service.
+1. In the Aiven web console, select the **Jobs & Data** tab in your Aiven for Apache Flink® service.
 
 #. Go to the **Data Tables** subtab.
 
@@ -124,7 +124,7 @@ For this setup, you need to configure a source table to read the metrics data fr
 
    a. Select your Kafka service.
    b. Select ``cpu_load_stats_real`` as the topic.
-   c. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Apache Kafka® SQL Connector** as the connector type.
    d. Select **Key not used** as the key.
    e. Select **JSON** as the value data format.
    f. Enter ``CPU_IN`` as the name
@@ -139,7 +139,7 @@ For this setup, you need to configure a source table to read the metrics data fr
 
    a. Select your Kafka service.
    b. Enter ``cpu_load_stats_real_filter`` as the topic.
-   c. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Apache Kafka® SQL Connector** as the connector type.
    d. Select **Key not used** as the key.
    e. Select **JSON** as the value data format.
    f. Enter ``CPU_OUT_FILTER`` as the name
@@ -181,7 +181,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created in the previou
 
    a. Select your Kafka service.
    b. Enter ``cpu_load_stats_agg`` as the topic.
-   c. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Apache Kafka® SQL Connector** as the connector type.
    d. Select **Key not used** as the key.
    e. Select **JSON** as the value data format.
    f. Enter ``CPU_OUT_AGG`` as the name
@@ -204,10 +204,10 @@ This uses the same ``CPU_IN`` Kafka source table that you created in the previou
    When the job is running, you should start to see messages indicating hosts with high CPU loads in the ``cpu_load_stats_agg`` topic of your ``demo-kafka`` service.
 
 
-Create a Flink SQL job using PostgreSQL thresholds
+Create a Flink SQL job using PostgreSQL® thresholds
 --------------------------------------------------
 
-This setup uses host-specific thresholds that are stored in PostgreSQL as a basis for determining instances of high CPU load.
+This setup uses host-specific thresholds that are stored in PostgreSQL® as a basis for determining instances of high CPU load.
 
 .. mermaid::
 
@@ -217,10 +217,10 @@ This setup uses host-specific thresholds that are stored in PostgreSQL as a basi
 		id2(PosgreSQL source)-- host-specific thresholds -->id3;
         id3-- host with high CPU -->id4(Kafka sink);
 
-This uses the same ``CPU_IN`` Kafka source table that you created earlier. In addition, you need a new sink table to send the processed messages to a separate Kafka topic, a source table to get the PostgreSQL threshold data, and a new Flink job to process the data.
+This uses the same ``CPU_IN`` Kafka source table that you created earlier. In addition, you need a new sink table to send the processed messages to a separate Kafka topic, a source table to get the PostgreSQL® threshold data, and a new Flink job to process the data.
 
 .. note::
-   For creating and configuring the tables in your PostgreSQL service, these steps use the Aiven CLI to call ``psql``. You can instead use other tools to complete these steps if you prefer.
+   For creating and configuring the tables in your PostgreSQL® service, these steps use the Aiven CLI to call ``psql``. You can instead use other tools to complete these steps if you prefer.
 
 1. In the Aiven CLI, run the following command to connect to the ``demo-postgresql`` service:
    
@@ -228,7 +228,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 	  
       avn service cli demo-postgresql --project PROJECT_NAME
    
-#. Enter the following commands to set up the PostgreSQL table containing the threshold values:
+#. Enter the following commands to set up the PostgreSQL® table containing the threshold values:
    
    .. literalinclude:: /code/products/flink/pgthresholds_cpu-thresholds_table.md
       :language: sql
@@ -255,7 +255,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 
 #. In the Aiven web console, go to the **Jobs & Data** > **Data Tables** tab for your Flink service.
 
-#. Select your PostgreSQL service, enter ``SOURCE_THRESHOLDS`` as the name, select ``public.cpu_thresholds`` as the table, and enter the following as the SQL schema, then click **Create Table**:
+#. Select your PostgreSQL® service, enter ``SOURCE_THRESHOLDS`` as the name, select ``public.cpu_thresholds`` as the table, and enter the following as the SQL schema, then click **Create Table**:
    
    .. literalinclude:: /code/products/flink/pgthresholds_source-thresholds_table.md
       :language: sql
@@ -264,7 +264,7 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 
    a. Select your Kafka service.
    b. Select ``cpu_load_stats_real_filter_pg`` as the topic.
-   c. Select **Apache Kafka SQL Connector** as the connector type.
+   c. Select **Apache Kafka® SQL Connector** as the connector type.
    d. Select **Key not used** as the key.
    e. Select **JSON** as the value data format.
    f. Enter ``CPU_OUT_FILTER_PG`` as the name
@@ -284,13 +284,13 @@ This uses the same ``CPU_IN`` Kafka source table that you created earlier. In ad
 
    The new job is added to the list on the **Jobs** subtab and starts automatically once a task slot is available. The status changes to *RUNNING* once the job starts.
 
-   When the job is running, you should start to see messages indicating CPU loads that exceed the PostgreSQL-defined thresholds in the ``cpu_load_stats_real_filter_pg`` topic of your ``demo-kafka`` service.
+   When the job is running, you should start to see messages indicating CPU loads that exceed the PostgreSQL®-defined thresholds in the ``cpu_load_stats_real_filter_pg`` topic of your ``demo-kafka`` service.
 
 
-Create an aggregated data pipeline with Kafka and PostgreSQL
+Create an aggregated data pipeline with Kafka and PostgreSQL®
 ------------------------------------------------------------
 
-This setup highlights the instances where the average CPU load over a :doc:`windowed interval </docs/products/flink/concepts/windows>` exceeds the threshold and stores the results in PostgreSQL.
+This setup highlights the instances where the average CPU load over a :doc:`windowed interval </docs/products/flink/concepts/windows>` exceeds the threshold and stores the results in PostgreSQL®.
 
 .. mermaid::
 
@@ -298,12 +298,12 @@ This setup highlights the instances where the average CPU load over a :doc:`wind
 
         id1(Kafka source)-- timestamped metrics -->id3(Flink job);
 		id2(PosgreSQL source)-- host-specific thresholds -->id3;
-        id3-- high 30-second average CPU -->id4(PostgreSQL sink);
+        id3-- high 30-second average CPU -->id4(PostgreSQL® sink);
 
-This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` PostgreSQL source table that you created earlier. In addition, you need a new sink table to store the processed data in PostgreSQL and a new Flink job to process the data.
+This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` PostgreSQL® source table that you created earlier. In addition, you need a new sink table to store the processed data in PostgreSQL® and a new Flink job to process the data.
 
 .. note::
-   For creating and configuring the tables in your PostgreSQL service, these steps use the Aiven CLI to call ``psql``. You can instead use other tools to complete these steps if you prefer.
+   For creating and configuring the tables in your PostgreSQL® service, these steps use the Aiven CLI to call ``psql``. You can instead use other tools to complete these steps if you prefer.
 
 1. In the Aiven CLI, run the following command to connect to the ``demo-postgresql`` service:
    
@@ -311,14 +311,14 @@ This uses the same ``CPU_IN`` Kafka source table and ``SOURCE_THRESHOLDS`` Postg
 	  
       avn service cli demo-postgresql --project PROJECT_NAME
    
-#. Enter the following command to set up the PostgreSQL table for storing the results:
+#. Enter the following command to set up the PostgreSQL® table for storing the results:
    
    .. literalinclude:: /code/products/flink/combined_cpu-load-stats-agg-pg_table.md
       :language: sql
    
 #. In the Aiven web console, go to the **Jobs & Data** > **Data Tables** tab for your Flink service.
    
-#. Select your PostgreSQL service, enter ``CPU_OUT_AGG_PG`` as the name, select ``cpu_load_stats_agg_pg`` as the table, and enter the following as the SQL schema, then click **Create Table**:
+#. Select your PostgreSQL® service, enter ``CPU_OUT_AGG_PG`` as the name, select ``cpu_load_stats_agg_pg`` as the table, and enter the following as the SQL schema, then click **Create Table**:
    
    .. literalinclude:: /code/products/flink/combined_cpu-out-agg-pg_table.md
       :language: sql

--- a/docs/products/flink/reference.rst
+++ b/docs/products/flink/reference.rst
@@ -1,6 +1,6 @@
 Reference
 =========
 
-Additional reference information for Aiven for Apache Flink:
+Additional reference information for Aiven for Apache Flink®:
 
 .. tableofcontents::


### PR DESCRIPTION
# What changed, and why it matters

Opensearch has been released as Flink sink, added docs and fixed trademark issues in Flink docs (missing the index page as of now since once we change that, also the page three on the left will show the ®)