### PR TITLE
Update list of Kafka Connectors

### DIFF
--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -60,7 +60,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
-* Opensearch
+* OpenSearch
 
 * `Snowflake <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`__ :badge:`preview,cls=badge-secondary badge-pill`
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -9,54 +9,58 @@ Source connectors
 
 Source connectors enable the integration of data from an existing technology into an Apache Kafka topic. The following is the list of available source connectors:
 
-* `Couchbase <https://github.com/couchbase/kafka-connect-couchbase>`__
+* `Couchbase <https://github.com/couchbase/kafka-connect-couchbase>`__ (author: Couchbase)
 
-* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
+* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill` (author: MongoDB)
 
-* `Debezium for MongoDB <https://debezium.io/docs/connectors/mongodb/>`__
+* `Debezium for MongoDB <https://debezium.io/docs/connectors/mongodb/>`__ (author: Debezium)
 
-* `Debezium for MySQL <https://debezium.io/docs/connectors/mysql/>`__
+* `Debezium for MySQL <https://debezium.io/docs/connectors/mysql/>`__ (author: Debezium)
 
-* `Debezium for PostgreSQL <https://help.aiven.io/kafka/setting-up-debezium-with-aiven-postgresql>`__
+* `Debezium for PostgreSQL <https://help.aiven.io/kafka/setting-up-debezium-with-aiven-postgresql>`__ (author: Debezium)
 
-* `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__
+* `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__ (author: Debezium)
 
-* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector>`__
+* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector>`__ (author: Google)
 
-* `JDBC <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`__
+* Google Cloud Pub/Sub Lite (author: Google)
 
-* Schema Source
+* `JDBC <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`__ (author: Aiven)
 
-* `Stream Reactor Cassandra <https://docs.lenses.io/connectors/source/cassandra.html>`__
+* Schema Source (author: Confluent)
 
-* `Stream Reactor MQTT <https://docs.lenses.io/connectors/source/mqtt.html>`__
+* `Stream Reactor Cassandra <https://docs.lenses.io/connectors/source/cassandra.html>`__ (author: Lenses.io)
+
+* `Stream Reactor MQTT <https://docs.lenses.io/connectors/source/mqtt.html>`__ (author: Lenses.io)
 
 Sink connectors
 -----------------
 
 Sink connectors enable the integration of data from an existing Apache Kafka topic to a target technology. The following is the list of available sink connectors:
 
-* `Aiven for Kafka GCS Sink Connector <https://help.aiven.io/kafka/connectors/aiven-kafka-gcs-sink-connector>`__
-
 * `Aiven for Kafka S3 Sink Connector <https://help.aiven.io/kafka/connectors/aiven-kafka-s3-sink-connector>`__
 
 * `Confluent Amazon S3 Sink <https://help.aiven.io/kafka/aiven-kafka-kafka-connect-s3>`__
-
-* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
 * `Couchbase <https://github.com/couchbase/kafka-connect-couchbase>`__
 
 * `Elasticsearch <https://help.aiven.io/kafka/aiven-kafka-elasticsearch-sink-connector>`__
 
-* `Confluent Elasticsearch Sink <https://docs.confluent.io/kafka-connect-elasticsearch/current/index.html>`__
+* `Google BigQuery <https://github.com/wepay/kafka-connect-bigquery>`__
 
 * `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/>`__
 
-* `Google BigQuery <https://github.com/wepay/kafka-connect-bigquery>`__
+* Google Cloud Pub/Sub Lite
+
+* Google Cloud Storage
 
 * `HTTP <https://github.com/aiven/aiven-kafka-connect-http>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
 * `JDBC <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/sink-connector.md>`__
+
+* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
+
+* Opensearch
 
 * `Snowflake <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`__ :badge:`preview,cls=badge-secondary badge-pill`
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -9,29 +9,29 @@ Source connectors
 
 Source connectors enable the integration of data from an existing technology into an Apache Kafka topic. The following is the list of available source connectors:
 
-* `Couchbase <https://github.com/couchbase/kafka-connect-couchbase>`__ (author: Couchbase)
+* `Couchbase <https://github.com/couchbase/kafka-connect-couchbase>`__
 
-* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill` (author: MongoDB)
+* `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
-* `Debezium for MongoDB <https://debezium.io/docs/connectors/mongodb/>`__ (author: Debezium)
+* `Debezium for MongoDB <https://debezium.io/docs/connectors/mongodb/>`__ 
 
-* `Debezium for MySQL <https://debezium.io/docs/connectors/mysql/>`__ (author: Debezium)
+* `Debezium for MySQL <https://debezium.io/docs/connectors/mysql/>`__ 
 
-* `Debezium for PostgreSQL <https://help.aiven.io/kafka/setting-up-debezium-with-aiven-postgresql>`__ (author: Debezium)
+* `Debezium for PostgreSQL <https://help.aiven.io/kafka/setting-up-debezium-with-aiven-postgresql>`__ 
 
-* `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__ (author: Debezium)
+* `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__ 
 
-* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector>`__ (author: Google)
+* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector>`__ 
 
-* Google Cloud Pub/Sub Lite (author: Google)
+* `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_ 
 
-* `JDBC <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`__ (author: Aiven)
+* `JDBC <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`__ 
 
-* Schema Source (author: Confluent)
+* Schema Source 
 
-* `Stream Reactor Cassandra <https://docs.lenses.io/connectors/source/cassandra.html>`__ (author: Lenses.io)
+* `Stream Reactor Cassandra <https://docs.lenses.io/connectors/source/cassandra.html>`__ 
 
-* `Stream Reactor MQTT <https://docs.lenses.io/connectors/source/mqtt.html>`__ (author: Lenses.io)
+* `Stream Reactor MQTT <https://docs.lenses.io/connectors/source/mqtt.html>`__ 
 
 Sink connectors
 -----------------
@@ -50,9 +50,9 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/>`__
 
-* Google Cloud Pub/Sub Lite
+* `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_
 
-* Google Cloud Storage
+* `Google Cloud Storage <https://help.aiven.io/kafka/connectors/aiven-kafka-gcs-sink-connector>`_
 
 * `HTTP <https://github.com/aiven/aiven-kafka-connect-http>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
@@ -60,7 +60,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Official MongoDB <https://docs.mongodb.com/kafka-connector/current/>`__ :badge:`preview,cls=badge-secondary badge-pill`
 
-* OpenSearch
+* `OpenSearch <https://github.com/aiven/opensearch-connector-for-apache-kafka/blob/main/docs/opensearch-sink-connector-config-options.rst>`_ :badge:`preview,cls=badge-secondary badge-pill`
 
 * `Snowflake <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`__ :badge:`preview,cls=badge-secondary badge-pill`
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -1,7 +1,7 @@
-List of available Apache Kafka Connect connectors
+List of available Apache Kafka® Connect connectors
 =================================================
 
-The following connectors can be used in any Aiven for Kafka services with Kafka Connect enabled. 
+The following connectors can be used in any Aiven for Apache Kafka® services with Apache Kafka Connect enabled. 
 
 
 Source connectors
@@ -17,7 +17,7 @@ Source connectors enable the integration of data from an existing technology int
 
 * `Debezium for MySQL <https://debezium.io/docs/connectors/mysql/>`__ 
 
-* `Debezium for PostgreSQL <https://help.aiven.io/kafka/setting-up-debezium-with-aiven-postgresql>`__ 
+* :doc:`Debezium for PostgreSQL <../howto/debezium-source-connector-pg>` 
 
 * `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__ 
 
@@ -38,7 +38,7 @@ Sink connectors
 
 Sink connectors enable the integration of data from an existing Apache Kafka topic to a target technology. The following is the list of available sink connectors:
 
-* `Aiven for Kafka S3 Sink Connector <https://help.aiven.io/kafka/connectors/aiven-kafka-s3-sink-connector>`__
+* `Aiven for Apache Kafka S3 Sink Connector <https://help.aiven.io/kafka/connectors/aiven-kafka-s3-sink-connector>`__
 
 * `Confluent Amazon S3 Sink <https://help.aiven.io/kafka/aiven-kafka-kafka-connect-s3>`__
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -1,5 +1,5 @@
 List of available Apache Kafka® Connect connectors
-=================================================
+==================================================
 
 The following connectors can be used in any Aiven for Apache Kafka® services with Apache Kafka Connect enabled. 
 
@@ -38,7 +38,7 @@ Sink connectors
 
 Sink connectors enable the integration of data from an existing Apache Kafka topic to a target technology. The following is the list of available sink connectors:
 
-* `Aiven for Apache Kafka S3 Sink Connector <https://help.aiven.io/kafka/connectors/aiven-kafka-s3-sink-connector>`__
+* :doc:`Aiven for Apache Kafka S3 Sink Connector <../howto/s3-sink-connector-aiven>`
 
 * `Confluent Amazon S3 Sink <https://help.aiven.io/kafka/aiven-kafka-kafka-connect-s3>`__
 


### PR DESCRIPTION
Playing around in the console I noticed that the list of Kafka connectors on https://developer.aiven.io/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins is out of sync with the one in the console:
![screencapture-console-aiven-io-project-dev-sandbox-services-kafkaconnect-1c60b577-connectors-2022-02-11-15_38_08](https://user-images.githubusercontent.com/1087213/153622208-e13ca2b9-73ba-4882-8b6a-b847152eeef7.png)

Made a few additions, and removed connectors that no longer show up in the console:
* Aiven for Kafka GCS Sink Connector https://help.aiven.io/kafka/connectors/aiven-kafka-gcs-sink-connector>
* Confluent Elasticsearch Sink https://docs.confluent.io/kafka-connect-elasticsearch/current/index.html>

For the Source connectors, maybe we can change the "Debezium for PostgreSQL" to link to a developer.aiven.io page (instead of help)?
Same goes for the following sink connectors: 
- Aiven for Kafka GCS Sink Connector
- Aiven for Kafka S3 Sink Connector 
- Confluent Amazon S3 Sink
- Elasticsearch (#566)

(Some of these could be in #319 still)

And do we want to list the authors of the connectors (I don't want to cram the page with info, but it can be interesting information?). A screenshot:

![screencapture-localhost-8000-docs-products-kafka-kafka-connect-concepts-list-of-connector-plugins-html-2022-02-11-16_30_20](https://user-images.githubusercontent.com/1087213/153622590-ad61fcea-1402-43b8-8838-4f76a9b77b6b.png)

