### PR TITLE
Add more ® to "front" matter

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -57,7 +57,7 @@ entries:
 
   # -------- PRODUCT-SPECIFIC --------
   - file: docs/products/kafka/index
-    title: Apache Kafka
+    title: Apache Kafka®
     entries:
       - file: docs/products/kafka/getting-started
       - file: docs/products/kafka/concepts
@@ -96,7 +96,7 @@ entries:
         entries:
           - glob: docs/products/kafka/reference/*
       - file: docs/products/kafka/kafka-connect/index
-        title: Apache Kafka Connect
+        title: Apache Kafka® Connect
         entries:
         - file: docs/products/kafka/kafka-connect/getting-started
         - file: docs/products/kafka/kafka-connect/concepts
@@ -122,7 +122,7 @@ entries:
             - file: docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters
 
       - file: docs/products/kafka/kafka-mirrormaker/index
-        title: Apache Kafka MirrorMaker2
+        title: Apache Kafka® MirrorMaker2
         entries:
         - file: docs/products/kafka/kafka-mirrormaker/getting-started
         - file: docs/products/kafka/kafka-mirrormaker/concepts
@@ -141,7 +141,7 @@ entries:
             - glob: docs/products/kafka/kafka-mirrormaker/reference/*
 
   - file: docs/products/postgresql/index
-    title: PostgreSQL
+    title: PostgreSQL®
     entries:
       - file: docs/products/postgresql/getting-started
       - file: docs/products/postgresql/howto/pagila
@@ -247,7 +247,7 @@ entries:
           - glob: docs/products/clickhouse/reference/*
 
   - file: docs/products/opensearch/index
-    title: OpenSearch
+    title: OpenSearch®
     entries:
       - file: docs/products/opensearch/getting-started
         title: Getting started
@@ -278,7 +278,7 @@ entries:
           - file: docs/products/opensearch/howto/set_index_retention_patterns
           - file: docs/products/opensearch/howto/opensearch-alerting-api
       - file: docs/products/opensearch/dashboards/index
-        title: OpenSearch Dashboards
+        title: OpenSearch® Dashboards
         entries:
           - file: docs/products/opensearch/dashboards/getting-started
           - file: docs/products/opensearch/dashboards/howto
@@ -295,7 +295,7 @@ entries:
             title: Advanced Parameters
 
   - file: docs/products/m3db/index
-    title: M3DB
+    title: M3
     entries:
       - file: docs/products/m3db/getting-started
       - file: docs/products/m3db/concepts
@@ -325,7 +325,7 @@ entries:
           - glob: docs/products/mysql/reference/*
 
   - file: docs/products/redis/index
-    title: Redis
+    title: Redis™*
     entries:
       - file: docs/products/redis/get-started
         title: Getting started
@@ -357,10 +357,10 @@ entries:
           - glob: docs/products/redis/reference/*
 
   - file: docs/products/cassandra/index
-    title: Apache Cassandra
+    title: "Apache Cassandra®"
 
   - file: docs/products/grafana/index
-    title: Grafana
+    title: Grafana®
     entries:
       - file: docs/products/grafana/get-started
       - file: docs/products/grafana/howto

--- a/docs/products/clickhouse/index.rst
+++ b/docs/products/clickhouse/index.rst
@@ -1,5 +1,5 @@
-ClickHouse :badge:`beta,cls=badge-secondary text-black badge-pill`
-==================================================================
+ClickHouse® :badge:`beta,cls=badge-secondary text-black badge-pill`
+===================================================================
 
 .. note::
    The Aiven for ClickHouse service is currently available as a beta release and is intended for **non-production use**.

--- a/docs/products/flink/index.rst
+++ b/docs/products/flink/index.rst
@@ -1,5 +1,5 @@
-Apache Flink :badge:`beta,cls=badge-secondary text-black badge-pill`
-====================================================================
+Apache Flink® :badge:`beta,cls=badge-secondary text-black badge-pill`
+=====================================================================
 
 What is Aiven for Apache Flink?
 -------------------------------

--- a/docs/products/opensearch/index.rst
+++ b/docs/products/opensearch/index.rst
@@ -42,9 +42,10 @@ Ways to use OpenSearch
 
 OpenSearch is ideal for working with various types of unstructured data, where you need to be able to find things quickly. The most common examples include:
 
-* Send your **logs** to OpenSearch so that you can quickly identify and diagnose problems if they arise. 
-.. tip::
-    Check how to send logs from a service to your OpenSearch service :doc:`by enabling log integration <howto/opensearch-log-integration>` feature.
+* Send your **logs** to OpenSearch so that you can quickly identify and diagnose problems if they arise.
+
+  .. tip::
+     Check how to send logs from a service to your OpenSearch service :doc:`by enabling log integration <howto/opensearch-log-integration>` feature.
 
 * Use OpenSearch to index documents, so that you can get meaningful **search results** from a large body of knowledge.
 

--- a/index.rst
+++ b/index.rst
@@ -141,7 +141,7 @@ Learn about the Aiven platform
     
     ---
 
-    |icon-clickhouse| **ClickHouse** A highly scalable, open source database that uses a column-oriented structure. :badge:`beta,cls=badge-secondary text-black badge-pill`
+    |icon-clickhouse| **ClickHouse®** A highly scalable, open source database that uses a column-oriented structure. :badge:`beta,cls=badge-secondary text-black badge-pill`
 
     +++
 


### PR DESCRIPTION
These changes make the names visible in the ToC sidebar have appropriate marks.

1. Add ® to `title` elements in the _toc.yml. Not all of these get
   displayed, but it seems sensible to correct them anyway.
2. Add missing ® to ClickHouse in the main index.
3. Add ® to those product index pages whose titles are used for the
   ToC.
4. Fix a `tip` in the opensearch index page that was giving
   reStructuredText syntax errors.


