### PR TITLE
Migrated connector list not currently available

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -134,6 +134,7 @@ entries:
           entries:
           - file: docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins
           - file: docs/products/kafka/kafka-connect/concepts/jdbc-source-modes
+          - file: docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available
 
         - file: docs/products/kafka/kafka-connect/howto
           title: HowTo

--- a/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
+++ b/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
@@ -5,7 +5,7 @@ Sometimes, when accessing the `Aiven Console <https://console.aiven.io/>`_ and t
 
 .. Note::
 
-    The same error message is shown in Terraform (e.g when using ``terraform plan``) because it uses the same backend API.
+    The same error message is shown in Terraform (for example, when using ``terraform plan``) because it uses the same backend API.
  
 There can be a number of reasons why you are seeing the above message:
 

--- a/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
+++ b/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
@@ -13,7 +13,7 @@ There can be a number of reasons why you are seeing the above message:
 * The Apache Kafka Connect API on a Kafka cluster was just enabled. It should take a few seconds for the Apache Kafka Connect services to be operational
 * The Apache Kafka Connect cluster is in the process of setting up/reconfiguring a connector. This message should clear after a few seconds
 * The Apache Kafka Connect cluster is running out of memory. You will likely keep seeing this message unless you upgrade to a larger plan
-* One or more nodes on the Apache Kafka Connect cluster crashed. The API that fetches the connector list calls the Apache Kafka Connect cluster by it's hostname and that maps to either one of the 3 workers randomly. If you see this message appear intermittently, this is likely the reason. The crashed node should recover automatically, but if it doesn't, please `contact our support <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ to further help
+* One or more nodes on the Apache Kafka Connect cluster crashed. The API that fetches the connector list calls the Apache Kafka Connect cluster by it's hostname and that maps to one of the 3 workers randomly. If you see this message appear intermittently, this is likely the reason. The crashed node should recover automatically, but if it doesn't, please `contact our support <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ for further help
 
 
 If you are in doubt whether or not any of the following reasons above is the issue  that you are experiencing, you can `contact our support channel <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ and we will be able to help you further.

--- a/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
+++ b/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
@@ -1,0 +1,19 @@
+Causes of "connector list not currently available"
+==================================================
+
+Sometimes, when accessing the `Aiven Console <https://console.aiven.io/>`_ and trying to view the list of connectors in your Aiven for Apache Kafka® Connect cluster you can encounter the message ``connector list not currently available``. 
+
+.. Note::
+
+    The same error message is shown in Terraform (e.g when using ``terraform plan``) because it uses the same backend API.
+ 
+There can be a number of reasons why you are seeing the above message:
+
+* The dedicated Apache Kafka Connect cluster was just created. The list will load after the cluster is fully online with all the nodes in running state
+* The Apache Kafka Connect API on a Kafka cluster was just enabled. It should take a few seconds for the Apache Kafka Connect services to be operational
+* The Apache Kafka Connect cluster is in the process of setting up/reconfiguring a connector. This message should clear after a few seconds
+* The Apache Kafka Connect cluster is running out of memory. You will likely keep seeing this message unless you upgrade to a larger plan
+* One or more nodes on the Apache Kafka Connect cluster crashed. The API that fetches the connector list calls the Apache Kafka Connect cluster by it's hostname and that maps to either one of the 3 workers randomly. If you see this message appear intermittently, this is likely the reason. The crashed node should recover automatically, but if it doesn't, please `contact our support <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ to further help
+
+
+If you are in doubt whether or not any of the following reasons above is the issue  that you are experiencing, you can `contact our support channel <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ and we will be able to help you further.


### PR DESCRIPTION
# What changed, and why it matters

Migrated https://help.aiven.io/en/articles/5290278-aiven-for-apache-kafka-connect-connector-list-not-currently-available -> https://deploy-preview-643--developer-aiven-io-preview.netlify.app/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.html

Fixes #642 