### PR TITLE
Migrating Kafka Connect s3 sink by Confluent

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -116,10 +116,15 @@ entries:
           - file: docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg
           - file: docs/products/kafka/kafka-connect/howto/s3-sink-prereq
           - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven
+          - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent
         - file: docs/products/kafka/kafka-connect/reference
           title: Reference
           entries:
-            - file: docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters
+            - file: docs/products/kafka/kafka-connect/reference/s3-sink-formats
+              title: AWS S3 sink connector naming and data format
+              entries:
+              - file: docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters
+              - file: docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent
 
       - file: docs/products/kafka/kafka-mirrormaker/index
         title: Apache Kafka MirrorMaker2

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
@@ -1,11 +1,11 @@
-Create an Aiven S3 sink connector
-=================================
+Create an S3 sink connector by Aiven
+====================================
 
 The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage.
 
 .. Note::
 
-    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Aiven version. The S3 sink connector by Confluent is discussed in a `dedicated page <https://help.aiven.io/en/articles/2413736-aiven-kafka-s3-sink-connector-by-confluent>`_.
+    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Aiven version. The S3 sink connector by Confluent is discussed in a :doc:`dedicated page <s3-sink-connector-confluent>`.
 
 Prerequisites
 -------------

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
@@ -5,7 +5,7 @@ The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data f
 
 .. Note::
 
-    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Aiven version. The S3 sink connector by Confluent is discussed in a :doc:`dedicated page <s3-sink-connector-confluent>`.
+    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: one is developed by Aiven, another developed by Confluent. This article uses the Aiven version. The S3 sink connector by Confluent is discussed in a :doc:`dedicated page <s3-sink-connector-confluent>`.
 
 Prerequisites
 -------------

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
@@ -1,0 +1,121 @@
+Create an S3 sink connector by Confluent
+========================================
+
+The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage.
+
+.. Note::
+
+    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Confluent version. The S3 sink connector by Aiven is discussed in a :doc:`dedicated page <s3-sink-connector-aiven>`.
+
+Prerequisites
+-------------
+
+To setup the S3 sink connector by Confluent, you need an Aiven for Apache Kafka® service :doc:`with Apache Kafka Connect enabled <enable-connect>` or a :ref:`dedicated Aiven for Apache Kafka Connect cluster <apache_kafka_connect_dedicated_cluster>`.
+
+Furthermore you need to follow the steps :doc:`to prepare the AWS account and S3 sink <s3-sink-prereq>` and collect the following information about the target S3 bucket upfront:
+
+* ``AWS_S3_NAME``: The name of the S3 bucket
+* ``AWS_S3_REGION``: The AWS region where the S3 bucket has been created
+* ``AWS_USER_ACCESS_KEY_ID``: The AWS user access key ID
+* ``AWS_USER_SECRET_ACCESS_KEY``: The AWS user secret access key
+
+Setup an S3 sink connector with Aiven CLI
+-----------------------------------------
+
+The following example demonstrates how to setup an Apache Kafka Connect® S3 sink connector using the :ref:`Aiven CLI dedicated command <avn_service_connector_create>`.
+
+Define a Kafka Connect® configuration file
+''''''''''''''''''''''''''''''''''''''''''
+
+Define the connector configurations in a file (we'll refer to it with the name ``s3_sink.json``) with the following content:
+
+::
+
+    {
+        "name": "<CONECTOR_NAME>",
+        "topics": "<TOPIC_NAME>",
+        "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",
+        "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        "format.class": "io.confluent.connect.s3.format.bytearray.ByteArrayFormat",
+        "flush.size": "1",
+        "s3.bucket.name": "<AWS_S3_NAME>",
+        "s3.region": "<AWS_S3_REGION>",
+        "s3.credentials.provider.class": "io.aiven.kafka.connect.util.AivenAWSCredentialsProvider",
+        "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+        "s3.credentials.provider.secret_access_key": "<AWS_USER_SECRET_ACCESS_KEY>",
+        "s3.credentials.provider.access_key_id": "<AWS_USER_ACCESS_KEY_ID>"
+    }
+
+The configuration file contains the following entries:
+
+* ``name``: The connector name
+* ``topics``: The list of Apache Kafka® topics to sink to the S3 bucket
+* ``key.converter`` and ``value.converter``: Data converters, depending on the topic data format. Check the `related documentation <https://docs.confluent.io/5.0.0/connect/kafka-connect-s3/index.html>`_ for more information
+* ``format.class``: Defines the output data format in the S3 bucket. The ``io.confluent.connect.s3.format.bytearray.ByteArrayFormat`` writes messages in binary format.
+* ``flush.size``: Defines how many messages to write per file in the S3 bucket. E.g. setting ``flush.size`` to ``3`` generates a file every three messages in a topic and partition.
+* ``s3.bucket.name``: The name of the S3 bucket
+* ``s3.region``: The AWS region where the S3 bucket has been created
+* ``s3.credentials.provider.class``: The name of the class implementing the ``com.amazonaws.auth.AWSCredentialsProvider`` and ``org.apache.kafka.common.Configurable`` interfaces. Use ``io.aiven.kafka.connect.util.AivenAWSCredentialsProvider``.
+* ``s3.credentials.provider.secret_access_key``: The AWS user access key ID
+* ``s3.credentials.provider.access_key_id``: The AWS user secret access key
+
+Check out the `dedicated documentation <https://docs.confluent.io/5.0.0/connect/kafka-connect-s3/index.html>`_ for the full list of configuration options.
+
+
+Create an S3 sink connector with Aiven CLI
+''''''''''''''''''''''''''''''''''''''''''
+
+To create the connector, execute the following :ref:`Aiven CLI command <avn_service_connector_create>`, replacing the ``SERVICE_NAME`` with the name of the existing Aiven for Apache Kafka® service where the connector needs to run:
+
+:: 
+
+    avn service connector create SERVICE_NAME @s3_sink.json
+
+Check the connector status with the following command, replacing the ``SERVICE_NAME`` with the existing Aiven for Apache Kafka® service and the ``CONNECTOR_NAME`` with the name of the connector defined before:
+
+::
+
+    avn service connector status SERVICE_NAME CONNECTOR_NAME
+
+With the connection in place, verify that the data is flowing to the target S3 bucket.
+
+
+Example: define a S3 sink connector
+-----------------------------------
+
+The example creates an S3 sink connector with the following properties:
+
+* connector name: ``my_s3_sink``
+* source topics: ``students``
+* target S3 bucket name: ``my-test-bucket``
+* target S3 bucket region: ``eu-central-1``
+* AWS user access key id: ``AKIAXXXXXXXXXX``
+* AWS user secret access key: ``hELuXXXXXXXXXXXXXXXXXXXXXXXXXX``
+* generating a file in the S3 bucket every 10 messages
+
+The connector configuration is the following:
+
+::
+
+    {
+        "name": "my_s3_sink",
+        "topics": "students",
+        "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        "format.class": "io.confluent.connect.s3.format.bytearray.ByteArrayFormat",
+        "flush.size": "10",
+        "s3.bucket.name": "my-test-bucket",
+        "s3.region": "eu-central-1",
+        "s3.credentials.provider.class": "io.aiven.kafka.connect.util.AivenAWSCredentialsProvider",
+        "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+        "s3.credentials.provider.secret_access_key": "hELuXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "s3.credentials.provider.access_key_id": "AKIAXXXXXXXXXX"
+    }
+
+With the above configuration stored in a ``s3_sink.json`` file, you can create the connector in the ``demo-kafka`` instance with:
+
+::
+
+    avn service connector create demo-kafka @s3_sink.json

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
@@ -1,11 +1,11 @@
 Create an S3 sink connector by Confluent
 ========================================
 
-The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage.
+The **Apache Kafka Connect® S3 sink connector by Aiven** enables you to move data from an **Aiven for Apache Kafka®** cluster to **Amazon S3** for long term storage.
 
 .. Note::
 
-    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Confluent version. The S3 sink connector by Aiven is discussed in a :doc:`dedicated page <s3-sink-connector-aiven>`.
+    There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Confluent version. To learn about Aiven sink connector check out :doc:`the dedicated page <s3-sink-connector-aiven>`.
 
 Prerequisites
 -------------
@@ -57,8 +57,8 @@ The configuration file contains the following entries:
 * ``s3.bucket.name``: The name of the S3 bucket
 * ``s3.region``: The AWS region where the S3 bucket has been created
 * ``s3.credentials.provider.class``: The name of the class implementing the ``com.amazonaws.auth.AWSCredentialsProvider`` and ``org.apache.kafka.common.Configurable`` interfaces. Use ``io.aiven.kafka.connect.util.AivenAWSCredentialsProvider``.
-* ``s3.credentials.provider.secret_access_key``: The AWS user access key ID
-* ``s3.credentials.provider.access_key_id``: The AWS user secret access key
+* ``s3.credentials.provider.secret_access_key``: The AWS user secret access key
+* ``s3.credentials.provider.access_key_id``: The AWS user access key ID
 
 Check out the `dedicated documentation <https://docs.confluent.io/5.0.0/connect/kafka-connect-s3/index.html>`_ for the full list of configuration options.
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
@@ -1,0 +1,57 @@
+S3 sink connector by Confluent naming and data formats
+======================================================
+
+The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. The following document describes advanced parameters defining the naming and data formats.
+
+.. Warning::
+
+    Aiven provides, as managed service, two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
+    
+    This article is about the **Confluent** version. Documentation for the Aiven version is available at the :doc:`dedicated page <s3-sink-additional-parameters>`.
+
+
+S3 naming format
+---------------- 
+
+The Apache Kafka Connect® S3 sink connector by Confluent stores a series of files as objects in the specified S3 bucket. By default, each object is named using the pattern:
+
+::
+
+    topics/<TOPIC_NAME>/partition=<PARTITION_NUMBER>/<TOPIC_NAME>+<PARTITIOIN_NUMBER>+<START_OFFSET>.<FILE_EXTENSION>
+
+The placeholders are the following:
+
+* ``TOPIC_NAME``: Name of the topic to be pushed to S3
+* ``PARTITION_NUMBER``: Topic partitions number
+* ``START_OFFSET``: File starting offset
+* ``FILE_EXTENSION``: The file extension depends on serialization format defined. The ``bin`` extension is generated when serializing messages in binary format.
+
+For example, a topic with 3 partitions generates initially the following files in the destination S3 bucket:
+
+::
+
+    topics/<TOPIC_NAME>/partition=0/<TOPIC_NAME>+0+0000000000.bin
+    topics/<TOPIC_NAME>/partition=1/<TOPIC_NAME>+1+0000000000.bin
+    topics/<TOPIC_NAME>/partition=2/<TOPIC_NAME>+2+0000000000.bin
+
+S3 data format
+--------------
+
+By default, data is stored in binary format, one line per message. The connector creates a file every ``X`` messages, where ``X`` is defined by the ``flush.size`` parameter. Setting the ``flush.size`` parameter to ``1`` generates a file for each message in a topic. 
+
+In the above example, having a topic with 3 partitions and 10 messages, setting the ``flush.size`` parameter to 1 generates the following files (one per message) in the destination S3 bucket:
+
+::
+
+    topics/<TOPIC_NAME>/partition=0/<TOPIC_NAME>+0+0000000000.bin
+    topics/<TOPIC_NAME>/partition=0/<TOPIC_NAME>+0+0000000001.bin
+    topics/<TOPIC_NAME>/partition=0/<TOPIC_NAME>+0+0000000002.bin
+    topics/<TOPIC_NAME>/partition=0/<TOPIC_NAME>+0+0000000003.bin
+    topics/<TOPIC_NAME>/partition=1/<TOPIC_NAME>+1+0000000000.bin
+    topics/<TOPIC_NAME>/partition=1/<TOPIC_NAME>+1+0000000001.bin
+    topics/<TOPIC_NAME>/partition=1/<TOPIC_NAME>+1+0000000002.bin
+    topics/<TOPIC_NAME>/partition=2/<TOPIC_NAME>+2+0000000000.bin
+    topics/<TOPIC_NAME>/partition=2/<TOPIC_NAME>+2+0000000001.bin
+    topics/<TOPIC_NAME>/partition=2/<TOPIC_NAME>+2+0000000002.bin
+
+You can find additional documentation at the `dedicated page <https://docs.confluent.io/5.0.0/connect/kafka-connect-s3/index.html>`_.

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
@@ -5,7 +5,7 @@ The Apache Kafka Connect® S3 sink connector enables you to move data from an Ai
 
 .. Warning::
 
-    Aiven provides, as managed service, two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
+    As managed service Aiven provides two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
     
     This article is about the **Confluent** version. Documentation for the Aiven version is available at the :doc:`dedicated page <s3-sink-additional-parameters>`.
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
@@ -1,7 +1,7 @@
 S3 sink connector by Confluent naming and data formats
 ======================================================
 
-The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. The following document describes advanced parameters defining the naming and data formats.
+The **Apache Kafka Connect® S3 sink connector** enables you to move data from an **Aiven for Apache Kafka®** cluster to **Amazon S3** for long term storage. The following document describes advanced parameters defining the naming and data formats.
 
 .. Warning::
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent.rst
@@ -5,9 +5,9 @@ The Apache Kafka Connect® S3 sink connector enables you to move data from an Ai
 
 .. Warning::
 
-    As managed service Aiven provides two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
+    Aiven provides two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
     
-    This article is about the **Confluent** version. Documentation for the Aiven version is available at the :doc:`dedicated page <s3-sink-additional-parameters>`.
+    This article is about the **Confluent** version. Documentation for the Aiven version is available in the :doc:`dedicated page <s3-sink-additional-parameters>`.
 
 
 S3 naming format

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
@@ -1,7 +1,13 @@
-S3 sink connector naming and data formats
-=========================================
+S3 sink connector by Aiven naming and data formats
+==================================================
 
-The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. The following document describes advanced parameters defining the naming and data formats.
+The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. The following document describes advanced parameters defining the naming and data formats.
+
+.. Warning::
+
+    Aiven provides, as managed service, two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
+    
+    This article is about the **Aiven** version. Documentation for the Confluent version is available at the :doc:`dedicated page <s3-sink-additional-parameters-confluent>`.
 
 
 S3 naming format

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
@@ -1,7 +1,7 @@
 S3 sink connector by Aiven naming and data formats
 ==================================================
 
-The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. The following document describes advanced parameters defining the naming and data formats.
+The **Apache Kafka Connect® S3 sink connector** by Aiven enables you to move data from an **Aiven for Apache Kafka®** cluster to **Amazon S3** for long term storage. The following document describes advanced parameters defining the naming and data formats.
 
 .. Warning::
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
@@ -5,7 +5,7 @@ The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data f
 
 .. Warning::
 
-    Aiven provides, as managed service, two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
+    Aiven provides two version of S3 sink connector: one developed by Aiven, another developed by Confluent. 
     
     This article is about the **Aiven** version. Documentation for the Confluent version is available at the :doc:`dedicated page <s3-sink-additional-parameters-confluent>`.
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
@@ -1,0 +1,9 @@
+AWS S3 sink connector naming and data formats
+=============================================
+
+The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. 
+
+Aiven provides, as managed service, two version of the S3 sink connector, each one having different naming and data formats:
+
+* :doc:`Aiven for Apache Kafka - S3 sink connector by Aiven <s3-sink-additional-parameters>`
+* :doc:`Aiven for Apache Kafka - S3 sink connector by Confluent <s3-sink-additional-parameters-confluent>`

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
@@ -1,7 +1,7 @@
 AWS S3 sink connector naming and data formats
 =============================================
 
-The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. 
+The **Apache Kafka Connect® S3 sink connector** enables you to move data from an **Aiven for Apache Kafka®** cluster to **Amazon S3** for long term storage. 
 
 Aiven provides two version of the S3 sink connector, each one having different naming and data formats:
 

--- a/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-formats.rst
@@ -3,7 +3,7 @@ AWS S3 sink connector naming and data formats
 
 The Apache Kafka Connect® S3 sink connector enables you to move data from an Aiven for Apache Kafka® cluster to Amazon S3 for long term storage. 
 
-Aiven provides, as managed service, two version of the S3 sink connector, each one having different naming and data formats:
+Aiven provides two version of the S3 sink connector, each one having different naming and data formats:
 
 * :doc:`Aiven for Apache Kafka - S3 sink connector by Aiven <s3-sink-additional-parameters>`
 * :doc:`Aiven for Apache Kafka - S3 sink connector by Confluent <s3-sink-additional-parameters-confluent>`


### PR DESCRIPTION
# What changed, and why it matters
 
Migrated Kafka Connect s3 sink by Confluent (https://help.aiven.io/en/articles/2413736-aiven-for-apache-kafka-s3-sink-connector-by-confluent)

Split across multiple pages and fixed previous references to the ones "by Aiven"

Fix #561 