### PR TITLE
add/MySQL: link from homepage to landing page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -101,6 +101,13 @@ Learn about the Aiven platform
 
     |icon-mysql| **MySQL** Popular and much-loved relational database platform.
 
+    +++
+
+    .. link-button:: docs/products/mysql/index
+        :type: ref
+        :text: Read more
+        :classes: stretched-link
+
     ---
 
     |icon-influxdb| **InfluxDB** Specialist time series database, with good tooling support.


### PR DESCRIPTION
# What's wrong?
Recently added landing page for MySQL is missing the links from our main [page](https://developer.aiven.io/)

# URL of affected page, and any other information
https://developer.aiven.io/
<img width="440" alt="Screenshot 2022-02-02 at 12 42 46" src="https://user-images.githubusercontent.com/36624597/152150232-034d52e6-4060-4041-942a-a88f5276bc41.png">

 Fixes: https://github.com/aiven/devportal/issues/526

