### PR TITLE
Update postgresql jdbc driver version

### DIFF
--- a/docs/products/postgresql/howto/connect-java.rst
+++ b/docs/products/postgresql/howto/connect-java.rst
@@ -27,7 +27,7 @@ There are several options to do that
 
 1. In case you have maven version >= 2+ run the code::
 
-    mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.postgresql:postgresql:42.2.24:jar -Ddest=postgresql-42.2.24.jar
+    mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.postgresql:postgresql:42.3.2:jar -Ddest=postgresql-42.3.2.jar
 
 2. Manually the jar could be downloaded from https://jdbc.postgresql.org/download.html
 


### PR DESCRIPTION
# What changed, and why it matters

Since there is an RCE in postgresql jdbc driver, it's better to have link to fixed version
https://nvd.nist.gov/vuln/detail/CVE-2022-21724


