### PR TITLE
Terraform section layout and getting-started

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -59,7 +59,12 @@ entries:
       - file: docs/tools/terraform/index
         title: Aiven Terraform provider
         entries:
-        - file: docs/tools/terraform/upgrade-provider-v1-v2
+        - file: docs/tools/terraform/getting-started
+        - file: docs/tools/terraform/howto
+          title: HowTo
+          entries:
+            - file: docs/tools/terraform/howto/upgrade-provider-v1-v2
+              title: Upgrade the Aiven Terraform Provider from v1 to v2
         - file: docs/tools/terraform/reference
           entries:
           - file: docs/tools/terraform/reference/cookbook

--- a/_toc.yml
+++ b/_toc.yml
@@ -60,6 +60,7 @@ entries:
         title: Aiven Terraform provider
         entries:
         - file: docs/tools/terraform/get-started
+          title: Get started
         - file: docs/tools/terraform/howto
           title: HowTo
           entries:

--- a/_toc.yml
+++ b/_toc.yml
@@ -59,7 +59,7 @@ entries:
       - file: docs/tools/terraform/index
         title: Aiven Terraform provider
         entries:
-        - file: docs/tools/terraform/getting-started
+        - file: docs/tools/terraform/get-started
         - file: docs/tools/terraform/howto
           title: HowTo
           entries:

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -10,7 +10,28 @@ Requirements
 - `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_ on Aiven's console or CLI
 
 
-1. ``provider.tf`` file:
+Configure your project and services
+'''''''''''''''''''''''''''''''''''
+
+Your Terraform file(s) consists of lines for the actual infrastructure as well as required dependencies and configurations. While you can stuff these together in one file, it's ideal to keep those as separate files.
+In this section, you'll learn how to structure a simple Terraform project. 
+
+1.  BYOTF - Bring Your Own Terraform Script. 
+
+``services.tf`` file:
+
+.. code:: bash
+
+   # Your actual Terraform script goes here 
+
+
+2. Consider the following code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the `required_providers` block, you mention the source of the provider and specify a certain version. 
+The versions here are for example purpose and will change in the future. Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, `api_token` is the only parameter for the provider configuration.
+
+Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
+For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
+
+``provider.tf`` file:
 
 .. code:: bash
 
@@ -28,12 +49,9 @@ Requirements
    }
 
 
-Consider this code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the *required_providers* block, you mention the source of the provider and specify a certain version. The versions here are for example purpose and will change in the future.
-Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, *api_token* is the only parameter for the provider configuration.
+3. Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
 
-Make sure the owner of the API Authentication Token has admin permissions in Aiven.
-
-2. ``variables.tf`` file:
+``variables.tf`` file:
 
 .. code:: bash
 
@@ -47,22 +65,19 @@ Make sure the owner of the API Authentication Token has admin permissions in Aiv
       type        = string
    }
 
-Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
 
-3. ``var-values.tfvars`` file:
+4. This is where you put the actual values for Aiven API token and Aiven console project name. This file is passed to Terraform using the ``-var-file=`` flag.
+
+``var-values.tfvars`` file:
 
 .. code:: bash
 
    aiven_api_token = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
    project_name = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
 
-This is where you put the actual values for Aiven API token and Aiven console project name. This file is passed to Terraform using the ``-var-file=`` flag.
 
-4. ``services.tf`` file:
-
-.. code:: bash
-
-   # Your actual Terraform script goes here 
+Execution
+'''''''''
 
 Create an empty folder and add the above files to that folder. Then execute the following commands in order:
 
@@ -84,8 +99,9 @@ This command creates an execution plan and shows you the resources that will be 
 
 If you're satisfied with ``terraform plan``, you execute ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
 
-Optional
---------
+
+Clean up
+''''''''
 
 If this was a test environment, be sure to delete the resources once you're done to avoid consuming unwanted bills. 
 
@@ -96,3 +112,9 @@ If this was a test environment, be sure to delete the resources once you're done
 .. code:: bash
 
    terraform destroy -var-file=var-values.tfvars
+
+
+Further reference
+'''''''''''''''''
+
+This article outlined a simple Terraform project structure. For a more complex project structure, please refer to the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_. 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -16,20 +16,34 @@ Configure your project and services
 Your Terraform file(s) consists of lines for the actual infrastructure as well as required dependencies and configurations. While you can stuff these together in one file, it's ideal to keep those as separate files.
 In this section, you'll learn how to structure a simple Terraform project. 
 
-1.  BYOTF - Bring Your Own Terraform Script. 
+1.  The following Terraform script deploys a single-node Redis service. This is a simple example which you can swap out with your own Terraform script(s) or other advanced recipes from :doc:`the Terraform cookbook <reference/cookbook>`.
 
 ``services.tf`` file:
 
 .. code:: bash
 
-   # Your actual Terraform script goes here 
+  # A single-node Redis service
+  
+   resource "aiven_redis" "single-node-aiven-redis" {
+  project                 = var.project_name
+  cloud_name              = "google-northamerica-northeast1"
+  plan                    = "startup-4"
+  service_name            = "gcp-single-node-redis1"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  redis_user_config {
+    redis_maxmemory_policy = "allkeys-random"
+
+    public_access {
+      redis = true
+    }
+  }
+}
 
 
-2. Consider the following code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the `required_providers` block, you mention the source of the provider and specify a certain version. 
-The versions here are for example purpose and will change in the future. Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, `api_token` is the only parameter for the provider configuration.
-
-Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
-For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
+2. Consider the following code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the ``required_providers`` block, you mention the source of the provider and specify a certain version. 
+The versions here are for example purpose and will change in the future. Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, ``api_token`` is the only parameter for the provider configuration.
 
 ``provider.tf`` file:
 
@@ -50,6 +64,9 @@ For more details, refer to the `Project members and roles page <https://develope
 
 
 3. Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
+
+Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
+For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
 
 ``variables.tf`` file:
 
@@ -76,8 +93,8 @@ For more details, refer to the `Project members and roles page <https://develope
    project_name = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
 
 
-Execution
-'''''''''
+Apply the Terraform configuration
+'''''''''''''''''''''''''''''''''
 
 Create an empty folder and add the above files to that folder. Then execute the following commands in order:
 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,7 +1,7 @@
-Set up your first Terraform project
-===================================
+Set up your first Aiven Terraform project
+=========================================
 
-This example shows the setup for a simple Terraform project and some useful commands to stand up (and destroy) your Aiven data infrastructure.
+This example shows the setup for a Terraform project containing a single Redis service, and shows off some useful commands to stand up (and destroy) your Aiven data infrastructure.
 
 Prepare the dependencies 
 ''''''''''''''''''''''''
@@ -9,46 +9,24 @@ Prepare the dependencies
 - `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
 - `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_
 
-.. Tip:: Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access.
+.. Tip::
 
-For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
+    Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access.
+
+    For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
 
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
 
-Your Terraform file(s) consists of lines for the actual infrastructure as well as required dependencies and configurations. While you can stuff these together in one file, it's ideal to keep those as separate files.
+Your Terraform files declare the structure of your infrastructure as well as required dependencies and configuration. While you can stuff these together in one file, it's ideal to keep those as separate files.
 In this section, you'll learn how to structure a simple Terraform project. 
 
-1.  The following Terraform script deploys a single-node Redis service. This is a simple example which you can swap out with your own Terraform script(s) or other advanced recipes from :doc:`the Terraform cookbook <reference/cookbook>`.
+Start with an empty folder, and follow these steps to define and then create your Aiven services.
 
-``services.tf`` file:
+1. First we declare a dependency on the *Aiven Terraform Provider*. Within the ``required_providers`` block, you mention the source of the provider and specify a certain version (check which are the current versions and update accordingly).
+Following `Aiven Terraform Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, ``api_token`` is the only parameter for the provider configuration.
 
-.. code:: bash
-
-   # A single-node Redis service
-  
-   resource "aiven_redis" "single-node-aiven-redis" {
-      project                 = var.project_name
-      cloud_name              = "google-northamerica-northeast1"
-      plan                    = "startup-4"
-      service_name            = "gcp-single-node-redis1"
-      maintenance_window_dow  = "monday"
-      maintenance_window_time = "10:00:00"
-
-      redis_user_config {
-         redis_maxmemory_policy = "allkeys-random"
-
-         public_access {
-            redis = true
-         }
-      }  
-   }
-
-
-2. Consider the following code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the ``required_providers`` block, you mention the source of the provider and specify a certain version. 
-The versions here are for example purpose and will change in the future. Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, ``api_token`` is the only parameter for the provider configuration.
-
-``provider.tf`` file:
+Add the following to a new ``provider.tf`` file:
 
 .. code:: bash
 
@@ -66,9 +44,35 @@ The versions here are for example purpose and will change in the future. Followi
    }
 
 
-3. Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
+2.  The following Terraform script deploys a single-node Redis service. This is a minimal example which you can swap out with your own Terraform scripts or other advanced recipes from :doc:`the Terraform cookbook <reference/cookbook>`.
 
-``variables.tf`` file:
+The contents of the ``redis.tf`` file should look like this:
+
+.. code:: bash
+
+    # A single-node Redis service
+  
+    resource "aiven_redis" "single-node-aiven-redis" {
+      project                 = var.project_name
+      cloud_name              = "google-northamerica-northeast1"
+      plan                    = "startup-4"
+      service_name            = "gcp-single-node-redis1"
+      maintenance_window_dow  = "monday"
+      maintenance_window_time = "10:00:00"
+
+      redis_user_config {
+        redis_maxmemory_policy = "allkeys-random"
+
+        public_access {
+          redis = true
+        }
+      }  
+    }
+
+
+3. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
+
+The ``variables.tf`` file defines both the API token, and the project name to use:
 
 .. code:: bash
 
@@ -83,7 +87,7 @@ The versions here are for example purpose and will change in the future. Followi
    }
 
 
-4. This is where you put the actual values for Aiven API token and Aiven console project name. This file is passed to Terraform using the ``-var-file=`` flag.
+The ``var-values.tfvars`` file holds the actual values and is passed to Terraform using the ``-var-file=`` flag.
 
 ``var-values.tfvars`` file:
 
@@ -92,30 +96,32 @@ The versions here are for example purpose and will change in the future. Followi
    aiven_api_token = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
    project_name = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
 
+Edit the file and replace the ``<..>`` sections with the API token you created earlier, and the name of the Aiven project that resources should be created in.
+
 
 Apply the Terraform configuration
 '''''''''''''''''''''''''''''''''
 
-Create an empty folder and add the above files to that folder. Then execute the following commands in order:
+
+The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.
 
 .. code:: bash
 
    terraform init 
 
-This command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform Provider plugins.
+The ``plan`` command creates an execution plan and shows you the resources that will be created (or modified) for you. This command does not actually create any resource; this is more like a preview.
 
 .. code:: bash
 
    terraform plan -var-file=var-values.tfvars
 
-This command creates an execution plan and shows you the resources that will be created (or modified) for you. This command does not actually create any resource; this is more like a preview.
+If you're satisfied with the output of ``terraform plan``, go ahead and run the ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
 
 .. code:: bash
 
    terraform apply -var-file=var-values.tfvars
 
-If you're satisfied with ``terraform plan``, you execute ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
-
+The output will show you if everything worked well. You can now visit the `Aiven web console <https://console.aiven.io>`_ and admire your new services.
 
 Clean up
 ''''''''
@@ -136,6 +142,7 @@ This will run ``terraform plan`` in destroy mode and show you the proposed destr
 
    terraform destroy -var-file=var-values.tfvars
 
+By destroying your services when you don't need them, for example in a testing environment, you can be confident that no unnecessary services are left running up the bills.
 
 Further reference
 '''''''''''''''''

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -9,6 +9,10 @@ Requirements
 - `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
 - `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_ on Aiven's console or CLI
 
+.. Tip:: Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
+For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
+
+
 
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
@@ -38,7 +42,7 @@ In this section, you'll learn how to structure a simple Terraform project.
     public_access {
       redis = true
     }
-  }
+  }  
 }
 
 
@@ -64,9 +68,6 @@ The versions here are for example purpose and will change in the future. Followi
 
 
 3. Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
-
-Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
-For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
 
 ``variables.tf`` file:
 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -3,16 +3,15 @@ Set up your first Terraform project
 
 This example shows the setup for a simple Terraform project and some useful commands to stand up (and destroy) your Aiven data infrastructure.
 
-Requirements 
-''''''''''''
+Prepare the dependencies 
+''''''''''''''''''''''''
 - `Download and install Terraform <https://www.terraform.io/downloads.html>`_
 - `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
-- `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_ on Aiven's console or CLI
+- `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_
 
-.. Tip:: Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access. 
+.. Tip:: Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access.
+
 For more details, refer to the `Project members and roles page <https://developer.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
-
-
 
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
@@ -26,24 +25,24 @@ In this section, you'll learn how to structure a simple Terraform project.
 
 .. code:: bash
 
-  # A single-node Redis service
+   # A single-node Redis service
   
    resource "aiven_redis" "single-node-aiven-redis" {
-  project                 = var.project_name
-  cloud_name              = "google-northamerica-northeast1"
-  plan                    = "startup-4"
-  service_name            = "gcp-single-node-redis1"
-  maintenance_window_dow  = "monday"
-  maintenance_window_time = "10:00:00"
+      project                 = var.project_name
+      cloud_name              = "google-northamerica-northeast1"
+      plan                    = "startup-4"
+      service_name            = "gcp-single-node-redis1"
+      maintenance_window_dow  = "monday"
+      maintenance_window_time = "10:00:00"
 
-  redis_user_config {
-    redis_maxmemory_policy = "allkeys-random"
+      redis_user_config {
+         redis_maxmemory_policy = "allkeys-random"
 
-    public_access {
-      redis = true
-    }
-  }  
-}
+         public_access {
+            redis = true
+         }
+      }  
+   }
 
 
 2. Consider the following code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the ``required_providers`` block, you mention the source of the provider and specify a certain version. 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,7 +1,7 @@
 Set up your first Terraform project
 ===================================
 
-This example shows the setup for a sample Terraform project and some useful commands to stand up (and destroy) your Aiven data infrastructure.
+This example shows the setup for a simple Terraform project and some useful commands to stand up (and destroy) your Aiven data infrastructure.
 
 Requirements 
 ''''''''''''
@@ -103,11 +103,17 @@ If you're satisfied with ``terraform plan``, you execute ``terraform apply`` com
 Clean up
 ''''''''
 
-If this was a test environment, be sure to delete the resources once you're done to avoid consuming unwanted bills. 
+If this was a test environment, be sure to delete the resources once you're done to avoid consuming unwanted bills. To be confident about the service termination, you can create a speculative destroy plan by running the following command:
+
+.. code:: bash
+
+   terraform plan -destroy
+
+This will run ``terraform plan`` in destroy mode and show you the proposed destroy changes without executing them.
 
 .. warning::
 
-   Use this command with caution. This will actually delete resources that might have important data.
+   Use the following command with caution. This will actually delete resources that might have important data.
 
 .. code:: bash
 

--- a/docs/tools/terraform/getting-started.rst
+++ b/docs/tools/terraform/getting-started.rst
@@ -1,0 +1,98 @@
+Set up your first Terraform project
+===================================
+
+This example shows the setup for a sample Terraform project and some useful commands to stand up (and destroy) your Aiven data infrastructure.
+
+Requirements 
+''''''''''''
+- `Download and install Terraform <https://www.terraform.io/downloads.html>`_
+- `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
+- `Generate an authentication token <https://developer.aiven.io/docs/platform/howto/create_authentication_token.html>`_ on Aiven's console or CLI
+
+
+1. ``provider.tf`` file:
+
+.. code:: bash
+
+   terraform {
+      required_providers {
+         aiven = {
+            source  = "aiven/aiven"
+            version = ">= 2.6.0, < 3.0.0"
+         }
+      }
+   }
+
+   provider "aiven" {
+      api_token = var.aiven_api_token
+   }
+
+
+Consider this code block similar to declaring a dependency; the *Aiven Terraform Provider* in this case. Within the *required_providers* block, you mention the source of the provider and specify a certain version. The versions here are for example purpose and will change in the future.
+Following `Aiven Terraform Provider doc <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, *api_token* is the only parameter for the provider configuration.
+
+Make sure the owner of the API Authentication Token has admin permissions in Aiven.
+
+2. ``variables.tf`` file:
+
+.. code:: bash
+
+   variable "aiven_api_token" {
+      description = "Aiven console API token"
+      type = string
+   }
+
+   variable "project_name" {
+      description = "Aiven console project name"
+      type        = string
+   }
+
+Avoid including sensitive values in configuration files that are under source control. Rather than using sensitive information within this *variables.tf* file, you can use a ``*.tfvars`` file so that Terraform receives the values during runtime.
+
+3. ``var-values.tfvars`` file:
+
+.. code:: bash
+
+   aiven_api_token = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
+   project_name = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
+
+This is where you put the actual values for Aiven API token and Aiven console project name. This file is passed to Terraform using the ``-var-file=`` flag.
+
+4. ``services.tf`` file:
+
+.. code:: bash
+
+   # Your actual Terraform script goes here 
+
+Create an empty folder and add the above files to that folder. Then execute the following commands in order:
+
+.. code:: bash
+
+   terraform init 
+
+This command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform Provider plugins.
+
+.. code:: bash
+
+   terraform plan -var-file=var-values.tfvars
+
+This command creates an execution plan and shows you the resources that will be created (or modified) for you. This command does not actually create any resource; this is more like a preview.
+
+.. code:: bash
+
+   terraform apply -var-file=var-values.tfvars
+
+If you're satisfied with ``terraform plan``, you execute ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
+
+Optional
+--------
+
+If this was a test environment, be sure to delete the resources once you're done to avoid consuming unwanted bills. 
+
+.. warning::
+
+   Use this command with caution. This will actually delete resources that might have important data.
+
+.. code:: bash
+
+   terraform destroy -var-file=var-values.tfvars

--- a/docs/tools/terraform/howto.rst
+++ b/docs/tools/terraform/howto.rst
@@ -1,0 +1,6 @@
+HowTo
+=====
+
+A collection of helpful guides for performing tasks with Aiven Terraform Provider.
+
+.. tableofcontents::

--- a/docs/tools/terraform/howto/upgrade-provider-v1-v2.rst
+++ b/docs/tools/terraform/howto/upgrade-provider-v1-v2.rst
@@ -10,7 +10,7 @@ tool (`see the project page <https://github.com/tfutils/tfenv>`_), but you can u
 direct releases from Hashicorp if you prefer.
 
 Major changes in v2
--------------------
+'''''''''''''''''''
 
 Aiven Terraform Provider has a `detailed changelog <https://github.com/aiven/terraform-provider-aiven/blob/master/CHANGELOG.md>`_ but the main additions in v2 are:
 
@@ -23,7 +23,7 @@ Aiven Terraform Provider has a `detailed changelog <https://github.com/aiven/ter
    ``aiven_flink`` and ``aiven_opensearch``.
 
 Upgrade Aiven Terraform provider
---------------------------------
+''''''''''''''''''''''''''''''''
 
 Update the Aiven Terraform Provider by
 editing the providers block of your script to include the latest version of
@@ -39,7 +39,7 @@ the Aiven Terraform Provider (v2.3.1 at the time of writing)::
     }
 
 Upgrade Terraform
------------------
+'''''''''''''''''
 
 We recommend keeping your Terraform version up to date.
 If you have v0.12 then follow the steps below.
@@ -154,7 +154,7 @@ field removed. Any references to ``aiven_service.kafka.*`` should be updated to 
     terraform apply
 
 Further reading
----------------
+'''''''''''''''
 
 There are examples of migrating each of the available service types on the
 `Aiven examples repository <https://github.com/aiven/aiven-examples/tree/master/terraform>`__

--- a/docs/tools/terraform/index.rst
+++ b/docs/tools/terraform/index.rst
@@ -16,73 +16,20 @@ See the `official documentation <https://registry.terraform.io/providers/aiven/a
 
 Getting started
 ---------------
-Let's get started by configuring Aiven's Terraform provider and deploying a PostgreSQL® database.
 
-Requirements 
-''''''''''''
-- `Download and install Terraform <https://www.terraform.io/downloads.html>`_
-- `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
-- `Generate an authentication token <https://help.aiven.io/en/articles/2059201-authentication-tokens>`_ on Aiven's console or CLI
+Please refer to the :doc:`getting started guide <geting-started>` for your first Terraform project.
 
-Set up the provider
-'''''''''''''''''''
-To initialise the provider, we will need to configure the Terraform `required_providers` block and add the API authentication token in the `api_token` field.
+.. panels::
 
-Create a file named `main.tf` and add the content below:
+    💻 :doc:`howto`
 
-.. code:: bash
+    ---
 
-    terraform {
-      required_providers {
-        aiven = {
-          source  = "aiven/aiven"
-          version = "2.5.0" # check out the latest version in the github release section
-        }
-      }
-    }
+    📖 :doc:`reference`
 
-    provider "aiven" {
-      api_token = "your-api-token"
-    }
+    ---
 
-Run the command below to initialize Terraform. It will create a directory structure containing Terraform configuration files, install custom providers etc::
-
-  $ terraform init
-
-Deploy a PostgreSQL® database
-'''''''''''''''''''''''''''''
-Now let's deploy a fully managed PostgreSQL® database on the GCP Frankfurt region. You can also see other services and available regions `on our pricing page <https://aiven.io/pricing>`_.
-
-Add the following block of code to the `main.tf` file:
-
-.. code:: bash
-
-    resource "aiven_pg" "postgresql" {
-      project                = "your-project-name"
-      service_name           = "postgresql"
-      cloud_name             = "google-europe-west3"
-      plan                   = "startup-4"
-    }
-    
-    output "postgresql_service_uri" {
-      value     = aiven_pg.postgresql.service_uri
-      sensitive = true
-    }
-
-Plan and apply the Terraform code::
-
-  $ terraform plan
-  $ terraform apply
-
-We now have a PostgreSQL service up and running! You can access it with the command below that combines the ``psql`` command with fetching the connection information from Terraform::
-
-  $ psql "$(terraform output -raw postgresql_service_uri)"
-
-Clean up
-''''''''
-To destroy the created PostgreSQL database, use the following command::
-
-  $ terraform destroy
+    👨‍🍳 :doc:`reference/cookbook`  
 
 Learn more
 ----------

--- a/docs/tools/terraform/index.rst
+++ b/docs/tools/terraform/index.rst
@@ -1,23 +1,22 @@
 Aiven Terraform provider
 ========================
 
-    Terraform is an open-source infrastructure as code software tool that provides a consistent CLI workflow to manage hundreds of cloud services. Terraform codifies cloud APIs into declarative configuration files. `Terraform website <https://www.terraform.io/>`_.
+With Aiven's `Terraform <https://www.terraform.io>`_ provider, you can use an open-source infrastructure as code software tool to declare and manage your cloud services.
 
-With Aiven's Terraform Provider you can manage all your services programmatically.
-
-See the `official documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ to learn about all the possible services and resources and the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_ for reporting issues and contributing.
+See the `Aiven Terraform provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ to learn about the services and resources,and visit the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_ to report any issues or contribute to the project.
 
 .. caution::
+
   Recreating stateful services with Terraform will possibly delete the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be deleted or replaced, a catastrophic action is possibly about to happen.
 
   Some properties, like project and the resource name, cannot be changed and it will trigger a resource replacement.
 
-  To avoid any issues, please set the termination_protection property to true on all production services, it will prevent Terraform to remove the service until the flag is set back to false again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed even when this section is enabled. Be very careful!
+  We recommend you set the ``termination_protection`` property to true on all production services, it will prevent Terraform from removing the service. Be aware that any logical databases, topics or other configurations may be removed even when this setting is enabled. Be very careful!
 
 Getting started
 ---------------
 
-Please refer to the :doc:`getting started guide <get-started>` for your first Terraform project.
+Check out the :doc:`getting started guide <get-started>` for your first Terraform project.
 
 .. panels::
 

--- a/docs/tools/terraform/index.rst
+++ b/docs/tools/terraform/index.rst
@@ -17,7 +17,7 @@ See the `official documentation <https://registry.terraform.io/providers/aiven/a
 Getting started
 ---------------
 
-Please refer to the :doc:`getting started guide <geting-started>` for your first Terraform project.
+Please refer to the :doc:`getting started guide <get-started>` for your first Terraform project.
 
 .. panels::
 


### PR DESCRIPTION
# What changed, and why it matters

This PR brings in the following changes:

1. Terraform section layout including HowTo, Reference, and a Getting Started page.
2. Removing old getting started from the landing page.
3. Adding a new getting-started page.
4. Moving the only HowTo article under a HowTo section.

