### PR TITLE
Use synonyms when searching

### DIFF
--- a/SEARCH.md
+++ b/SEARCH.md
@@ -125,6 +125,19 @@ os_client.index(index='devportal',
 
 You might also need to take care of removing documents that no longer exist.
 
+# Synonyms
+
+If you want to alias one search term to another, then you can update the file `scripts/synonyms.json` with comma-separated lists of aliases.  For example:
+```
+[
+     "postgresql, postgres, pg",
+     "kafka, kafak, kfaka"
+]
+```
+Note the lack of a trailing comma on the final term; this file must be valid JSON.
+
+The aliases are used at index-creation time, so if this file changes then the index needs to be re-created before it will take effect.
+
 # Testing changes to search functionality
 
 It seems like Netlify uses the deployed functions rather than the ones in a branch when building a preview, so we need to take care when testing these. A good approach is to use the [Netlify CLI](https://www.netlify.com/products/cli/) locally. For example, to test the search function:

--- a/netlify/functions/search/search.js
+++ b/netlify/functions/search/search.js
@@ -23,6 +23,7 @@ const handler = async (event) => {
       }
     }
 
+    let analyzer_name = "devportal_analyzer" // Needs to match what the index was created with
     const response = await client.search({
       index: "devportal",
       body: {
@@ -38,6 +39,7 @@ const handler = async (event) => {
                     query: query,
                     slop: 2,
                     boost: 5,
+                    analyzer: analyzer_name,
                   },
                 },
               },
@@ -54,6 +56,7 @@ const handler = async (event) => {
                   description: {
                     query: query,
                     slop: 2,
+                    analyzer: analyzer_name,
                   },
                 },
               },
@@ -62,6 +65,7 @@ const handler = async (event) => {
                   content: {
                     query: query,
                     slop: 5,
+                    analyzer: analyzer_name,
                   },
                 },
               },
@@ -70,6 +74,7 @@ const handler = async (event) => {
                   url: {
                     query: query,
                     slop: 5,
+                    analyzer: analyzer_name,
                   },
                 },
               },

--- a/scripts/create_index.py
+++ b/scripts/create_index.py
@@ -8,7 +8,31 @@ parser.add_argument('--es-url', help='OpenSearch URL')
 def create_index(os_client, index_name):
     # If needed uncomment next line to start over
     # os_client.indices.delete(index=index_name)
-    os_client.indices.create(index=index_name, ignore=400)
+    index_body = {
+            "settings": {
+                "index": {
+                    "analysis": {
+                        "analyzer": {
+                            "devportal_analyzer": {
+                                "tokenizer": "whitespace",
+                                "filter": ["lowercase", "devportal_synonyms"]
+                                }
+                            },
+                        "filter": {
+                            "devportal_synonyms": {
+                                "type": "synonym",
+                                "synonyms": [
+                                        "postgresql, postgres, pg",
+                                        "kafka, kafak, kfaka",
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+    os_client.indices.create(index=index_name, body=index_body, ignore=400)
     os_client.indices.put_mapping(index=index_name,
                            body={
                                'dynamic': False,

--- a/scripts/create_index.py
+++ b/scripts/create_index.py
@@ -1,11 +1,16 @@
 from opensearchpy import OpenSearch
 import argparse
+import json
+import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--es-url', help='OpenSearch URL')
 
 
 def create_index(os_client, index_name):
+    # Load the synonyms from a JSON file
+    syns = json.load(open(os.path.dirname(__file__) + '/synonyms.json', 'r'))
+
     # If needed uncomment next line to start over
     # os_client.indices.delete(index=index_name)
     index_body = {
@@ -21,10 +26,7 @@ def create_index(os_client, index_name):
                         "filter": {
                             "devportal_synonyms": {
                                 "type": "synonym",
-                                "synonyms": [
-                                        "postgresql, postgres, pg",
-                                        "kafka, kafak, kfaka",
-                                    ]
+                                "synonyms": syns
                                 }
                             }
                         }

--- a/scripts/synonyms.json
+++ b/scripts/synonyms.json
@@ -1,4 +1,4 @@
 [
      "postgresql, postgres, pg",
-     "kafka, kafak, kfaka"
+     "mirrormaker, mm2"
 ]

--- a/scripts/synonyms.json
+++ b/scripts/synonyms.json
@@ -1,0 +1,4 @@
+[
+     "postgresql, postgres, pg",
+     "kafka, kafak, kfaka"
+]


### PR DESCRIPTION
# What changed, and why it matters

This PR adds the capability to specify a list of synonyms to be used when searching.  It adds them at index-creation time, there are a couple of them seeded in the PR so it's obvious where to add more.

Note that this PR clashes with #649 so I've built it on top of that and will leave as draft until that is accepted/rejected (and if the latter, I'll rebuild it on main).