### PR TITLE
Updating npm packages based on dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "homepage": "https://github.com/aiven/devportal#readme",
   "devDependencies": {
-    "netlify-cli": "^3.37.26"
+    "netlify-cli": "^9.13.3"
   },
   "dependencies": {
-    "@opensearch-project/opensearch": "1.0.0",
-    "pg": "^8.7.1"
+    "@opensearch-project/opensearch": "1.0.2",
+    "pg": "^8.7.3"
   }
 }


### PR DESCRIPTION
# What changed, and why it matters

https://github.com/aiven/devportal/security/dependabot shows 8 alerts from medium to high severity levels.

## Actions taken:

(base) dewan.ahmed@Dewans-MacBook-Pro devportal % ncu
Checking /Users/dewan.ahmed/code/github.com/devportal/package.json
[====================] 3/3 100%

 @opensearch-project/opensearch     1.0.0  →    1.0.2     
 pg                                ^8.7.1  →   ^8.7.3     
 netlify-cli                     ^3.37.26  →  ^9.13.3     

Run ncu -u to upgrade package.json
(base) dewan.ahmed@Dewans-MacBook-Pro devportal % ncu -u
Upgrading /Users/dewan.ahmed/code/github.com/devportal/package.json
[====================] 3/3 100%

 @opensearch-project/opensearch     1.0.0  →    1.0.2     
 pg                                ^8.7.1  →   ^8.7.3     
 netlify-cli                     ^3.37.26  →  ^9.13.3  

## Review required

I don't have a JS background so please confirm if this is the proper way to update these submodules. I observed that since these are submodules of the `netlify-cli `, trying to update individual packages don't take any effect. I also tried `npm audit fix` but that didn't change the required submodule versions. 

I ran `make livehtml` locally after the change and the site seems to appear fine. However, please review in case these updates break anything.