### PR TITLE
update bigquery sink link to confluent as wepay is deprecated

### DIFF
--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -48,7 +48,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Elasticsearch <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/elasticsearch-sink>`__
 
-* `Google BigQuery <https://github.com/wepay/kafka-connect-bigquery>`__
+* `Google BigQuery <https://github.com/confluentinc/kafka-connect-bigquery>`__
 
 * `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/>`__
 


### PR DESCRIPTION
# What changed, and why it matters
Replace wepay bigquery link with confluent as it is deprecated and we use the confluent one.

