### PR TITLE
Reorganised Kafka Connect HowTo

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -127,16 +127,22 @@ entries:
         - file: docs/products/kafka/kafka-connect/howto
           title: HowTo
           entries:
-          - file: docs/products/kafka/kafka-connect/howto/best-practices
-          - file: docs/products/kafka/kafka-connect/howto/enable-connect
-          - file: docs/products/kafka/kafka-connect/howto/enable-automatic-restart
-          - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg
-          - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-mysql
-          - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-sql-server
-          - file: docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg
-          - file: docs/products/kafka/kafka-connect/howto/s3-sink-prereq
-          - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven
-          - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent
+          - file: docs/products/kafka/kafka-connect/howto/list-admin
+            entries:
+            - file: docs/products/kafka/kafka-connect/howto/best-practices
+            - file: docs/products/kafka/kafka-connect/howto/enable-connect
+            - file: docs/products/kafka/kafka-connect/howto/enable-automatic-restart
+          - file: docs/products/kafka/kafka-connect/howto/list-source-connectors
+            entries:
+            - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg
+            - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-mysql
+            - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-sql-server
+            - file: docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg
+          - file: docs/products/kafka/kafka-connect/howto/list-sink-connectors
+            entries:
+            - file: docs/products/kafka/kafka-connect/howto/s3-sink-prereq
+            - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven
+            - file: docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent
         - file: docs/products/kafka/kafka-connect/reference
           title: Reference
           entries:

--- a/docs/products/kafka/kafka-connect/howto/list-admin.rst
+++ b/docs/products/kafka/kafka-connect/howto/list-admin.rst
@@ -1,0 +1,4 @@
+Administration tasks
+====================
+
+.. tableofcontents::

--- a/docs/products/kafka/kafka-connect/howto/list-sink-connectors.rst
+++ b/docs/products/kafka/kafka-connect/howto/list-sink-connectors.rst
@@ -1,0 +1,4 @@
+Source connectors
+====================
+
+.. tableofcontents::

--- a/docs/products/kafka/kafka-connect/howto/list-source-connectors.rst
+++ b/docs/products/kafka/kafka-connect/howto/list-source-connectors.rst
@@ -1,0 +1,4 @@
+Source connectors
+====================
+
+.. tableofcontents::


### PR DESCRIPTION
# What changed, and why it matters

This PR reorganises Kafka Connect HowTo t split it into sections (rather than a huge list of articles). Sections are:
* Admin tasks
* Source Connectors
* Sink Connectors

Fixed #582 
