### PR TITLE
Article about dump data index from OS cluster

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -315,6 +315,7 @@ entries:
           - file: docs/products/opensearch/howto/opensearch-aggregations-and-nodejs
           - file: docs/products/opensearch/howto/control_access_to_content
           - file: docs/products/opensearch/howto/restore_opensearch_backup
+          - file: docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump
           - file: docs/products/opensearch/howto/set_index_retention_patterns
           - file: docs/products/opensearch/howto/opensearch-alerting-api
       - file: docs/products/opensearch/dashboards/index

--- a/docs/products/opensearch/concepts/backups.rst
+++ b/docs/products/opensearch/concepts/backups.rst
@@ -1,3 +1,5 @@
+.. _opensearch-backup:
+
 Backups
 =======
 

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -34,11 +34,11 @@ Prerequisites
 Here are some information you need to collect to copy your data:
 
 OpenSearch cluster:
-* OpenSearch cluster url , for e.g. ``http://opensearch-url:9243/``
+* OpenSearch cluster URL , for e.g. ``http://opensearch-url:9243/``
 
 Aiven for OpenSearch:
 * ``INDEX_NAME``: the name of the index that you aim to backup.
-* ``SERVICE_URI``: OpenSearch service uri. You can find it in Aiven's dashboard.
+* ``SERVICE_URI``: OpenSearch service URI. You can find it in Aiven's dashboard.
 
 
 
@@ -85,7 +85,7 @@ You need to collect this information about your Aiven for OpenSearch cluster and
 
 Aiven for OpenSearch:
 
-* ``SERVICE_URI``: OpenSearch service uri, which you can find in Aiven's dashboard.
+* ``SERVICE_URI``: OpenSearch service URI, which you can find in Aiven's dashboard.
 * ``INDEX_NAME``: the name of the index that you aim to backup.
 
 AWS S3:

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -1,12 +1,12 @@
 
-Dump OpenSearch index using ``elasticsearch-dump``
-==================================================
+Dump OpenSearch® index using ``elasticsearch-dump``
+===================================================
 
-It is a good practice to perform backups of your OpenSearch data to another storage service. This way you can access your data and restore it if something unexpected happens to it. 
+It is a good practice to perform backups of your OpenSearch® data to another storage service. This way you can access your data and restore it if something unexpected happens to it. 
 
 In this article, you can find out how to dump your OpenSearch data to an:
 
-* :ref:`Aiven OpenSearch <copy-data-from-os-to-os>`
+* :ref:`Aiven for OpenSearch® <copy-data-from-os-to-os>`
 * :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
 
 To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on how to install it. From this library, we will use ``elasticdump`` command to copy the input index data to an specific output. 

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -72,8 +72,8 @@ When the dump is completed, you can check that the index is available in the Ope
 
 .. _copy-data-from-os-to-s3:
 
-Copying data from Aiven OpenSearch to S3
-----------------------------------------
+Copying data from Aiven OpenSearch to AWS S3
+--------------------------------------------
 
 Prerequisites
 ~~~~~~~~~~~~~

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -9,7 +9,11 @@ In this article, you can find out how to dump your OpenSearch data to an:
 * :ref:`OpenSearch cluster <copy-data-from-os-to-os>`
 * :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
 
-We will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ for these processes. To install the ``elasticsearch-dump``, read the `instructions <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on GitHub.
+To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ in how to install it. From this library, we will use ``elasticdump`` command to copy the ``input`` index data to an specific ``output``. 
+
+.. note::
+
+    Make sure to have ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed for the next steps.
 
 .. _copy-data-from-os-to-os:
 
@@ -19,33 +23,52 @@ Copying data from OpenSearch to Aiven OpenSearch
 Prerequisites
 ~~~~~~~~~~~~~
 
-* Aiven for OpenSearch cluster 
-* OpenSearch cluster 
-* ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed
+* OpenSearch cluster as the ``input`` (can be in Aiven or elsewhere)
+* Aiven for OpenSearch cluster as the ``output``
 
-To import the data we will use ``elasticdump`` command. This command works by copying the ``input`` index data to an specific ``output``. The ``input`` and ``ouput`` can be either an OpenSearch URL or a file path (local or remote file storage). In this particular case, we are using both URLs, one from an **OpenSearch cluster** and the other one from **Aiven for OpenSearch cluster**.
+.. note::
+    
+    The ``input`` and ``ouput`` can be either an OpenSearch URL or a file path (local or remote file storage). In this particular case, we are using both URLs, one from an **OpenSearch cluster** and the other one from **Aiven for OpenSearch cluster**. 
+
+
+Here are some information you need to collect to copy your data:
+
+OpenSearch cluster:
+* OpenSearch cluster url , for e.g. ``http://opensearch-url:9243/``
+
+Aiven for OpenSearch:
+* ``INDEX_NAME``: the name of the index that you aim to backup.
+* ``SERVICE_URI``: OpenSearch service uri. You can find it in Aiven's dashboard.
+
+
+
 
 Import mapping
 ~~~~~~~~~~~~~~
 
+The process of defining how a document and the fields are stored and indexed is called mapping. When no data structure is specified, we rely on OpenSearch to automatically detect the fields using dynamic mapping. However, we can set our data mapping before the data is sent:
+
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/index_name \
-    --output=SERVICE_URI/index_name \
+    --input=http://opensearch-url:9243/INDEX_NAME \
+    --output=SERVICE_URI/INDEX_NAME \
     --type=mapping
+
 
 Import data 
 ~~~~~~~~~~~
 
+This is how you can copy your index data from an OpenSearch cluster (can be in Aiven or elsewhere) to an Aiven for OpenSearch one.
+
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/index_name \
-    --output=SERVICE_URI/index_name \
+    --input=http://opensearch-url:9243/INDEX_NAME \
+    --output=SERVICE_URI/INDEX_NAME \
     --type=data
 
-When the dump is completed, you can check that the index is available in the OpenSearch service you send it to. You will able to find it under the **Indexes** tab in your Aiven console.
+When the dump is completed, you can check that the index is available in the OpenSearch service you send it to. You will be able to find it under the **Indexes** tab in your Aiven console.
 
 .. _copy-data-from-os-to-s3:
 
@@ -55,26 +78,40 @@ Copying data from Aiven OpenSearch to S3
 Prerequisites
 ~~~~~~~~~~~~~
 
-* Aiven for OpenSearch cluster 
-* S3 bucket
-* ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed
+* Aiven for OpenSearch cluster as the ``input``
+* AWS S3 bucket as the ``output``
+
+You need to collect this information about your Aiven for OpenSearch cluster and your AWS service:
+
+Aiven for OpenSearch:
+
+* ``SERVICE_URI``: OpenSearch service uri, which you can find in Aiven's dashboard.
+* ``INDEX_NAME``: the name of the index that you aim to backup.
+
+AWS S3:
+
+* AWS credentials (``ACCESS_KEY_ID`` and ``SECRET_ACCESS_KEY``).
+* S3 file path, with the bucket name and file name, for e.g. ``s3://${BUCKET_NAME}/${FILE_NAME}.json``
+
+.. seealso::
+
+    You can find more information about AWS credentials in the `AWS documentation <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_.
+
 
 Export OpenSearch index data to S3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use ``elasticsearch-dump`` command to copy the data from your **Aiven OpenSearch cluster** to your **S3 bucket**. For the ``input`` use your Aiven OpenSearch ``SERVICE_URI``. For the ``output``, choose an AWS S3 file path including the file name that you want for your document. 
-
-.. Tip::
-
-    You can find the ``SERVICE_URI`` on Aiven's dashboard.
+Use ``elasticsearch-dump`` command to copy the data from your **Aiven OpenSearch cluster** to your **AWS S3 bucket**. Use your Aiven OpenSearch ``SERVICE_URI`` for the ``input`` . For the ``output``, choose an AWS S3 file path including the file name that you want for your document. 
 
 
 .. code-block:: shell
 
     elasticdump \
-    --s3AccessKeyId "${access_key_id}" \
-    --s3SecretAccessKey "${access_key_secret}" \
-    --input=SERVICE_URI/index_name --output "s3://${bucket_name}/${file_name}.json"  
+    --s3AccessKeyId "${ACCESS_KEY_ID}" \
+    --s3SecretAccessKey "${SECRET_ACCESS_KEY}" \
+    --input=SERVICE_URI/index_name --output "s3://${BUCKET_NAME}/${FILE_NAME}.json"  
 
+Resources
+---------
 
-The AWS credentials are required for the operation to succeed. You can find more information about those credentials in the `AWS documentation <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_.
+Aiven for OpenSearch databases are automatically backed up, so you can check more information about how the :ref:`Backup process works <opensearch-backup>`.

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -85,7 +85,7 @@ You need to collect the following information about your Aiven for OpenSearch cl
 
 Aiven for OpenSearch:
 
-* ``SERVICE_URI`: OpenSearch service URI, which you can find in Aiven's dashboard.
+* ``SERVICE_URI``: OpenSearch service URI, which you can find in Aiven's dashboard.
 * ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
 
 AWS S3:

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -35,11 +35,11 @@ Here are some information you need to collect to copy your data:
 
 OpenSearch cluster:
 
-* OpenSearch cluster URL , for e.g. ``http://opensearch-url:9243/``
+* ``INPUT_SERVICE_URI``: OpenSearch cluster URL, for e.g. ``http://opensearch-url:9243/``
+* ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
 
 Aiven for OpenSearch:
 
-* ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
 * ``OUTPUT_INDEX_NAME``: the index that you want to have in your output with the copied data.
 * ``SERVICE_URI``: OpenSearch service URI. You can find it in Aiven's dashboard.
 
@@ -51,7 +51,7 @@ The process of defining how a document and the fields are stored and indexed is 
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/INPUT_INDEX_NAME \
+    --input=INPUT_SERVICE_URI/INPUT_INDEX_NAME \
     --output=SERVICE_URI/OUTPUT_INDEX_NAME \
     --type=mapping
 
@@ -64,7 +64,7 @@ This is how you can copy your index data from an OpenSearch cluster (can be in A
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/INPUT_INDEX_NAME \
+    --input=INPUT_SERVICE_URI/INPUT_INDEX_NAME \
     --output=SERVICE_URI/OUTPUT_INDEX_NAME \
     --type=data
 
@@ -85,13 +85,13 @@ You need to collect the following information about your Aiven for OpenSearch cl
 
 Aiven for OpenSearch:
 
-* ``SERVICE_URI``: OpenSearch service URI, which you can find in Aiven's dashboard.
+* ``SERVICE_URI`: OpenSearch service URI, which you can find in Aiven's dashboard.
 * ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
 
 AWS S3:
 
 * AWS credentials (``ACCESS_KEY_ID`` and ``SECRET_ACCESS_KEY``).
-* S3 file path, with the bucket name and file name, for e.g. ``s3://${BUCKET_NAME}/${FILE_NAME}.json``
+* S3 file path. This includes bucket name and file name, for e.g. ``s3://${BUCKET_NAME}/${FILE_NAME}.json``
 
 .. seealso::
 

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -9,7 +9,7 @@ In this article, you can find out how to dump your OpenSearch data to an:
 * :ref:`Aiven OpenSearch <copy-data-from-os-to-os>`
 * :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
 
-To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ in how to install it. From this library, we will use ``elasticdump`` command to copy the ``input`` index data to an specific ``output``. 
+To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on how to install it. From this library, we will use ``elasticdump`` command to copy the input index data to an specific output. 
 
 .. note::
 
@@ -39,11 +39,9 @@ OpenSearch cluster:
 
 Aiven for OpenSearch:
 
-* ``INDEX_NAME``: the name of the index that you aim to backup.
+* ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
+* ``OUTPUT_INDEX_NAME``: the index that you want to have in your output with the copied data.
 * ``SERVICE_URI``: OpenSearch service URI. You can find it in Aiven's dashboard.
-
-
-
 
 Import mapping
 ~~~~~~~~~~~~~~
@@ -53,8 +51,8 @@ The process of defining how a document and the fields are stored and indexed is 
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/INDEX_NAME \
-    --output=SERVICE_URI/INDEX_NAME \
+    --input=http://opensearch-url:9243/INPUT_INDEX_NAME \
+    --output=SERVICE_URI/OUTPUT_INDEX_NAME \
     --type=mapping
 
 
@@ -66,8 +64,8 @@ This is how you can copy your index data from an OpenSearch cluster (can be in A
 .. code-block:: shell
 
     elasticdump \
-    --input=http://opensearch-url:9243/INDEX_NAME \
-    --output=SERVICE_URI/INDEX_NAME \
+    --input=http://opensearch-url:9243/INPUT_INDEX_NAME \
+    --output=SERVICE_URI/OUTPUT_INDEX_NAME \
     --type=data
 
 When the dump is completed, you can check that the index is available in the OpenSearch service you send it to. You will be able to find it under the **Indexes** tab in your Aiven console.
@@ -83,12 +81,12 @@ Prerequisites
 * Aiven for OpenSearch cluster as the ``input``
 * AWS S3 bucket as the ``output``
 
-You need to collect this information about your Aiven for OpenSearch cluster and your AWS service:
+You need to collect the following information about your Aiven for OpenSearch cluster and your AWS service:
 
 Aiven for OpenSearch:
 
 * ``SERVICE_URI``: OpenSearch service URI, which you can find in Aiven's dashboard.
-* ``INDEX_NAME``: the name of the index that you aim to backup.
+* ``INPUT_INDEX_NAME``: the index that you aim to copy from your input source.
 
 AWS S3:
 
@@ -111,7 +109,7 @@ Use ``elasticsearch-dump`` command to copy the data from your **Aiven OpenSearch
     elasticdump \
     --s3AccessKeyId "${ACCESS_KEY_ID}" \
     --s3SecretAccessKey "${SECRET_ACCESS_KEY}" \
-    --input=SERVICE_URI/index_name --output "s3://${BUCKET_NAME}/${FILE_NAME}.json"  
+    --input=SERVICE_URI/INPUT_INDEX_NAME --output "s3://${BUCKET_NAME}/${FILE_NAME}.json"  
 
 Resources
 ---------

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -6,7 +6,7 @@ It is a good practice to perform backups of your OpenSearch data to another stor
 
 In this article, you can find out how to dump your OpenSearch data to an:
 
-* :ref:`OpenSearch cluster <copy-data-from-os-to-os>`
+* :ref:`Aiven OpenSearch <copy-data-from-os-to-os>`
 * :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
 
 To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ in how to install it. From this library, we will use ``elasticdump`` command to copy the ``input`` index data to an specific ``output``. 
@@ -34,9 +34,11 @@ Prerequisites
 Here are some information you need to collect to copy your data:
 
 OpenSearch cluster:
+
 * OpenSearch cluster URL , for e.g. ``http://opensearch-url:9243/``
 
 Aiven for OpenSearch:
+
 * ``INDEX_NAME``: the name of the index that you aim to backup.
 * ``SERVICE_URI``: OpenSearch service URI. You can find it in Aiven's dashboard.
 

--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -1,0 +1,80 @@
+
+Dump OpenSearch index using ``elasticsearch-dump``
+==================================================
+
+It is a good practice to perform backups of your OpenSearch data to another storage service. This way you can access your data and restore it if something unexpected happens to it. 
+
+In this article, you can find out how to dump your OpenSearch data to an:
+
+* :ref:`OpenSearch cluster <copy-data-from-os-to-os>`
+* :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
+
+We will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ for these processes. To install the ``elasticsearch-dump``, read the `instructions <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on GitHub.
+
+.. _copy-data-from-os-to-os:
+
+Copying data from OpenSearch to Aiven OpenSearch
+------------------------------------------------
+
+Prerequisites
+~~~~~~~~~~~~~
+
+* Aiven for OpenSearch cluster 
+* OpenSearch cluster 
+* ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed
+
+To import the data we will use ``elasticdump`` command. This command works by copying the ``input`` index data to an specific ``output``. The ``input`` and ``ouput`` can be either an OpenSearch URL or a file path (local or remote file storage). In this particular case, we are using both URLs, one from an **OpenSearch cluster** and the other one from **Aiven for OpenSearch cluster**.
+
+Import mapping
+~~~~~~~~~~~~~~
+
+.. code-block:: shell
+
+    elasticdump \
+    --input=http://opensearch-url:9243/index_name \
+    --output=SERVICE_URI/index_name \
+    --type=mapping
+
+Import data 
+~~~~~~~~~~~
+
+.. code-block:: shell
+
+    elasticdump \
+    --input=http://opensearch-url:9243/index_name \
+    --output=SERVICE_URI/index_name \
+    --type=data
+
+When the dump is completed, you can check that the index is available in the OpenSearch service you send it to. You will able to find it under the **Indexes** tab in your Aiven console.
+
+.. _copy-data-from-os-to-s3:
+
+Copying data from Aiven OpenSearch to S3
+----------------------------------------
+
+Prerequisites
+~~~~~~~~~~~~~
+
+* Aiven for OpenSearch cluster 
+* S3 bucket
+* ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed
+
+Export OpenSearch index data to S3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``elasticsearch-dump`` command to copy the data from your **Aiven OpenSearch cluster** to your **S3 bucket**. For the ``input`` use your Aiven OpenSearch ``SERVICE_URI``. For the ``output``, choose an AWS S3 file path including the file name that you want for your document. 
+
+.. Tip::
+
+    You can find the ``SERVICE_URI`` on Aiven's dashboard.
+
+
+.. code-block:: shell
+
+    elasticdump \
+    --s3AccessKeyId "${access_key_id}" \
+    --s3SecretAccessKey "${access_key_secret}" \
+    --input=SERVICE_URI/index_name --output "s3://${bucket_name}/${file_name}.json"  
+
+
+The AWS credentials are required for the operation to succeed. You can find more information about those credentials in the `AWS documentation <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_.


### PR DESCRIPTION
Article about dump data index from OS cluster

https://help.aiven.io/en/articles/3280782-moving-indexes-with-elasticsearch-dump-tool

Tested and works as well with OpenSearch (OS) v1.0.0