### PR TITLE
Add Java example to connect to MySql

### DIFF
--- a/code/products/mysql/connect.java
+++ b/code/products/mysql/connect.java
@@ -1,0 +1,40 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+
+public class MySqlExample {
+    public static void main(String[] args) throws ClassNotFoundException {
+        String host, port, databaseName, userName, password;
+        host = port = databaseName = userName = password = null;
+        for (int i = 0; i < args.length - 1; i++) {
+            switch (args[i].toLowerCase(Locale.ROOT)) {
+                case "-host": host = args[++i]; break;
+                case "-username": userName = args[++i]; break;
+                case "-password": password = args[++i]; break;
+                case "-database": databaseName = args[++i]; break;
+                case "-port": port = args[++i]; break;
+            }
+        }
+        // JDBC allows to have nullable username and password
+        if (host == null || port == null || databaseName == null) {
+            System.out.println("Host, port, database information is required");
+            return;
+        }
+        Class.forName("java.sql.Driver");
+        try (final Connection connection =
+                     DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + databaseName + "?sslmode=require", userName, password);
+             final Statement statement = connection.createStatement();
+             final ResultSet resultSet = statement.executeQuery("SELECT version() AS version")) {
+
+            while (resultSet.next()) {
+                System.out.println("Version: " + resultSet.getString("version"));
+            }
+        } catch (SQLException e) {
+            System.out.println("Connection failure.");
+            e.printStackTrace();
+        }
+    }
+}

--- a/code/products/mysql/connect.java
+++ b/code/products/mysql/connect.java
@@ -23,7 +23,7 @@ public class MySqlExample {
             System.out.println("Host, port, database information is required");
             return;
         }
-        Class.forName("java.sql.Driver");
+        Class.forName("com.mysql.cj.jdbc.Driver");
         try (final Connection connection =
                      DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + databaseName + "?sslmode=require", userName, password);
              final Statement statement = connection.createStatement();

--- a/docs/products/mysql/howto/connect-with-java.rst
+++ b/docs/products/mysql/howto/connect-with-java.rst
@@ -8,17 +8,20 @@ Variables
 
 These are the placeholders you will need to replace in the code sample:
 
-==================      =============================================================
-Variable                Description
-==================      =============================================================
-``MYSQL_HOST``          Host name for the connection, from the service overview page
-------------------      -------------------------------------------------------------
-``MYSQL_PORT``          Port number to use, from the service overview page
-------------------      -------------------------------------------------------------
-``MYSQL_PASSWORD``      Password for ``avnadmin`` user
-------------------      -------------------------------------------------------------
-``MYSQL_DATABASE``      Database to connect
-==================      =============================================================
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Variable
+     - Description
+   * - ``MYSQL_HOST``
+     - Host name for the connection, from the service overview page
+   * - ``MYSQL_PORT``
+     - Port number to use, from the service overview page
+   * - ``MYSQL_PASSWORD``
+     - Password for ``avnadmin`` user
+   * - ``MYSQL_DATABASE``
+     - Database to connect
 
 Pre-requisites
 ''''''''''''''

--- a/docs/products/mysql/howto/connect-with-java.rst
+++ b/docs/products/mysql/howto/connect-with-java.rst
@@ -27,7 +27,7 @@ For this example you will need:
 
 * JDK 1.8+
 
-* MySQL JDBC Driver which could be downloaded manually from https://dev.mysql.com/downloads/connector/j/
+* MySQL JDBC Driver which could be downloaded manually from `MySQL Community Downloads <https://dev.mysql.com/downloads/connector/j/>`_
   or it could be downloaded with maven like::
 
     mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=mysql:mysql-connector-java:8.0.28:jar -Ddest=mysql-driver-8.0.28.jar

--- a/docs/products/mysql/howto/connect-with-java.rst
+++ b/docs/products/mysql/howto/connect-with-java.rst
@@ -1,0 +1,55 @@
+Connect to MySQL with Java
+============================
+
+This example connects your Java application to a MySQL service.
+
+Variables
+'''''''''
+
+These are the placeholders you will need to replace in the code sample:
+
+==================      =============================================================
+Variable                Description
+==================      =============================================================
+``MYSQL_HOST``          Host name for the connection, from the service overview page
+------------------      -------------------------------------------------------------
+``MYSQL_PORT``          Port number to use, from the service overview page
+------------------      -------------------------------------------------------------
+``MYSQL_PASSWORD``      Password for avnadmin user
+------------------      -------------------------------------------------------------
+``MYSQL_DATABASE``      Database to connect
+==================      =============================================================
+
+Pre-requisites
+''''''''''''''
+
+For this example you will need:
+
+* JDK 1.8+
+
+* MySql jdbc Driver which could be downloaded manually from https://dev.mysql.com/downloads/connector/j/
+  or it could be downloaded with maven like::
+
+    mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=mysql:mysql-connector-java:8.0.28:jar -Ddest=mysql-driver-8.0.28.jar
+
+
+Code
+''''
+
+Add the following to ``MySqlExample.java``:
+
+.. literalinclude:: /code/products/mysql/connect.java
+
+
+This code creates a MySQL client and connects to the database. It fetches version of MySql and prints it the output.
+
+Run the code after replacement of the placeholders with values for your project::
+
+    javac MySqlExample.java && java -cp mysql-driver-8.0.28.jar:. MySqlExample -host MYSQL_HOST -port MYSQL_PORT -database MYSQL_DATABASE -username avnadmin -password MYSQL_PASSWORD
+
+If the script runs successfully, the output will be the values that were inserted into the table::
+
+    Version: 8.0.26
+
+Now that your application is connected, you are all set to use Java with Aiven for MySQL.
+

--- a/docs/products/mysql/howto/connect-with-java.rst
+++ b/docs/products/mysql/howto/connect-with-java.rst
@@ -15,7 +15,7 @@ Variable                Description
 ------------------      -------------------------------------------------------------
 ``MYSQL_PORT``          Port number to use, from the service overview page
 ------------------      -------------------------------------------------------------
-``MYSQL_PASSWORD``      Password for avnadmin user
+``MYSQL_PASSWORD``      Password for ``avnadmin`` user
 ------------------      -------------------------------------------------------------
 ``MYSQL_DATABASE``      Database to connect
 ==================      =============================================================
@@ -27,7 +27,7 @@ For this example you will need:
 
 * JDK 1.8+
 
-* MySql jdbc Driver which could be downloaded manually from https://dev.mysql.com/downloads/connector/j/
+* MySQL JDBC Driver which could be downloaded manually from https://dev.mysql.com/downloads/connector/j/
   or it could be downloaded with maven like::
 
     mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=mysql:mysql-connector-java:8.0.28:jar -Ddest=mysql-driver-8.0.28.jar
@@ -41,7 +41,7 @@ Add the following to ``MySqlExample.java``:
 .. literalinclude:: /code/products/mysql/connect.java
 
 
-This code creates a MySQL client and connects to the database. It fetches version of MySql and prints it the output.
+This code creates a MySQL client and connects to the database. It fetches version of MySQL and prints it the output.
 
 Run the code after replacement of the placeholders with values for your project::
 

--- a/docs/products/mysql/howto/connect-with-python.rst
+++ b/docs/products/mysql/howto/connect-with-python.rst
@@ -40,7 +40,7 @@ Add the following to ``main.py`` and replace the placeholders with values for yo
 .. literalinclude:: /code/products/mysql/connect.py
 
 
-This code creates a PostgreSQL client and connects to the database. It creates a table, inserts some values, fetches them and prints the output.
+This code creates a MySQL client and connects to the database. It creates a table, inserts some values, fetches them and prints the output.
 
 To run the code::
 


### PR DESCRIPTION
# What changed, and why it matters
The PR adds a java example to connect to MySql
+ it fixes a small misprint in the same python example

