### PR TITLE
Add ® and ™ marks to index page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -147,12 +147,3 @@ You can use the Aiven platform in the way that best fits your workflow:
 * :doc:`docs/tools/terraform/index` gives orchestration features for infrastructure-as-code projects.
 
 * :doc:`docs/tools/kubernetes` adds orchestration of your Aiven services to your existing Kubernetes cluster.
-
---------
-
-.. Adding this disclaimer text explicitly here for the moment, but it should
-   eventually become a standard footer for all devportal pages
-
-*Apache Kafka®, Apache Flink® and Apache Cassandra® are either registered
-trademarks or trademarks of the Apache Software Foundation in the United
-States and/or other countries. M3, M3 Aggregator, M3 Coordinator, OpenSearch®, PostgreSQL®, MySQL, InfluxDB®, Grafana® are trademarks and property of their respective owners. \*Redis is a trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven. All product and service names used in this website are for identification purposes only and do not imply endorsement.*

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,16 @@
 Aiven developer
 ===============
 
-Aiven is a database-as-a-service for open source data solutions including Apache Kafka, PostgreSQL, Redis, OpenSearch, MySQL, Cassandra, M3DB, Grafana and InfluxDB.
+Aiven is a database-as-a-service for open source data solutions including
+PostgreSQL®,
+M3,
+Apache Kafka®,
+Apache Flink®,
+OpenSearch®,
+Apache Cassandra®,
+Redis™*,
+MySQL,
+InfluxDB® and Grafana®.
 
 ----------------
 
@@ -29,7 +38,7 @@ Learn about the Aiven platform
 .. panels::
     :card: shadow
 
-    |icon-postgres| **PostgreSQL** Powerful relational database platform. We have the latest versions, and an excellent selection of extensions.
+    |icon-postgres| **PostgreSQL®** Powerful relational database platform. We have the latest versions, and an excellent selection of extensions.
 
     +++
 
@@ -40,7 +49,7 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-m3db| **M3DB** Distributed time-series database for scalable solutions, with M3 Coordinator included, and M3 Aggregator also available.
+    |icon-m3db| **M3** Distributed time-series database for scalable solutions, with M3 Coordinator included, and M3 Aggregator also available.
 
     +++
 
@@ -51,7 +60,7 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-kafka| **Apache Kafka** Streaming data pipelines for the modern enterprise. Apache MirrorMaker2 and Kafka Connect also available.
+    |icon-kafka| **Apache Kafka®** Streaming data pipelines for the modern enterprise. Apache MirrorMaker2 and Kafka Connect also available.
 
 
     +++
@@ -63,7 +72,7 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-flink| **Apache Flink** Framework for definining powerful transformations of batch and streaming data sets. :badge:`beta,cls=badge-secondary text-black badge-pill`
+    |icon-flink| **Apache Flink®** Framework for definining powerful transformations of batch and streaming data sets. :badge:`beta,cls=badge-secondary text-black badge-pill`
 
     +++
 
@@ -73,7 +82,7 @@ Learn about the Aiven platform
         :classes: stretched-link
     ---
 
-    |icon-opensearch| **OpenSearch** Document database with specialist search features, bring your freeform documents, logs or metrics, and make sense of them here.
+    |icon-opensearch| **OpenSearch®** Document database with specialist search features, bring your freeform documents, logs or metrics, and make sense of them here.
 
     +++
 
@@ -84,11 +93,11 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-cassandra| **Cassandra** High performance storage solution for large data quantities. This specialist data solution is a partitioned row store.
+    |icon-cassandra| **Apache Cassandra®** High performance storage solution for large data quantities. This specialist data solution is a partitioned row store.
 
     ---
 
-    |icon-redis| **Redis** In-memory data store for all your high-peformance short-term storage and caching needs.
+    |icon-redis| **Redis™\*** In-memory data store for all your high-peformance short-term storage and caching needs.
 
     +++
 
@@ -110,11 +119,11 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-influxdb| **InfluxDB** Specialist time series database, with good tooling support.
+    |icon-influxdb| **InfluxDB®** Specialist time series database, with good tooling support.
 
     ---
 
-    |icon-grafana| **Grafana** The visualization tool you need to explore and understand your data. Grafana integrates with the other services in just a few clicks.
+    |icon-grafana| **Grafana®** The visualization tool you need to explore and understand your data. Grafana integrates with the other services in just a few clicks.
 
     +++
 
@@ -122,7 +131,7 @@ Learn about the Aiven platform
         :type: ref
         :text: Read more
         :classes: stretched-link
-    
+
 
 Tools
 -----
@@ -133,9 +142,17 @@ You can use the Aiven platform in the way that best fits your workflow:
 
 * The ``avn`` :doc:`command-line tool <docs/tools/cli>` brings Aiven features to your terminal.
 
-* For programmatic integrations, the :doc:`Aiven API <docs/tools/api/index>` provides an interface you can use.
+* The :doc:`Aiven API <docs/tools/api/index>` provides an interface you can use for programmatic integrations.
 
-* The :doc:`terraform <docs/tools/terraform/index>` gives orchestration features for infrastructure-as-code projects.
+* :doc:`docs/tools/terraform/index` gives orchestration features for infrastructure-as-code projects.
 
-* The :doc:`docs/tools/kubernetes` adds orchestration of your Aiven services to your existing Kubernetes cluster.
+* :doc:`docs/tools/kubernetes` adds orchestration of your Aiven services to your existing Kubernetes cluster.
 
+--------
+
+.. Adding this disclaimer text explicitly here for the moment, but it should
+   eventually become a standard footer for all devportal pages
+
+*Apache Kafka®, Apache Flink® and Apache Cassandra® are either registered
+trademarks or trademarks of the Apache Software Foundation in the United
+States and/or other countries. M3, M3 Aggregator, M3 Coordinator, OpenSearch®, PostgreSQL®, MySQL, InfluxDB®, Grafana® are trademarks and property of their respective owners. \*Redis is a trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven. All product and service names used in this website are for identification purposes only and do not imply endorsement.*


### PR DESCRIPTION
Fix: https://github.com/aiven/devportal/issues/545

Since the index page is the first thing people see for devportal, it seems
worth fixing it now.

1. Add necessary ® and ™ marks, including the asterisk needed for Redis
   (note that Redis' own usage doesn't require this to be superscripted)
2. Split the service names in the opening paragraph over multiple lines
   to make it easier to maintain the list (it still displays as one),
3. Refer to M3 rather than M3DB
4. Tidy some of the sentences in the final list


