### PR TITLE
OpenSearch: Get data mapping with Python

### DIFF
--- a/docs/products/opensearch/howto/sample-dataset.rst
+++ b/docs/products/opensearch/howto/sample-dataset.rst
@@ -144,10 +144,10 @@ OpenSearch Python client offers a helper called bulk() which allows us to send m
 
 Get data mapping with Python
 ----------------------------
-When the data has been sent to OpenSearch cluster on :ref:`load the data with Python <load-data-with-python>`, no data structure was specified.
-This is possible because OpenSearch has `dynamic mapping feature <https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/#mappings>`_ that automatically add the fields to their type mapping.
+When we sent the data to OpenSearch cluster on :ref:`load the data with Python <load-data-with-python>`, no data structure was specified.
+This is possible because OpenSearch uses **dynamic mapping** to automatically add the fields to their type mapping. 
 
-To check the mapping definition, we will use ``get_mapping`` method with the index name as argument.
+Use ``get_mapping`` method with the index name as the argument to check the mapping definition of your data.
 
 .. code:: python
 
@@ -161,7 +161,40 @@ To check the mapping definition, we will use ``get_mapping`` method with the ind
 
     schema = mapping_data[INDEX_NAME]["mappings"][doc_type]
     print(f"Fields: {list(schema.keys())} \n")
-    pprint(schema, width=80, indent=0)
+    pprint(schema, width=50, indent=1)
+
+You should be able to see this output:
+
+.. code-block:: bash
+
+    Fields: ['calories', 'categories', 'date', 'desc', 'directions', 'fat', 'ingredients', 'protein', 'rating', 'sodium', 'title'] 
+
+And the mapping with the fields and their respective types.
+
+.. code-block:: bash
+
+    {'calories': {'type': 'float'},
+    'categories': {'fields': {'keyword': {'ignore_above': 256,
+                                        'type': 'keyword'}},
+                    'type': 'text'},
+    'date': {'type': 'date'},
+    'desc': {'fields': {'keyword': {'ignore_above': 256,
+                                    'type': 'keyword'}},
+            'type': 'text'},
+    'directions': {'fields': {'keyword': {'ignore_above': 256,
+                                        'type': 'keyword'}},
+                    'type': 'text'},
+    'fat': {'type': 'float'},
+    'ingredients': {'fields': {'keyword': {'ignore_above': 256,
+                                            'type': 'keyword'}},
+                    'type': 'text'},
+    'protein': {'type': 'float'},
+    'rating': {'type': 'float'},
+    'sodium': {'type': 'float'},
+    'title': {'fields': {'keyword': {'ignore_above': 256,
+                                    'type': 'keyword'}},
+            'type': 'text'}}
+
 
 
 .. seealso::

--- a/docs/products/opensearch/howto/sample-dataset.rst
+++ b/docs/products/opensearch/howto/sample-dataset.rst
@@ -40,55 +40,6 @@ Let's take a look at a sample recipe document:
         "sodium": 959.0,
     }
 
-Sample queries with HTTP client
--------------------------------
-
-With the data in place, we can start trying some queries against your OpenSearch service. Since it has a simple HTTP interface, you can use your favorite HTTP client. In these examples, we will use `httpie <https://github.com/httpie/httpie>`_ because it's one of our favorites.
-
-First, export the ``SERVICE_URI`` variable with your OpenSearch service URI address and index name from the previous script:
-
-.. code:: bash
-
-    export SERVICE_URI="YOUR_SERVICE_URI_HERE/epicurious-recipes"
-
-1. Execute a basic search for the word ``vegan`` across all documents and fields:
-
-.. code:: bash
-
-    http "$SERVICE_URI/_search?q=vegan"
-
-2. Search for ``vegan`` in the ``desc`` or ``title`` fields only: 
-
-.. code:: bash
-
-    http POST "$SERVICE_URI/_search" <<< '
-    {
-        "query": {
-            "multi_match": {
-                "query": "vegan",
-                "fields": ["desc", "title"]
-            }
-        }
-    }
-    '
-
-3. Search for recipes published only in 2013:
-
-.. code:: bash
-
-    http POST "$SERVICE_URI/_search" <<< '
-    {
-        "query": {
-            "range" : {
-                "date": {
-                "gte": "2013-01-01",
-                "lte": "2013-12-31"
-                }
-            }
-        }
-    }
-    '
-
 .. _load-data-with-python:
 
 Load the data with Python
@@ -283,6 +234,55 @@ You should be able to see the following structure:
     }
 
 These are the fields you can play with. You can find information on dynamic mapping types `in the documentation <https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/#dynamic-mapping-types>`_.
+
+Sample queries with HTTP client
+-------------------------------
+
+With the data in place, we can start trying some queries against your OpenSearch service. Since it has a simple HTTP interface, you can use your favorite HTTP client. In these examples, we will use `httpie <https://github.com/httpie/httpie>`_ because it's one of our favorites.
+
+First, export the ``SERVICE_URI`` variable with your OpenSearch service URI address and index name from the previous script:
+
+.. code:: bash
+
+    export SERVICE_URI="YOUR_SERVICE_URI_HERE/epicurious-recipes"
+
+1. Execute a basic search for the word ``vegan`` across all documents and fields:
+
+.. code:: bash
+
+    http "$SERVICE_URI/_search?q=vegan"
+
+2. Search for ``vegan`` in the ``desc`` or ``title`` fields only: 
+
+.. code:: bash
+
+    http POST "$SERVICE_URI/_search" <<< '
+    {
+        "query": {
+            "multi_match": {
+                "query": "vegan",
+                "fields": ["desc", "title"]
+            }
+        }
+    }
+    '
+
+3. Search for recipes published only in 2013:
+
+.. code:: bash
+
+    http POST "$SERVICE_URI/_search" <<< '
+    {
+        "query": {
+            "range" : {
+                "date": {
+                "gte": "2013-01-01",
+                "lte": "2013-12-31"
+                }
+            }
+        }
+    }
+    '
 
 Ready for a challenge?
 ----------------------

--- a/docs/products/opensearch/howto/sample-dataset.rst
+++ b/docs/products/opensearch/howto/sample-dataset.rst
@@ -95,14 +95,12 @@ OpenSearch Python client offers a helper called bulk() which allows us to send m
 
 Get data mapping with Python
 ----------------------------
-When we sent the data to OpenSearch cluster on :ref:`load the data with Python <load-data-with-python>`, no data structure was specified.
-This is possible because OpenSearch uses **dynamic mapping** to automatically add the fields to their type mapping. 
 
-Use ``get_mapping`` method with the index name as the argument to check the mapping definition of your data.
+When no data structure is specified, which is our case as shown on :ref:`load the data with Python <load-data-with-python>`, OpenSearch uses dynamic mapping to automatically detect the fields. To check the mapping definition of your data, OpenSearch client provides a function called ``get_mapping`` as shown:
 
 .. code:: python
 
-    from pprint import pprint
+    import pprint
 
     INDEX_NAME = 'epicurious-recipes'
     mapping_data = os_client.indices.get_mapping(INDEX_NAME)
@@ -111,46 +109,52 @@ Use ``get_mapping`` method with the index name as the argument to check the mapp
     doc_type = list(mapping_data[INDEX_NAME]["mappings"].keys())[0]
 
     schema = mapping_data[INDEX_NAME]["mappings"][doc_type]
-    print(f"Fields: {list(schema.keys())} \n")
-    pprint(schema, width=50, indent=1)
+    fields =  list(schema.keys())
+    pprint(fields)
+    pprint(schema)
 
-You should be able to see this output:
+You should be able to see the fields's output:
 
 .. code-block:: bash
 
-    Fields: ['calories', 'categories', 'date', 'desc', 'directions', 'fat', 'ingredients', 'protein', 'rating', 'sodium', 'title'] 
+    ['calories',
+    'categories',
+    'date',
+    'desc',
+    'directions',
+    'fat',
+    'ingredients',
+    'protein',
+    'rating',
+    'sodium',
+    'title']
 
 And the mapping with the fields and their respective types.
 
 .. code-block:: bash
 
-    {'calories': {'type': 'float'},
-    'categories': {'fields': {'keyword': {'ignore_above': 256,
-                                        'type': 'keyword'}},
-                    'type': 'text'},
-    'date': {'type': 'date'},
-    'desc': {'fields': {'keyword': {'ignore_above': 256,
-                                    'type': 'keyword'}},
-            'type': 'text'},
-    'directions': {'fields': {'keyword': {'ignore_above': 256,
-                                        'type': 'keyword'}},
-                    'type': 'text'},
-    'fat': {'type': 'float'},
-    'ingredients': {'fields': {'keyword': {'ignore_above': 256,
-                                            'type': 'keyword'}},
-                    'type': 'text'},
-    'protein': {'type': 'float'},
-    'rating': {'type': 'float'},
-    'sodium': {'type': 'float'},
-    'title': {'fields': {'keyword': {'ignore_above': 256,
-                                    'type': 'keyword'}},
-            'type': 'text'}}
-
-
+        {'calories': {'type': 'float'},
+         'categories': {'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                        'type': 'text'},
+         'date': {'type': 'date'},
+         'desc': {'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                  'type': 'text'},
+         'directions': {'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                        'type': 'text'},
+         'fat': {'type': 'float'},
+         'ingredients': {'fields': {'keyword': {'ignore_above': 256,
+                                                'type': 'keyword'}},
+                         'type': 'text'},
+         'protein': {'type': 'float'},
+         'rating': {'type': 'float'},
+         'sodium': {'type': 'float'},
+         'title': {'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                   'type': 'text'}}
+        
 
 .. seealso::
 
-    More about `OpenSearch mapping <https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/#mappings>`_ 
+    Read more about OpenSearch mapping in the `official OpenSearch documentation <https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/create-index/#mappings>`_.
 
 
 .. _load-data-with-nodejs:


### PR DESCRIPTION
This adds sample code in `Howto Get data mapping with Python` for OpenSearch code. 
I will make reference to the OpenSearch section `How to write search queries with Python`. So I'm adding tags to refer later.

I have changed the order to first: HTTP subjects, Python subjects and NodeJS. 

We should think in another PR how to organize this file structure better.

Fixes: https://github.com/aiven/devportal/issues/587