### PR TITLE
creating new databases for mysql and postgresql

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -152,6 +152,7 @@ entries:
       - file: docs/products/postgresql/howto
         title: HowTo
         entries:
+          - file: docs/products/postgresql/howto/create-database
           - file: docs/products/postgresql/howto/list-code-samples
             entries:
               - file: docs/products/postgresql/howto/connect-go

--- a/_toc.yml
+++ b/_toc.yml
@@ -152,7 +152,6 @@ entries:
       - file: docs/products/postgresql/howto
         title: HowTo
         entries:
-          - file: docs/products/postgresql/howto/create-database
           - file: docs/products/postgresql/howto/list-code-samples
             entries:
               - file: docs/products/postgresql/howto/connect-go
@@ -162,6 +161,7 @@ entries:
               - file: docs/products/postgresql/howto/connect-python
           - file: docs/products/postgresql/howto/list-dba-tasks
             entries:
+              - file: docs/products/postgresql/howto/create-database
               - file: docs/products/postgresql/howto/upgrade
               - file: docs/products/postgresql/howto/manage-extensions
               - file: docs/products/postgresql/howto/create-manual-backups

--- a/docs/products/mysql/get-started.rst
+++ b/docs/products/mysql/get-started.rst
@@ -30,5 +30,8 @@ Next steps with Aiven for MySQL
     - :doc:`from the command line <howto/connect-from-cli>`
     - :doc:`with MySQL workbench <howto/connect-from-mysql-workbench>`
 
+* Create additional databases:
+    - :doc:`create your database <howto/create-database>`
+
 * Connect from your own :doc:`Python application <howto/connect-with-python>`.
 

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -1,0 +1,40 @@
+Create additional MySQL databases
+==================================
+
+Once you've created your MySQL service, you can add additional databases
+
+
+Using the Aiven web console
+----------------------------
+
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+
+2. On the **Services** page, click on the service name.
+
+3. Select the **Databases** tab:
+
+   a. Enter a name for your database.
+
+4. Click **Add database** on the right hand side of the console.
+
+   The new database will be visible immediately.
+
+Using the Aiven client (CLI)
+-----------------------------
+
+1. Prepare the command to add the database to your MySQL service.
+
+2. Add the ``mysql_service`` parameter to specify the service for which you want to create a new database, and the ``database_name`` for the new database. For instance, to add the topic ``database_name`` to the service ``mysql_service``, you would use this command::
+
+    avn service topic-create --dbname  mysql_service 
+
+The changes are applied immediately.
+
+Using a MySQL client (CLI)
+-----------------------------
+
+1. :doc:`Connect to your service <connect-from-cli>` using either the ``mysqlsh`` or ``mysql`` utilities.
+2. Run the following command from the MySQL prompt::
+
+    CREATE DATABASE database_name;
+

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -1,9 +1,9 @@
-Create additional MySQL databases
+Create additional MySQL® databases
 ==================================
 
-Once you've created your Aiven for MySQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
+Once you've created your Aiven for MySQL® service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
-1. In the Aiven console, on the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
+1. In the `Aiven Console <https://console.aiven.io/>`_, on the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
 
 2. Select the **Databases** tab:
 
@@ -13,7 +13,9 @@ Once you've created your Aiven for MySQL service, you can add additional databas
 
    The new database will be visible immediately.
 
-You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`MySQL client<connect-from-cli>` to create your database  from the CLI.
+.. Tip::
+
+   You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`MySQL client<connect-from-cli>` to create your database  from the CLI.
 
 
 

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -1,40 +1,23 @@
 Create additional MySQL databases
 ==================================
 
-Once you've created your MySQL service, you can add additional databases
+Once you've created your Aiven for MySQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
 
-Using the Aiven web console
+Use the Aiven console
 ----------------------------
 
-1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+1. On the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
 
-2. On the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
-
-3. Select the **Databases** tab:
+2. Select the **Databases** tab:
 
    a. Enter a name for your database.
 
-4. Click **Add database** on the right hand side of the console.
+3. Click **Add database** on the right hand side of the console.
 
    The new database will be visible immediately.
 
-Using the Aiven client (CLI)
------------------------------
+You can also use the :doc:`Aiven client </tools/cli/database#manage-databases>` or the :doc:`MySQL client<connect-from-cli>` to create your database  from the CLI.
 
-1. Prepare the command to add the database to your MySQL service.
 
-2. Add the ``mysql_service`` parameter to specify the service for which you want to create a new database, and the ``database_name`` for the new database. For instance, to add the topic ``database_name`` to the service ``mysql_service``, you would use this command::
-
-    avn service topic-create --dbname  mysql_service 
-
-The changes are applied immediately.
-
-Using a MySQL client (CLI)
------------------------------
-
-1. :doc:`Connect to your service <connect-from-cli>` using either the ``mysqlsh`` or ``mysql`` utilities.
-2. Run the following command from the MySQL prompt::
-
-    CREATE DATABASE database_name;
 

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -9,7 +9,7 @@ Using the Aiven web console
 
 1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
 
-2. On the **Services** page, click on the service name.
+2. On the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
 
 3. Select the **Databases** tab:
 

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -3,6 +3,8 @@ Create additional MySQL® databases
 
 Once you've created your Aiven for MySQL® service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
+To create a new MySQL® database:
+
 1. In the `Aiven Console <https://console.aiven.io/>`_, on the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
 
 2. Select the **Databases** tab:

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -13,7 +13,7 @@ Once you've created your Aiven for MySQL service, you can add additional databas
 
    The new database will be visible immediately.
 
-You can also use the :doc:`Aiven client </tools/cli/database#manage-databases>` or the :doc:`MySQL client<connect-from-cli>` to create your database  from the CLI.
+You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`MySQL client<connect-from-cli>` to create your database  from the CLI.
 
 
 

--- a/docs/products/mysql/howto/create-database.rst
+++ b/docs/products/mysql/howto/create-database.rst
@@ -3,11 +3,7 @@ Create additional MySQL databases
 
 Once you've created your Aiven for MySQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
-
-Use the Aiven console
-----------------------------
-
-1. On the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
+1. In the Aiven console, on the **Services** page, click on the Aiven for MySQL service name for which you want to create a new database.
 
 2. Select the **Databases** tab:
 

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -1,10 +1,10 @@
-Create additional PostgreSQL databases
+Create additional PostgreSQL® databases
 =============================================
 
-Once you've created your Aiven for PostgreSQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
+Once you've created your Aiven for PostgreSQL® service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
 
-1. In the Aiven console, on the **Services** page, click on the Aiven for PostgreSQL service name for which you want to create a new database.
+1. In the `Aiven Console <https://console.aiven.io/>`_, on the **Services** page, click on the Aiven for PostgreSQL service name for which you want to create a new database.
 
 2. Select the **Databases** tab:
 
@@ -14,4 +14,6 @@ Once you've created your Aiven for PostgreSQL service, you can add additional da
 
    The new database will be visible immediately.
 
-You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`PostgreSQL client<connect-psql>` to create your database from the CLI.
+.. Tip::
+
+   You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`PostgreSQL client<connect-psql>` to create your database from the CLI.

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -1,0 +1,41 @@
+Create additional PostgreSQL databases
+=============================================
+
+Once you've created your PostgreSQL service, you can add additional databases
+
+
+Using the Aiven web console
+----------------------------
+
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+
+2. On the **Services** page, click on the service name.
+
+3. Select the **Databases** tab:
+
+   a. Enter a name for your database.
+
+4. Click **Add database** on the right hand side of the console.
+
+   The new database will be visible immediately.
+
+Using the Aiven client (CLI)
+-----------------------------
+
+1. Prepare the command to add the database to your PostgreSQL service.
+
+2. Add the ``postgresql_service`` parameter to specify the service for which you want to create a new database, and the ``database_name`` for the new database. For instance, to add the topic ``database_name`` to the service ``PostgreSQL_service``, you would use this command::
+
+    avn service topic-create --dbname  postgresql_service 
+
+The changes are applied immediately.
+
+Using a PostgreSQL client (CLI)
+-------------------------------------
+
+1. :doc:`Connect to your service  <connect-psql>` using  the ``psql`` utility.
+
+2. Run the following command from the PostgreSQL prompt::
+
+    CREATE DATABASE database_name;
+

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -3,6 +3,7 @@ Create additional PostgreSQL® databases
 
 Once you've created your Aiven for PostgreSQL® service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
+To create a new PostgreSQL® database:
 
 1. In the `Aiven Console <https://console.aiven.io/>`_, on the **Services** page, click on the Aiven for PostgreSQL service name for which you want to create a new database.
 

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -14,4 +14,4 @@ Once you've created your Aiven for PostgreSQL service, you can add additional da
 
    The new database will be visible immediately.
 
-You can also use the :doc:`Aiven client </tools/cli/database#manage-databases>` or the :doc:`PostgreSQL client<connect-from-cli>` to create your database from the CLI.
+You can also use the :ref:`Aiven client <avn-service-database-create>` or the :doc:`PostgreSQL client<connect-psql>` to create your database from the CLI.

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -4,7 +4,7 @@ Create additional PostgreSQL databases
 Once you've created your Aiven for PostgreSQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
 
-1. In the Aiven console, on the **Services** page, click on the service name.
+1. In the Aiven console, on the **Services** page, click on the Aiven for PostgreSQL service name for which you want to create a new database.
 
 2. Select the **Databases** tab:
 

--- a/docs/products/postgresql/howto/create-database.rst
+++ b/docs/products/postgresql/howto/create-database.rst
@@ -1,41 +1,17 @@
 Create additional PostgreSQL databases
 =============================================
 
-Once you've created your PostgreSQL service, you can add additional databases
+Once you've created your Aiven for PostgreSQL service, you can add additional databases, whether for security purposes or to isolate your data per application.
 
 
-Using the Aiven web console
-----------------------------
+1. In the Aiven console, on the **Services** page, click on the service name.
 
-1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
-
-2. On the **Services** page, click on the service name.
-
-3. Select the **Databases** tab:
+2. Select the **Databases** tab:
 
    a. Enter a name for your database.
 
-4. Click **Add database** on the right hand side of the console.
+3. Click **Add database** on the right hand side of the console.
 
    The new database will be visible immediately.
 
-Using the Aiven client (CLI)
------------------------------
-
-1. Prepare the command to add the database to your PostgreSQL service.
-
-2. Add the ``postgresql_service`` parameter to specify the service for which you want to create a new database, and the ``database_name`` for the new database. For instance, to add the topic ``database_name`` to the service ``PostgreSQL_service``, you would use this command::
-
-    avn service topic-create --dbname  postgresql_service 
-
-The changes are applied immediately.
-
-Using a PostgreSQL client (CLI)
--------------------------------------
-
-1. :doc:`Connect to your service  <connect-psql>` using  the ``psql`` utility.
-
-2. Run the following command from the PostgreSQL prompt::
-
-    CREATE DATABASE database_name;
-
+You can also use the :doc:`Aiven client </tools/cli/database#manage-databases>` or the :doc:`PostgreSQL client<connect-from-cli>` to create your database from the CLI.

--- a/docs/tools/cli/service/database.rst
+++ b/docs/tools/cli/service/database.rst
@@ -7,6 +7,8 @@ Here you’ll find the full list of commands for ``avn service database``.
 Manage databases
 --------------------------------------------------------
 
+.. _avn-service-database-create:
+
 ``avn service database-create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
# What changed, and why it matters

(apologies for the piecemeal PRs, but I figured they'd be easier to review than a giant PR with 50~ files).

Adding articles on how to create additional databases past the default one created when the service is spun, using the console, the aiven client, and the native utilities (`mysql`/`psql`)
