### PR TITLE
Switch to shorter title decoration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,6 +19,7 @@
 project = 'Aiven Developer'
 copyright = '2021, Aiven Team'
 author = 'Aiven Team'
+html_title = 'Aiven'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
# What changed, and why it matters

We had a request from the SEO agency to keep our titles under a certain length. As a first step, this reduces the trailing character count from 32 characters to 8. We should also revisit page titles to keep them short (ideal max is 60 chars)


