### PR TITLE
Fix typo in PG replication slot name

### DIFF
--- a/docs/products/postgresql/howto/setup-logical-replication.rst
+++ b/docs/products/postgresql/howto/setup-logical-replication.rst
@@ -163,7 +163,7 @@ The command output is like::
 
 * If the ``dest_slot`` connector is no longer needed, run the following command to remove it::
 
-    SELECT pg_drop_replication_slot('dest_subscription');
+    SELECT pg_drop_replication_slot('dest_slot');
 
 4. In both cases, after the next PostgreSQL checkpoint, the disk space that the WAL logs have reserved for the ``dest_subscription`` connector should be freed up.
 


### PR DESCRIPTION
# What changed, and why it matters

There's a typo in the name of the replication slot - it's been copied from the subscription name, not the slot name.
