### PR TITLE
Removing the extra hyphen from the front page banner

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -2,7 +2,7 @@
 
 {% block body -%}
 {% include "partials/icons.html" %}
-<div class="sign-up-banner">Try Aiven for free for 30-days! <a href="https://console.aiven.io/signup" target="_blank" class="get-started-link">Get started -></a></div>
+<div class="sign-up-banner">Try Aiven for free for 30 days! <a href="https://console.aiven.io/signup" target="_blank" class="get-started-link">Get started -></a></div>
 <a class="gh-ribbon gray right" href="https://github.com/aiven/devportal" target="_blank">Fork me on GitHub!</a>
 <br />
 <input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation">


### PR DESCRIPTION
# What changed, and why it matters

Removing the extra hyphen from the front page banner. It should read "30 days" instead of "30-days".

