### PR TITLE
Updated PostgeSQL logical replication is supported by GCP CloudSQL

### DIFF
--- a/docs/products/postgresql/concepts/aiven-db-migrate.rst
+++ b/docs/products/postgresql/concepts/aiven-db-migrate.rst
@@ -8,7 +8,7 @@ Logical replication is the default method and once successfully set up, this kee
 Regardless of the migration method used, the migration tool first performs a schema dump and migration to ensure schema compatibility.
 
 .. Note::
-    Logical replication also works when migrating from AWS RDS PostgreSQL 10+. Google Cloud Platform's PostgreSQL for CloudSQL does not support logical replication.
+    Logical replication also works when migrating from AWS RDS PostgreSQL 10+ and `Google CloudSQL PostgreSQL <https://cloud.google.com/sql/docs/release-notes#August_30_2021>`_.
 
 .. _aiven-db-migrate-migration-requirements:
 

--- a/docs/products/postgresql/howto/migrate-aiven-db-migrate.rst
+++ b/docs/products/postgresql/howto/migrate-aiven-db-migrate.rst
@@ -10,7 +10,7 @@ Logical replication is the default method which keeps the two databases synchron
 If the preconditions for logical replication are not met for a database, the migration falls back to using ``pg_dump``.
 
 .. Note::
-    You can use logical replication when migrating from AWS RDS PostgreSQL 10+, whereas the Google Cloud Platform's PostgreSQL for CloudSQL does not support it.
+    You can use logical replication when migrating from AWS RDS PostgreSQL 10+ and `Google CloudSQL PostgreSQL <https://cloud.google.com/sql/docs/release-notes#August_30_2021>`_.
 
 What you'll need
 ----------------

--- a/docs/products/postgresql/howto/setup-logical-replication.rst
+++ b/docs/products/postgresql/howto/setup-logical-replication.rst
@@ -6,9 +6,7 @@ Aiven for PostgreSQL represents an ideal managed solution for a variety of use c
 Whether you are migrating or have another use case to keep an existing system in sync with an Aiven for PostgreSQL service, setting up a **logical replica** is a good way to achieve that. This article goes through the steps of replicating some tables from a self-managed PostgreSQL cluster to Aiven.
 
 .. Note::
-    These instructions work also with AWS RDS PostgreSQL 10+.
-
-    Google Cloud Platform's PostgreSQL for CloudSQL does not currently support logical replication.
+    These instructions work also with AWS RDS PostgreSQL 10+ and `Google CloudSQL PostgreSQL <https://cloud.google.com/sql/docs/release-notes#August_30_2021>`_.
 
 
 Variables


### PR DESCRIPTION
Updated PostgeSQL logical replication is supported by GCP CloudSQL since Aug 30, 2021
https://cloud.google.com/sql/docs/release-notes#August_30_2021
