### PR TITLE
Update Community page without events list #465

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -12,7 +12,6 @@ There are lots of other ways to learn more about Aiven, and interact with us.
     +++
 
     .. link-button:: https://twitter.com/aiven_io
-        :type: ref
         :text: To the Twitterverse
         :classes: stretched-link
 
@@ -23,7 +22,6 @@ There are lots of other ways to learn more about Aiven, and interact with us.
     +++
 
     .. link-button:: https://aiven.io/blog
-        :type: ref
         :text: To the blog
         :classes: stretched-link
 
@@ -35,7 +33,6 @@ There are lots of other ways to learn more about Aiven, and interact with us.
     +++
 
     .. link-button:: https://www.youtube.com/c/Aiven_io
-        :type: ref
         :text: To YouTube
         :classes: stretched-link
 
@@ -46,7 +43,6 @@ There are lots of other ways to learn more about Aiven, and interact with us.
     +++
 
     .. link-button:: https://github.com/aiven
-        :type: ref
         :text: To the code
         :classes: stretched-link
 

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -3,13 +3,52 @@ Aiven community
 
 There are lots of other ways to learn more about Aiven, and interact with us.
 
-**Blog**: https://aiven.io/blog - to read tech news, tutorials, and updates on what we're up to.
 
-**Aiven Console**: https://console.aiven.io - your Aiven web interface. New accounts get a free trial.
+.. panels::
+    :card: shadow
 
-**Help articles**: https://help.aiven.io - more tech facing goodness to help you get things done.
+    🐦 **Twitter** We love to chat! Tell us what you're building with Aiven!
 
-**Twitter**: https://twitter.com/aiven_io - we love to chat! Tell us what you're building with Aiven :)
+    +++
 
-**YouTube**: https://www.youtube.com/c/Aiven_io - if video is your thing, cool, it's ours too.
+    .. link-button:: https://twitter.com/aiven_io
+        :type: ref
+        :text: To the Twitterverse
+        :classes: stretched-link
 
+    ---
+
+    📖 **Blog** To read tech news, tutorials, and updates on what we're up to.
+
+    +++
+
+    .. link-button:: https://aiven.io/blog
+        :type: ref
+        :text: To the blog
+        :classes: stretched-link
+
+    ---
+
+    📺 **YouTube** If video is your thing, cool, it's ours too.
+
+
+    +++
+
+    .. link-button:: https://www.youtube.com/c/Aiven_io
+        :type: ref
+        :text: To YouTube
+        :classes: stretched-link
+
+    ---
+
+    🐱 **GitHub** Find our public repositories on GitHub, work on `open source <https://aiven.io/open-source>`_ with us! 
+
+    +++
+
+    .. link-button:: https://github.com/aiven
+        :type: ref
+        :text: To the code
+        :classes: stretched-link
+
+
+Check out the `Aiven Console <https://console.aiven.io>`_ for your Aiven web interface. New accounts get a free trial!


### PR DESCRIPTION
Changed formatting of the [Community page](https://developer.aiven.io/docs/community.html) to: 
![screencapture-localhost-8000-docs-community-html-2022-02-09-21_23_50](https://user-images.githubusercontent.com/1087213/153284044-f9e5bda3-88d5-464c-8acd-696ca9a36581.png)

Addresses #465

