### PR TITLE
Adding tfvars to Vale vocab

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -121,6 +121,7 @@ TaskManager
 Telegraf
 Terraform
 Terraforming
+tfvars
 TimescaleDB
 toolchain
 Transport Layer Security


### PR DESCRIPTION
# What changed, and why it matters

``tfvars`` is a specific file extension for Terraform. Requesting to add this word to Vale's *accept.txt* for builds to pass.
