### PR TITLE
Provide links to onward resources from the upgrading to opensearch page

### DIFF
--- a/docs/products/opensearch/howto/upgrade-to-opensearch.rst
+++ b/docs/products/opensearch/howto/upgrade-to-opensearch.rst
@@ -47,4 +47,4 @@ Here are some related resources that may help you with your upgrade process
 * :doc:`Understand how OpenSearch relates to Elasticsearch <../concepts/opensearch-vs-elasticsearch>`
 * :doc:`Upgrade your application client libraries for OpenSearch <upgrade-clients-to-opensearch>`
 * :doc:`Plugins available on for Aiven for OpenSearch <../reference/plugins>`
-* :doc:`OpenSearch Dashboards <../dashboards/index>` replaces Kibana
+* :doc:`OpenSearch Dashboards <../dashboards/index>` as a replacement to Kibana

--- a/docs/products/opensearch/howto/upgrade-to-opensearch.rst
+++ b/docs/products/opensearch/howto/upgrade-to-opensearch.rst
@@ -39,3 +39,12 @@ To perform the upgrade, visit the service overview page and choose the button la
 
 When the operation completes, your Aiven for OpenSearch service should continue to operate much as your Elasticsearch service did.
 
+More resources
+--------------
+
+Here are some related resources that may help you with your upgrade process
+
+* :doc:`Understand how OpenSearch relates to Elasticsearch <../concepts/opensearch-vs-elasticsearch>`
+* :doc:`Upgrade your application client libraries for OpenSearch <upgrade-clients-to-opensearch>`
+* :doc:`Plugins available on for Aiven for OpenSearch <../reference/plugins>`
+* :doc:`OpenSearch Dashboards <../dashboards/index>` replaces Kibana


### PR DESCRIPTION
As well as upgrading the server, we have a lot of resources about the OpenSearch services, so add some links to the article (this is also where we link to when sending emails about the EOL for the old Elasticsearch service)