### PR TITLE
Adding disclaimer in the footer

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -58,10 +58,10 @@
       </article>
       <footer>
         {% include "feedback-form.html" %}
-        <font size="-1"><p><em>Apache Kafka®, Apache Kafka Connect®, Apache Kafka MirrorMaker 2®, Apache Flink® and Apache Cassandra® are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+        <div class="disclaimer"><p>Apache Kafka®, Apache Kafka Connect®, Apache Kafka MirrorMaker 2®, Apache Flink® and Apache Cassandra® are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
               M3, M3 Aggregator, OpenSearch®, PostgreSQL®, MySQL, InfluxDB®, Grafana® are trademarks and property of their respective owners. *Redis is a trademark of Redis Ltd.
               Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven.
-              All product and service names used in this website are for identification purposes only and do not imply endorsement.</em></p></font>
+              All product and service names used in this website are for identification purposes only and do not imply endorsement.</p></div>
         {% block footer %}
 
         <div class="related-information">

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -58,7 +58,10 @@
       </article>
       <footer>
         {% include "feedback-form.html" %}
-
+        <font size="-1"><p><em>Apache Kafka®, Apache Kafka Connect®, Apache Kafka MirrorMaker 2®, Apache Flink® and Apache Cassandra® are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+              M3, M3 Aggregator, OpenSearch®, PostgreSQL®, MySQL, InfluxDB®, Grafana® are trademarks and property of their respective owners. *Redis is a trademark of Redis Ltd.
+              Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven.
+              All product and service names used in this website are for identification purposes only and do not imply endorsement.</em></p></font>
         {% block footer %}
 
         <div class="related-information">

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -58,10 +58,9 @@
       </article>
       <footer>
         {% include "feedback-form.html" %}
-        <div class="disclaimer"><p>Apache Kafka®, Apache Kafka Connect®, Apache Kafka MirrorMaker 2®, Apache Flink® and Apache Cassandra® are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
-              M3, M3 Aggregator, OpenSearch®, PostgreSQL®, MySQL, InfluxDB®, Grafana® are trademarks and property of their respective owners. *Redis is a trademark of Redis Ltd.
-              Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven.
-              All product and service names used in this website are for identification purposes only and do not imply endorsement.</p></div>
+        <div class="disclaimer"><p>Apache, Apache Kafka, Kafka, Apache Flink, Flink, Apache Cassandra, and Cassandra are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
+          M3, M3 Aggregator, M3 Coordinator, OpenSearch, PostgreSQL, MySQL, InfluxDB, Grafana, Terraform, and Kubernetes are trademarks and property of their respective owners.
+         *Redis is a trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven. All product and service names used in this website are for identification purposes only and do not imply endorsement.</p></div>
         {% block footer %}
 
         <div class="related-information">


### PR DESCRIPTION
# What changed, and why it matters

The existing DevPortal pages don't have disclaimers. Rather than adding the disclaimer individually on each page, this PR adds the disclaimer in the template that will be reflected to all DevPortal pages as a footer.

Fix https://github.com/aiven/devportal/issues/485
