### PR TITLE
Fixing a Terraform link that has changed recently.

### DIFF
--- a/docs/tools/terraform/upgrade-provider-v1-v2.rst
+++ b/docs/tools/terraform/upgrade-provider-v1-v2.rst
@@ -87,7 +87,7 @@ Upgrade Terraform from 0.13 or later
 Any version above 0.13 can be upgraded to latest without any special steps.
 
 .. note::
-  If you are using Aiven Terraform provider v1 with Terraform 0.14 ``dev_overrides`` (see `<https://www.terraform.io/docs/cli/config/config-file.html#provider-installation>`__ )
+  If you are using Aiven Terraform provider v1 with Terraform 0.14 ``dev_overrides`` (see `<https://www.terraform.io/cli/config/config-file#provider-installation>`__ )
   you will need to add Aiven provider to the ``exclude`` block or remove ``dev_overrides`` completely.
 
 1. Use ``tfenv`` to get the latest version (1.0.10 at the time of writing) ``tfenv install latest && tfenv use latest``


### PR DESCRIPTION
# What changed, and why it matters

A link in https://developer.aiven.io/docs/tools/terraform/upgrade-provider-v1-v2.html has changed since the post was published:

Old link: https://www.terraform.io/docs/cli/config/config-file.html#provider-installation

New link: https://www.terraform.io/cli/config/config-file#provider-installation

This broken link is causing https://github.com/aiven/devportal/pull/653 to fail.

Please review. 
