### PR TITLE
Adding instructions on topic creation for kafka

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -104,13 +104,11 @@ entries:
           - file: docs/products/kafka/howto/list-topic-schema
             title: Topic/schema management
             entries:
+              - file: docs/products/kafka/howto/create-topic
               - file: docs/products/kafka/howto/create-topics-automatically
               - file: docs/products/kafka/howto/get-topic-partition-details
               - file: docs/products/kafka/howto/schema-registry
               - file: docs/products/kafka/howto/change-retention-period
-
-
-
       - file: docs/products/kafka/reference
         title: Reference
         entries:

--- a/docs/products/kafka/howto/create-topic.rst
+++ b/docs/products/kafka/howto/create-topic.rst
@@ -6,17 +6,20 @@ While you can set Apache Kafka® to :doc:`automatically create a topic when the 
 * it lets you to define granular topic settings such as the number of partitions, the replication factor, the retention period and more.
 * It prevents the wrong topic being generated (for instance with typos).
 
-1. Log in to the `Aiven console <https://console.aiven.io/>`_.
+Create an Apache Kafka® topic via Aiven Console
+-----------------------------------------------
 
-2. On the **Services** page, click on the service name.
+To create a new topic via the `Aiven Console <https://console.aiven.io/>`_:
 
-3. Select the **Topics** tab:
+1. On the **Services** page, click on the Aiven for Apache Kafka® service where you want to crate the topic.
 
-   a. Enter a name for your topic.
+2. Select the **Topics** tab:
 
-   b. Select **Advanced configuration** to set the replication factor, number of partitions and other advanced settings. These can be modified later.
+   a. In the *Add new topic* section, enter a name for your topic.
 
-4. Click **Add Topic** on the right hand side of the console.
+   b. In the **Advanced configuration** you can set the replication factor, number of partitions and other advanced settings. These can be modified later.
+
+3. Click **Add Topic** on the right hand side of the console.
 
    The new topic will be visible immediately, but may take a few minutes before you can update its settings.
 

--- a/docs/products/kafka/howto/create-topic.rst
+++ b/docs/products/kafka/howto/create-topic.rst
@@ -1,0 +1,35 @@
+Creating an Apache Kafka topic
+===============================
+
+While you can set Kafka to automatically create a topic when a message is produced to a topic that does not exist, creating topics beforehand is generally considered a preferred practice and recommended for production environments. 
+
+Create a new Apache Kafka topic using the Aiven console
+--------------------------------------------------------
+
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+
+2. On the **Services** page, click on the service name.
+
+3. Select the **Topics** tab:
+
+   a. Enter a name for your topic.
+
+   b. Select **Advanced configuration** to set the replication factor, number of partitions and other advanced settings. These can be modified later.
+
+4. Click **Add Topic** on the right hand side of the console.
+
+   The new topic will be visible immediately, but may take a few minutes before you can update its settings.
+
+
+Create an Apache Kafka topic using the Aiven client (CLI)
+----------------------------------------------------------
+
+1. Prepare the command to add the topic to your Apache Kafka service.
+
+
+2. Add the ``kafka_service`` parameter to specify the service for which you want to create a new topic, and the ``topic_name`` for the new topic. You will also need to specify the replication factor and number of partitions. For instance, to add the topic ``topic_name`` to the Apache Kafka service ``kafka_service``, with a replication factor of 3 and 2 partitions per topic, you would use this command:
+
+    avn service topic-create --partitions 2 --replication 3 kafka_service topic_name
+
+The changes are applied immediately.
+

--- a/docs/products/kafka/howto/create-topic.rst
+++ b/docs/products/kafka/howto/create-topic.rst
@@ -1,17 +1,12 @@
 Creating an Apache Kafka® topic
 ===============================
 
-While you can set Apache Kafka® to :doc:`automatically create a topic when the a message is produced to a topic that does not exist <create-topics-automatically>`, creating topics beforehand is generally considered a preferred practice and recommended for production environments since:
+While you can set Apache Kafka® to :doc:`automatically create a topic when the a message is produced to a topic that does not exist <create-topics-automatically>`, creating topics beforehand is generally considered a preferred practice and recommended for production environments:
 
-* Allows you to define granular topic settings like the number of partitions, replication factor, retention etc.
-* Avoids wrong topic generation in case of typos
+* it lets you to define granular topic settings such as the number of partitions, the replication factor, the retention period and more.
+* It prevents the wrong topic being generated (for instance with typos).
 
-If you're using Aiven for Apache Kafka you can create topics via the `Aiven console <https://console.aiven.io>`_ or the :doc:`Aiven CLI </docs/tools/cli>`.
-
-Create a new Apache Kafka topic using the Aiven console
---------------------------------------------------------
-
-1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+1. Log in to the `Aiven console <https://console.aiven.io/>`_.
 
 2. On the **Services** page, click on the service name.
 
@@ -26,30 +21,5 @@ Create a new Apache Kafka topic using the Aiven console
    The new topic will be visible immediately, but may take a few minutes before you can update its settings.
 
 
-Create an Apache Kafka topic using the Aiven client (CLI)
-----------------------------------------------------------
 
-Use the :ref:`dedicated topic-create function <avn_cli_service_topic_create>` to create a new topic via the :doc:`Aiven CLI </docs/tools/cli>`.
-
-Example: Create a new topic via Aiven CLI
-'''''''''''''''''''''''''''''''''''''''''
-
-Create a new topic named ``students`` on the Aiven for Apache Kafka instance ``demo-kafka`` with the following settings:
-
-* ``replication_factor``: 3
-* ``partitions``: 2
-* ``retention``: 4 hours
-
-Execute following command:
-
-::
-   
-   avn service topic-create demo-kafka students   \
-      --partitions 2                               \
-      --replication 3                              \
-      --retention 4
-
-.. Note::
-
-   After executing the command the required changes are applied immediately. However some operation, like partition balancing after a overall partition number change, can take some time (depending on the data volume) to take full effect.
-
+You can also use the :ref:`dedicated topic-create function <avn_cli_service_topic_create>` to create a new topic via the :doc:`Aiven CLI </docs/tools/cli>`.

--- a/docs/products/kafka/howto/create-topic.rst
+++ b/docs/products/kafka/howto/create-topic.rst
@@ -1,7 +1,12 @@
-Creating an Apache Kafka topic
+Creating an Apache Kafka® topic
 ===============================
 
-While you can set Kafka to automatically create a topic when a message is produced to a topic that does not exist, creating topics beforehand is generally considered a preferred practice and recommended for production environments. 
+While you can set Apache Kafka® to :doc:`automatically create a topic when the a message is produced to a topic that does not exist <create-topics-automatically>`, creating topics beforehand is generally considered a preferred practice and recommended for production environments since:
+
+* Allows you to define granular topic settings like the number of partitions, replication factor, retention etc.
+* Avoids wrong topic generation in case of typos
+
+If you're using Aiven for Apache Kafka you can create topics via the `Aiven console <https://console.aiven.io>`_ or the :doc:`Aiven CLI </docs/tools/cli>`.
 
 Create a new Apache Kafka topic using the Aiven console
 --------------------------------------------------------
@@ -24,12 +29,27 @@ Create a new Apache Kafka topic using the Aiven console
 Create an Apache Kafka topic using the Aiven client (CLI)
 ----------------------------------------------------------
 
-1. Prepare the command to add the topic to your Apache Kafka service.
+Use the :ref:`dedicated topic-create function <avn_cli_service_topic_create>` to create a new topic via the :doc:`Aiven CLI </docs/tools/cli>`.
 
+Example: Create a new topic via Aiven CLI
+'''''''''''''''''''''''''''''''''''''''''
 
-2. Add the ``kafka_service`` parameter to specify the service for which you want to create a new topic, and the ``topic_name`` for the new topic. You will also need to specify the replication factor and number of partitions. For instance, to add the topic ``topic_name`` to the Apache Kafka service ``kafka_service``, with a replication factor of 3 and 2 partitions per topic, you would use this command:
+Create a new topic named ``students`` on the Aiven for Apache Kafka instance ``demo-kafka`` with the following settings:
 
-    avn service topic-create --partitions 2 --replication 3 kafka_service topic_name
+* ``replication_factor``: 3
+* ``partitions``: 2
+* ``retention``: 4 hours
 
-The changes are applied immediately.
+Execute following command:
+
+::
+   
+   avn service topic-create demo-kafka students   \
+      --partitions 2                               \
+      --replication 3                              \
+      --retention 4
+
+.. Note::
+
+   After executing the command the required changes are applied immediately. However some operation, like partition balancing after a overall partition number change, can take some time (depending on the data volume) to take full effect.
 

--- a/docs/products/kafka/howto/create-topics-automatically.rst
+++ b/docs/products/kafka/howto/create-topics-automatically.rst
@@ -1,7 +1,7 @@
 Create Apache Kafka topics automatically
 ==========================================
 
-You can set Kafka to automatically create a topic when a message is produced to a topic that does not exist. 
+You can set Apache Kafka to automatically create a topic when a message is produced to a topic that does not exist. 
 By default, in Aiven for Apache Kafka this features is turned off as safeguard against accidental topic creation and when a message is produced to a topic that does not yet exist. In such cases the common error message is the following::
 
     KafkaTimeoutError: Failed to update metadata after 60.0 secs.

--- a/docs/products/kafka/howto/create-topics-automatically.rst
+++ b/docs/products/kafka/howto/create-topics-automatically.rst
@@ -8,7 +8,7 @@ By default, in Aiven for Apache Kafka this features is turned off as safeguard a
 
 In such cases two options are available:
 
-#. :doc:`Create topics beforehand </docs/products/kafka/create-topic>`
+#. :doc:`Create topics beforehand </docs/products/kafka/howto/create-topic>`
 #. Enable topic automatic creation
 
 While option 2 seems the easier solution it has drawbacks like the risk of creating new topics in case of typos or accepting all the :doc:`topic configuration default values <set-kafka-parameters>` set at service level such as partition count, replication factor, and retention time.

--- a/docs/products/kafka/howto/create-topics-automatically.rst
+++ b/docs/products/kafka/howto/create-topics-automatically.rst
@@ -8,7 +8,7 @@ By default, in Aiven for Apache Kafka this features is turned off as safeguard a
 
 In such cases two options are available:
 
-#. Create topics beforehand
+#. :doc:`Create topics beforehand </docs/products/kafka/create-topic>`
 #. Enable topic automatic creation
 
 While option 2 seems the easier solution it has drawbacks like the risk of creating new topics in case of typos or accepting all the :doc:`topic configuration default values <set-kafka-parameters>` set at service level such as partition count, replication factor, and retention time.

--- a/docs/tools/cli/service/topic.rst
+++ b/docs/tools/cli/service/topic.rst
@@ -3,6 +3,7 @@
 
 Here you’ll find the full list of commands for ``avn service topic``.
 
+.. _avn_cli_service_topic_create:
 
 Manage Aiven for Apache Kafka topics
 --------------------------------------------------------


### PR DESCRIPTION
# What changed, and why it matters

Adding a small article on how to create kafka topics using either the Aiven console or Aiven client.

