### PR TITLE
Generate list of clouds from API, include in CLI docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,6 @@ service-type-config-grafana:
 service-type-config-influxdb:
 	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "influxdb" > includes/config-influxdb.rst
 
+# (Re)Generate cloud listing
+cloud-list:
+	python "$(SOURCEDIR)/scripts/aiven/clouds.py" > includes/clouds-list.rst

--- a/_toc.yml
+++ b/_toc.yml
@@ -39,6 +39,10 @@ entries:
       - file: docs/platform/howto/integrations/prometheus-metrics
       - file: docs/platform/howto/integrations/datadog-increase-metrics-limit
       - file: docs/platform/howto/static-ip-addresses.rst
+    - file: docs/platform/reference
+      title: Reference
+      entries:
+        - glob: docs/platform/reference/*
 
 
   # --------- GLOBAL -----------

--- a/docs/platform/reference.rst
+++ b/docs/platform/reference.rst
@@ -1,0 +1,6 @@
+Reference
+=========
+
+Useful reference materials for working with the Aiven platform.
+
+.. tableofcontents::

--- a/docs/platform/reference/list_of_clouds.rst
+++ b/docs/platform/reference/list_of_clouds.rst
@@ -9,4 +9,3 @@ A reference list of the default available cloud regions.
 
 
 .. include:: /includes/clouds-list.rst
-

--- a/docs/platform/reference/list_of_clouds.rst
+++ b/docs/platform/reference/list_of_clouds.rst
@@ -1,0 +1,12 @@
+List of available cloud regions
+===============================
+
+A reference list of the default available cloud regions. 
+
+.. Note::
+
+  The list of available clouds might differ per project. Furthermore not all Aiven services are available in all cloud vendors and regions.
+
+
+.. include:: /includes/clouds-list.rst
+

--- a/docs/tools/cli/cloud.rst
+++ b/docs/tools/cli/cloud.rst
@@ -39,11 +39,5 @@ Lists cloud regions with related geographical region, latitude and longitude.
   avn cloud list --project my-project
 
 
-Reference list of clouds
-------------------------
-
-A quick reference list of the default available clouds, but bear in mind that this may differ between projects.
-
-
-.. include:: /includes/clouds-list.rst
+A reference of the cloud regions is available in the :doc:`dedicated document </docs/platform/reference/list_of_clouds>`.
 

--- a/docs/tools/cli/cloud.rst
+++ b/docs/tools/cli/cloud.rst
@@ -25,15 +25,25 @@ Lists cloud regions with related geographical region, latitude and longitude.
   * - ``--project``
     - The project to fetch details for
 
-**Example:** Show the details of the currently selected project.
+**Example:** Show the clouds available to the currently selected project.
 
 ::
 
   avn cloud list
 
 
-**Example:** Show the details of a named project.
+**Example:** Show the clouds available to a named project.
 
 ::
 
   avn cloud list --project my-project
+
+
+Reference list of clouds
+------------------------
+
+A quick reference list of the default available clouds, but bear in mind that this may differ between projects.
+
+
+.. include:: /includes/clouds-list.rst
+

--- a/includes/clouds-list.rst
+++ b/includes/clouds-list.rst
@@ -353,4 +353,4 @@ UpCloud
     - ``upcloud-sg-sin``
     - Asia, Singapore 
 
-List of clouds retrieved at **2022-04-07 11:00:20.499579**
+List of clouds retrieved at **2022-04-07 11:10:33.677802**

--- a/includes/clouds-list.rst
+++ b/includes/clouds-list.rst
@@ -352,5 +352,3 @@ UpCloud
   * - Southeast Asia
     - ``upcloud-sg-sin``
     - Asia, Singapore 
-
-List of clouds retrieved at **2022-04-07 11:10:33.677802**

--- a/includes/clouds-list.rst
+++ b/includes/clouds-list.rst
@@ -1,0 +1,211 @@
+.. list-table::
+  :header-rows: 1
+
+  * - Cloud
+    - Description
+  * - ``aws-af-south-1``
+    - Africa, South Africa - Amazon Web Services: Cape Town
+  * - ``azure-south-africa-north``
+    - Africa, South Africa - Azure: South Africa North
+  * - ``aws-me-south-1``
+    - Asia, Bahrain - Amazon Web Services: Bahrain
+  * - ``aws-ap-east-1``
+    - Asia, Hong Kong - Amazon Web Services: Hong Kong
+  * - ``azure-eastasia``
+    - Asia, Hong Kong - Azure: East Asia
+  * - ``google-asia-east2``
+    - Asia, Hong Kong - Google Cloud: Hong Kong
+  * - ``aws-ap-south-1``
+    - Asia, India - Amazon Web Services: Mumbai
+  * - ``azure-india-central``
+    - Asia, India - Azure: Central India
+  * - ``azure-india-south``
+    - Asia, India - Azure: South India
+  * - ``azure-india-west``
+    - Asia, India - Azure: West India
+  * - ``do-blr``
+    - Asia, India - DigitalOcean: Bangalore
+  * - ``google-asia-south2``
+    - Asia, India - Google Cloud: Delhi
+  * - ``google-asia-south1``
+    - Asia, India - Google Cloud: Mumbai
+  * - ``google-asia-southeast2``
+    - Asia, Indonesia - Google Cloud: Jakarta
+  * - ``aws-ap-southeast-3``
+    - Asia, Jakarta - Amazon Web Services: Jakarta
+  * - ``aws-ap-northeast-1``
+    - Asia, Japan - Amazon Web Services: Tokyo
+  * - ``azure-japaneast``
+    - Asia, Japan - Azure: Japan East
+  * - ``azure-japanwest``
+    - Asia, Japan - Azure: Japan West
+  * - ``google-asia-northeast2``
+    - Asia, Japan - Google Cloud: Osaka
+  * - ``google-asia-northeast1``
+    - Asia, Japan - Google Cloud: Tokyo
+  * - ``aws-ap-northeast-2``
+    - Asia, Korea - Amazon Web Services: Seoul
+  * - ``azure-korea-central``
+    - Asia, Korea - Azure: Korea Central
+  * - ``azure-korea-south``
+    - Asia, Korea - Azure: Korea South
+  * - ``google-asia-northeast3``
+    - Asia, Korea - Google Cloud: Seoul
+  * - ``aws-ap-southeast-1``
+    - Asia, Singapore - Amazon Web Services: Singapore
+  * - ``azure-southeastasia``
+    - Asia, Singapore - Azure: Southeast Asia
+  * - ``do-sgp``
+    - Asia, Singapore - DigitalOcean: Singapore
+  * - ``google-asia-southeast1``
+    - Asia, Singapore - Google Cloud: Singapore
+  * - ``upcloud-sg-sin``
+    - Asia, Singapore - UpCloud: Singapore
+  * - ``google-asia-east1``
+    - Asia, Taiwan - Google Cloud: Taiwan
+  * - ``azure-australia-central``
+    - Australia, Canberra - Azure: Australia Central
+  * - ``aws-ap-southeast-2``
+    - Australia, New South Wales - Amazon Web Services: Sydney
+  * - ``azure-australiaeast``
+    - Australia, New South Wales - Azure: Australia East
+  * - ``google-australia-southeast1``
+    - Australia, New South Wales - Google Cloud: Sydney
+  * - ``upcloud-au-syd``
+    - Australia, New South Wales - UpCloud: Sydney
+  * - ``azure-australiasoutheast``
+    - Australia, Victoria - Azure: Australia Southeast
+  * - ``google-australia-southeast2``
+    - Australia, Victoria - Google Cloud: Melbourne
+  * - ``azure-canadacentral``
+    - Canada, Ontario - Azure: Canada Central
+  * - ``do-tor``
+    - Canada, Ontario - DigitalOcean: Toronto
+  * - ``google-northamerica-northeast2``
+    - Canada, Ontario - Google Cloud: Toronto
+  * - ``aws-ca-central-1``
+    - Canada, Quebec - Amazon Web Services: Canada Central
+  * - ``azure-canadaeast``
+    - Canada, Quebec - Azure: Canada East
+  * - ``google-northamerica-northeast1``
+    - Canada, Quebec - Google Cloud: Montréal
+  * - ``google-europe-west1``
+    - Europe, Belgium - Google Cloud: Belgium
+  * - ``aws-eu-west-2``
+    - Europe, England - Amazon Web Services: London
+  * - ``azure-uksouth``
+    - Europe, England - Azure: UK South
+  * - ``do-lon``
+    - Europe, England - DigitalOcean: London
+  * - ``google-europe-west2``
+    - Europe, England - Google Cloud: London
+  * - ``google-europe-north1``
+    - Europe, Finland - Google Cloud: Finland
+  * - ``upcloud-fi-hel``
+    - Europe, Finland - UpCloud: Helsinki
+  * - ``aws-eu-west-3``
+    - Europe, France - Amazon Web Services: Paris
+  * - ``azure-france-central``
+    - Europe, France - Azure: France Central
+  * - ``aws-eu-central-1``
+    - Europe, Germany - Amazon Web Services: Frankfurt
+  * - ``azure-germany-north``
+    - Europe, Germany - Azure: Germany North
+  * - ``azure-germany-westcentral``
+    - Europe, Germany - Azure: Germany West Central
+  * - ``do-fra``
+    - Europe, Germany - DigitalOcean: Frankfurt
+  * - ``google-europe-west3``
+    - Europe, Germany - Google Cloud: Frankfurt
+  * - ``upcloud-de-fra``
+    - Europe, Germany - UpCloud: Frankfurt
+  * - ``aws-eu-west-1``
+    - Europe, Ireland - Amazon Web Services: Ireland
+  * - ``azure-northeurope``
+    - Europe, Ireland - Azure: North Europe
+  * - ``aws-eu-south-1``
+    - Europe, Italy - Amazon Web Services: Milan
+  * - ``azure-westeurope``
+    - Europe, Netherlands - Azure: West Europe
+  * - ``do-ams``
+    - Europe, Netherlands - DigitalOcean: Amsterdam
+  * - ``google-europe-west4``
+    - Europe, Netherlands - Google Cloud: Netherlands
+  * - ``upcloud-nl-ams``
+    - Europe, Netherlands - UpCloud: Amsterdam
+  * - ``azure-norway-east``
+    - Europe, Norway - Azure: Norway East
+  * - ``azure-norway-west``
+    - Europe, Norway - Azure: Norway West
+  * - ``google-europe-central2``
+    - Europe, Poland - Google Cloud: Warsaw
+  * - ``upcloud-pl-waw``
+    - Europe, Poland - UpCloud: Warsaw
+  * - ``upcloud-es-mad``
+    - Europe, Spain - UpCloud: Madrid
+  * - ``aws-eu-north-1``
+    - Europe, Sweden - Amazon Web Services: Stockholm
+  * - ``azure-switzerland-north``
+    - Europe, Switzerland - Azure: Switzerland North
+  * - ``google-europe-west6``
+    - Europe, Switzerland - Google Cloud: Zürich
+  * - ``azure-ukwest``
+    - Europe, Wales - Azure: UK West
+  * - ``azure-uae-north``
+    - Middle East, United Arab Emirates - Azure: Middle East
+  * - ``aws-sa-east-1``
+    - South America, Brazil - Amazon Web Services: São Paulo
+  * - ``azure-brazilsouth``
+    - South America, Brazil - Azure: Brazil South
+  * - ``google-southamerica-east1``
+    - South America, Brazil - Google Cloud: Sao Paulo
+  * - ``google-southamerica-west1``
+    - South America, Chile - Google Cloud: Santiago
+  * - ``aws-us-west-1``
+    - United States, California - Amazon Web Services: N. California
+  * - ``azure-westus``
+    - United States, California - Azure: West US
+  * - ``do-sfo``
+    - United States, California - DigitalOcean: San Francisco
+  * - ``google-us-west2``
+    - United States, California - Google Cloud: Los Angeles
+  * - ``upcloud-us-sjo``
+    - United States, California - UpCloud: San Jose
+  * - ``azure-northcentralus``
+    - United States, Illinois - Azure: North Central US
+  * - ``upcloud-us-chi``
+    - United States, Illinois - UpCloud: Chicago
+  * - ``azure-centralus``
+    - United States, Iowa - Azure: Central US
+  * - ``google-us-central1``
+    - United States, Iowa - Google Cloud: Iowa
+  * - ``google-us-west4``
+    - United States, Nevada - Google Cloud: Las Vegas
+  * - ``do-nyc``
+    - United States, New York - DigitalOcean: New York
+  * - ``upcloud-us-nyc``
+    - United States, New York - UpCloud: New York
+  * - ``aws-us-east-2``
+    - United States, Ohio - Amazon Web Services: Ohio
+  * - ``aws-us-west-2``
+    - United States, Oregon - Amazon Web Services: Oregon
+  * - ``google-us-west1``
+    - United States, Oregon - Google Cloud: Oregon
+  * - ``google-us-east1``
+    - United States, South Carolina - Google Cloud: South Carolina
+  * - ``azure-southcentralus``
+    - United States, Texas - Azure: South Central US
+  * - ``google-us-west3``
+    - United States, Utah - Google Cloud: Salt Lake City
+  * - ``aws-us-east-1``
+    - United States, Virginia - Amazon Web Services: N. Virginia
+  * - ``azure-eastus``
+    - United States, Virginia - Azure: East US
+  * - ``azure-eastus2``
+    - United States, Virginia - Azure: East US 2
+  * - ``google-us-east4``
+    - United States, Virginia - Google Cloud: Northern Virginia
+  * - ``azure-westus2``
+    - United States, Washington - Azure: West US 2
+  * - ``azure-westcentralus``
+    - United States, Wyoming - Azure: West Central US

--- a/includes/clouds-list.rst
+++ b/includes/clouds-list.rst
@@ -1,211 +1,354 @@
+
+aws
+-----------------------------------------------------
 .. list-table::
   :header-rows: 1
 
-  * - Cloud
+  * - Region
+    - Cloud
     - Description
-  * - ``aws-af-south-1``
+  * - africa
+    - ``aws-af-south-1``
     - Africa, South Africa - Amazon Web Services: Cape Town
-  * - ``azure-south-africa-north``
-    - Africa, South Africa - Azure: South Africa North
-  * - ``aws-me-south-1``
-    - Asia, Bahrain - Amazon Web Services: Bahrain
-  * - ``aws-ap-east-1``
-    - Asia, Hong Kong - Amazon Web Services: Hong Kong
-  * - ``azure-eastasia``
-    - Asia, Hong Kong - Azure: East Asia
-  * - ``google-asia-east2``
-    - Asia, Hong Kong - Google Cloud: Hong Kong
-  * - ``aws-ap-south-1``
-    - Asia, India - Amazon Web Services: Mumbai
-  * - ``azure-india-central``
-    - Asia, India - Azure: Central India
-  * - ``azure-india-south``
-    - Asia, India - Azure: South India
-  * - ``azure-india-west``
-    - Asia, India - Azure: West India
-  * - ``do-blr``
-    - Asia, India - DigitalOcean: Bangalore
-  * - ``google-asia-south2``
-    - Asia, India - Google Cloud: Delhi
-  * - ``google-asia-south1``
-    - Asia, India - Google Cloud: Mumbai
-  * - ``google-asia-southeast2``
-    - Asia, Indonesia - Google Cloud: Jakarta
-  * - ``aws-ap-southeast-3``
-    - Asia, Jakarta - Amazon Web Services: Jakarta
-  * - ``aws-ap-northeast-1``
-    - Asia, Japan - Amazon Web Services: Tokyo
-  * - ``azure-japaneast``
-    - Asia, Japan - Azure: Japan East
-  * - ``azure-japanwest``
-    - Asia, Japan - Azure: Japan West
-  * - ``google-asia-northeast2``
-    - Asia, Japan - Google Cloud: Osaka
-  * - ``google-asia-northeast1``
-    - Asia, Japan - Google Cloud: Tokyo
-  * - ``aws-ap-northeast-2``
-    - Asia, Korea - Amazon Web Services: Seoul
-  * - ``azure-korea-central``
-    - Asia, Korea - Azure: Korea Central
-  * - ``azure-korea-south``
-    - Asia, Korea - Azure: Korea South
-  * - ``google-asia-northeast3``
-    - Asia, Korea - Google Cloud: Seoul
-  * - ``aws-ap-southeast-1``
-    - Asia, Singapore - Amazon Web Services: Singapore
-  * - ``azure-southeastasia``
-    - Asia, Singapore - Azure: Southeast Asia
-  * - ``do-sgp``
-    - Asia, Singapore - DigitalOcean: Singapore
-  * - ``google-asia-southeast1``
-    - Asia, Singapore - Google Cloud: Singapore
-  * - ``upcloud-sg-sin``
-    - Asia, Singapore - UpCloud: Singapore
-  * - ``google-asia-east1``
-    - Asia, Taiwan - Google Cloud: Taiwan
-  * - ``azure-australia-central``
-    - Australia, Canberra - Azure: Australia Central
-  * - ``aws-ap-southeast-2``
+  * - australia
+    - ``aws-ap-southeast-2``
     - Australia, New South Wales - Amazon Web Services: Sydney
-  * - ``azure-australiaeast``
-    - Australia, New South Wales - Azure: Australia East
-  * - ``google-australia-southeast1``
-    - Australia, New South Wales - Google Cloud: Sydney
-  * - ``upcloud-au-syd``
-    - Australia, New South Wales - UpCloud: Sydney
-  * - ``azure-australiasoutheast``
-    - Australia, Victoria - Azure: Australia Southeast
-  * - ``google-australia-southeast2``
-    - Australia, Victoria - Google Cloud: Melbourne
-  * - ``azure-canadacentral``
-    - Canada, Ontario - Azure: Canada Central
-  * - ``do-tor``
-    - Canada, Ontario - DigitalOcean: Toronto
-  * - ``google-northamerica-northeast2``
-    - Canada, Ontario - Google Cloud: Toronto
-  * - ``aws-ca-central-1``
-    - Canada, Quebec - Amazon Web Services: Canada Central
-  * - ``azure-canadaeast``
-    - Canada, Quebec - Azure: Canada East
-  * - ``google-northamerica-northeast1``
-    - Canada, Quebec - Google Cloud: Montréal
-  * - ``google-europe-west1``
-    - Europe, Belgium - Google Cloud: Belgium
-  * - ``aws-eu-west-2``
-    - Europe, England - Amazon Web Services: London
-  * - ``azure-uksouth``
-    - Europe, England - Azure: UK South
-  * - ``do-lon``
-    - Europe, England - DigitalOcean: London
-  * - ``google-europe-west2``
-    - Europe, England - Google Cloud: London
-  * - ``google-europe-north1``
-    - Europe, Finland - Google Cloud: Finland
-  * - ``upcloud-fi-hel``
-    - Europe, Finland - UpCloud: Helsinki
-  * - ``aws-eu-west-3``
-    - Europe, France - Amazon Web Services: Paris
-  * - ``azure-france-central``
-    - Europe, France - Azure: France Central
-  * - ``aws-eu-central-1``
+  * - east asia
+    - ``aws-ap-east-1``
+    - Asia, Hong Kong - Amazon Web Services: Hong Kong
+  * - east asia
+    - ``aws-ap-northeast-1``
+    - Asia, Japan - Amazon Web Services: Tokyo
+  * - east asia
+    - ``aws-ap-northeast-2``
+    - Asia, Korea - Amazon Web Services: Seoul
+  * - europe
+    - ``aws-eu-central-1``
     - Europe, Germany - Amazon Web Services: Frankfurt
-  * - ``azure-germany-north``
-    - Europe, Germany - Azure: Germany North
-  * - ``azure-germany-westcentral``
-    - Europe, Germany - Azure: Germany West Central
-  * - ``do-fra``
-    - Europe, Germany - DigitalOcean: Frankfurt
-  * - ``google-europe-west3``
-    - Europe, Germany - Google Cloud: Frankfurt
-  * - ``upcloud-de-fra``
-    - Europe, Germany - UpCloud: Frankfurt
-  * - ``aws-eu-west-1``
-    - Europe, Ireland - Amazon Web Services: Ireland
-  * - ``azure-northeurope``
-    - Europe, Ireland - Azure: North Europe
-  * - ``aws-eu-south-1``
-    - Europe, Italy - Amazon Web Services: Milan
-  * - ``azure-westeurope``
-    - Europe, Netherlands - Azure: West Europe
-  * - ``do-ams``
-    - Europe, Netherlands - DigitalOcean: Amsterdam
-  * - ``google-europe-west4``
-    - Europe, Netherlands - Google Cloud: Netherlands
-  * - ``upcloud-nl-ams``
-    - Europe, Netherlands - UpCloud: Amsterdam
-  * - ``azure-norway-east``
-    - Europe, Norway - Azure: Norway East
-  * - ``azure-norway-west``
-    - Europe, Norway - Azure: Norway West
-  * - ``google-europe-central2``
-    - Europe, Poland - Google Cloud: Warsaw
-  * - ``upcloud-pl-waw``
-    - Europe, Poland - UpCloud: Warsaw
-  * - ``upcloud-es-mad``
-    - Europe, Spain - UpCloud: Madrid
-  * - ``aws-eu-north-1``
+  * - europe
+    - ``aws-eu-north-1``
     - Europe, Sweden - Amazon Web Services: Stockholm
-  * - ``azure-switzerland-north``
-    - Europe, Switzerland - Azure: Switzerland North
-  * - ``google-europe-west6``
-    - Europe, Switzerland - Google Cloud: Zürich
-  * - ``azure-ukwest``
-    - Europe, Wales - Azure: UK West
-  * - ``azure-uae-north``
-    - Middle East, United Arab Emirates - Azure: Middle East
-  * - ``aws-sa-east-1``
-    - South America, Brazil - Amazon Web Services: São Paulo
-  * - ``azure-brazilsouth``
-    - South America, Brazil - Azure: Brazil South
-  * - ``google-southamerica-east1``
-    - South America, Brazil - Google Cloud: Sao Paulo
-  * - ``google-southamerica-west1``
-    - South America, Chile - Google Cloud: Santiago
-  * - ``aws-us-west-1``
-    - United States, California - Amazon Web Services: N. California
-  * - ``azure-westus``
-    - United States, California - Azure: West US
-  * - ``do-sfo``
-    - United States, California - DigitalOcean: San Francisco
-  * - ``google-us-west2``
-    - United States, California - Google Cloud: Los Angeles
-  * - ``upcloud-us-sjo``
-    - United States, California - UpCloud: San Jose
-  * - ``azure-northcentralus``
-    - United States, Illinois - Azure: North Central US
-  * - ``upcloud-us-chi``
-    - United States, Illinois - UpCloud: Chicago
-  * - ``azure-centralus``
-    - United States, Iowa - Azure: Central US
-  * - ``google-us-central1``
-    - United States, Iowa - Google Cloud: Iowa
-  * - ``google-us-west4``
-    - United States, Nevada - Google Cloud: Las Vegas
-  * - ``do-nyc``
-    - United States, New York - DigitalOcean: New York
-  * - ``upcloud-us-nyc``
-    - United States, New York - UpCloud: New York
-  * - ``aws-us-east-2``
-    - United States, Ohio - Amazon Web Services: Ohio
-  * - ``aws-us-west-2``
-    - United States, Oregon - Amazon Web Services: Oregon
-  * - ``google-us-west1``
-    - United States, Oregon - Google Cloud: Oregon
-  * - ``google-us-east1``
-    - United States, South Carolina - Google Cloud: South Carolina
-  * - ``azure-southcentralus``
-    - United States, Texas - Azure: South Central US
-  * - ``google-us-west3``
-    - United States, Utah - Google Cloud: Salt Lake City
-  * - ``aws-us-east-1``
+  * - europe
+    - ``aws-eu-south-1``
+    - Europe, Italy - Amazon Web Services: Milan
+  * - europe
+    - ``aws-eu-west-1``
+    - Europe, Ireland - Amazon Web Services: Ireland
+  * - europe
+    - ``aws-eu-west-2``
+    - Europe, England - Amazon Web Services: London
+  * - europe
+    - ``aws-eu-west-3``
+    - Europe, France - Amazon Web Services: Paris
+  * - north america
+    - ``aws-ca-central-1``
+    - Canada, Quebec - Amazon Web Services: Canada Central
+  * - north america
+    - ``aws-us-east-1``
     - United States, Virginia - Amazon Web Services: N. Virginia
-  * - ``azure-eastus``
+  * - north america
+    - ``aws-us-east-2``
+    - United States, Ohio - Amazon Web Services: Ohio
+  * - north america
+    - ``aws-us-west-1``
+    - United States, California - Amazon Web Services: N. California
+  * - north america
+    - ``aws-us-west-2``
+    - United States, Oregon - Amazon Web Services: Oregon
+  * - south america
+    - ``aws-sa-east-1``
+    - South America, Brazil - Amazon Web Services: São Paulo
+  * - south asia
+    - ``aws-ap-south-1``
+    - Asia, India - Amazon Web Services: Mumbai
+  * - south asia
+    - ``aws-me-south-1``
+    - Asia, Bahrain - Amazon Web Services: Bahrain
+  * - southeast asia
+    - ``aws-ap-southeast-1``
+    - Asia, Singapore - Amazon Web Services: Singapore
+  * - southeast asia
+    - ``aws-ap-southeast-3``
+    - Asia, Jakarta - Amazon Web Services: Jakarta
+
+azure
+-----------------------------------------------------
+.. list-table::
+  :header-rows: 1
+
+  * - Region
+    - Cloud
+    - Description
+  * - africa
+    - ``azure-south-africa-north``
+    - Africa, South Africa - Azure: South Africa North
+  * - australia
+    - ``azure-australia-central``
+    - Australia, Canberra - Azure: Australia Central
+  * - australia
+    - ``azure-australiaeast``
+    - Australia, New South Wales - Azure: Australia East
+  * - australia
+    - ``azure-australiasoutheast``
+    - Australia, Victoria - Azure: Australia Southeast
+  * - east asia
+    - ``azure-japaneast``
+    - Asia, Japan - Azure: Japan East
+  * - east asia
+    - ``azure-japanwest``
+    - Asia, Japan - Azure: Japan West
+  * - east asia
+    - ``azure-korea-central``
+    - Asia, Korea - Azure: Korea Central
+  * - east asia
+    - ``azure-korea-south``
+    - Asia, Korea - Azure: Korea South
+  * - europe
+    - ``azure-france-central``
+    - Europe, France - Azure: France Central
+  * - europe
+    - ``azure-germany-north``
+    - Europe, Germany - Azure: Germany North
+  * - europe
+    - ``azure-germany-westcentral``
+    - Europe, Germany - Azure: Germany West Central
+  * - europe
+    - ``azure-northeurope``
+    - Europe, Ireland - Azure: North Europe
+  * - europe
+    - ``azure-norway-east``
+    - Europe, Norway - Azure: Norway East
+  * - europe
+    - ``azure-norway-west``
+    - Europe, Norway - Azure: Norway West
+  * - europe
+    - ``azure-switzerland-north``
+    - Europe, Switzerland - Azure: Switzerland North
+  * - europe
+    - ``azure-uksouth``
+    - Europe, England - Azure: UK South
+  * - europe
+    - ``azure-ukwest``
+    - Europe, Wales - Azure: UK West
+  * - europe
+    - ``azure-westeurope``
+    - Europe, Netherlands - Azure: West Europe
+  * - middle east
+    - ``azure-uae-north``
+    - Middle East, United Arab Emirates - Azure: Middle East
+  * - north america
+    - ``azure-canadacentral``
+    - Canada, Ontario - Azure: Canada Central
+  * - north america
+    - ``azure-canadaeast``
+    - Canada, Quebec - Azure: Canada East
+  * - north america
+    - ``azure-centralus``
+    - United States, Iowa - Azure: Central US
+  * - north america
+    - ``azure-eastus``
     - United States, Virginia - Azure: East US
-  * - ``azure-eastus2``
+  * - north america
+    - ``azure-eastus2``
     - United States, Virginia - Azure: East US 2
-  * - ``google-us-east4``
-    - United States, Virginia - Google Cloud: Northern Virginia
-  * - ``azure-westus2``
-    - United States, Washington - Azure: West US 2
-  * - ``azure-westcentralus``
+  * - north america
+    - ``azure-northcentralus``
+    - United States, Illinois - Azure: North Central US
+  * - north america
+    - ``azure-southcentralus``
+    - United States, Texas - Azure: South Central US
+  * - north america
+    - ``azure-westcentralus``
     - United States, Wyoming - Azure: West Central US
+  * - north america
+    - ``azure-westus``
+    - United States, California - Azure: West US
+  * - north america
+    - ``azure-westus2``
+    - United States, Washington - Azure: West US 2
+  * - south america
+    - ``azure-brazilsouth``
+    - South America, Brazil - Azure: Brazil South
+  * - south asia
+    - ``azure-india-central``
+    - Asia, India - Azure: Central India
+  * - south asia
+    - ``azure-india-south``
+    - Asia, India - Azure: South India
+  * - south asia
+    - ``azure-india-west``
+    - Asia, India - Azure: West India
+  * - southeast asia
+    - ``azure-eastasia``
+    - Asia, Hong Kong - Azure: East Asia
+  * - southeast asia
+    - ``azure-southeastasia``
+    - Asia, Singapore - Azure: Southeast Asia
+
+do
+-----------------------------------------------------
+.. list-table::
+  :header-rows: 1
+
+  * - Region
+    - Cloud
+    - Description
+  * - europe
+    - ``do-ams``
+    - Europe, Netherlands - DigitalOcean: Amsterdam
+  * - europe
+    - ``do-fra``
+    - Europe, Germany - DigitalOcean: Frankfurt
+  * - europe
+    - ``do-lon``
+    - Europe, England - DigitalOcean: London
+  * - north america
+    - ``do-nyc``
+    - United States, New York - DigitalOcean: New York
+  * - north america
+    - ``do-sfo``
+    - United States, California - DigitalOcean: San Francisco
+  * - north america
+    - ``do-tor``
+    - Canada, Ontario - DigitalOcean: Toronto
+  * - south asia
+    - ``do-blr``
+    - Asia, India - DigitalOcean: Bangalore
+  * - southeast asia
+    - ``do-sgp``
+    - Asia, Singapore - DigitalOcean: Singapore
+
+google
+-----------------------------------------------------
+.. list-table::
+  :header-rows: 1
+
+  * - Region
+    - Cloud
+    - Description
+  * - australia
+    - ``google-australia-southeast1``
+    - Australia, New South Wales - Google Cloud: Sydney
+  * - australia
+    - ``google-australia-southeast2``
+    - Australia, Victoria - Google Cloud: Melbourne
+  * - east asia
+    - ``google-asia-east1``
+    - Asia, Taiwan - Google Cloud: Taiwan
+  * - east asia
+    - ``google-asia-east2``
+    - Asia, Hong Kong - Google Cloud: Hong Kong
+  * - east asia
+    - ``google-asia-northeast1``
+    - Asia, Japan - Google Cloud: Tokyo
+  * - east asia
+    - ``google-asia-northeast2``
+    - Asia, Japan - Google Cloud: Osaka
+  * - east asia
+    - ``google-asia-northeast3``
+    - Asia, Korea - Google Cloud: Seoul
+  * - europe
+    - ``google-europe-central2``
+    - Europe, Poland - Google Cloud: Warsaw
+  * - europe
+    - ``google-europe-north1``
+    - Europe, Finland - Google Cloud: Finland
+  * - europe
+    - ``google-europe-west1``
+    - Europe, Belgium - Google Cloud: Belgium
+  * - europe
+    - ``google-europe-west2``
+    - Europe, England - Google Cloud: London
+  * - europe
+    - ``google-europe-west3``
+    - Europe, Germany - Google Cloud: Frankfurt
+  * - europe
+    - ``google-europe-west4``
+    - Europe, Netherlands - Google Cloud: Netherlands
+  * - europe
+    - ``google-europe-west6``
+    - Europe, Switzerland - Google Cloud: Zürich
+  * - north america
+    - ``google-northamerica-northeast1``
+    - Canada, Quebec - Google Cloud: Montréal
+  * - north america
+    - ``google-northamerica-northeast2``
+    - Canada, Ontario - Google Cloud: Toronto
+  * - north america
+    - ``google-us-central1``
+    - United States, Iowa - Google Cloud: Iowa
+  * - north america
+    - ``google-us-east1``
+    - United States, South Carolina - Google Cloud: South Carolina
+  * - north america
+    - ``google-us-east4``
+    - United States, Virginia - Google Cloud: Northern Virginia
+  * - north america
+    - ``google-us-west1``
+    - United States, Oregon - Google Cloud: Oregon
+  * - north america
+    - ``google-us-west2``
+    - United States, California - Google Cloud: Los Angeles
+  * - north america
+    - ``google-us-west3``
+    - United States, Utah - Google Cloud: Salt Lake City
+  * - north america
+    - ``google-us-west4``
+    - United States, Nevada - Google Cloud: Las Vegas
+  * - south america
+    - ``google-southamerica-east1``
+    - South America, Brazil - Google Cloud: Sao Paulo
+  * - south america
+    - ``google-southamerica-west1``
+    - South America, Chile - Google Cloud: Santiago
+  * - south asia
+    - ``google-asia-south1``
+    - Asia, India - Google Cloud: Mumbai
+  * - south asia
+    - ``google-asia-south2``
+    - Asia, India - Google Cloud: Delhi
+  * - southeast asia
+    - ``google-asia-southeast1``
+    - Asia, Singapore - Google Cloud: Singapore
+  * - southeast asia
+    - ``google-asia-southeast2``
+    - Asia, Indonesia - Google Cloud: Jakarta
+
+upcloud
+-----------------------------------------------------
+.. list-table::
+  :header-rows: 1
+
+  * - Region
+    - Cloud
+    - Description
+  * - australia
+    - ``upcloud-au-syd``
+    - Australia, New South Wales - UpCloud: Sydney
+  * - europe
+    - ``upcloud-de-fra``
+    - Europe, Germany - UpCloud: Frankfurt
+  * - europe
+    - ``upcloud-es-mad``
+    - Europe, Spain - UpCloud: Madrid
+  * - europe
+    - ``upcloud-fi-hel``
+    - Europe, Finland - UpCloud: Helsinki
+  * - europe
+    - ``upcloud-nl-ams``
+    - Europe, Netherlands - UpCloud: Amsterdam
+  * - europe
+    - ``upcloud-pl-waw``
+    - Europe, Poland - UpCloud: Warsaw
+  * - north america
+    - ``upcloud-us-chi``
+    - United States, Illinois - UpCloud: Chicago
+  * - north america
+    - ``upcloud-us-nyc``
+    - United States, New York - UpCloud: New York
+  * - north america
+    - ``upcloud-us-sjo``
+    - United States, California - UpCloud: San Jose
+  * - southeast asia
+    - ``upcloud-sg-sin``
+    - Asia, Singapore - UpCloud: Singapore

--- a/includes/clouds-list.rst
+++ b/includes/clouds-list.rst
@@ -1,5 +1,5 @@
 
-aws
+Amazon Web Services
 -----------------------------------------------------
 .. list-table::
   :header-rows: 1
@@ -7,71 +7,71 @@ aws
   * - Region
     - Cloud
     - Description
-  * - africa
+  * - Africa
     - ``aws-af-south-1``
-    - Africa, South Africa - Amazon Web Services: Cape Town
-  * - australia
+    - Africa, South Africa 
+  * - Australia
     - ``aws-ap-southeast-2``
-    - Australia, New South Wales - Amazon Web Services: Sydney
-  * - east asia
+    - Australia, New South Wales 
+  * - East Asia
     - ``aws-ap-east-1``
-    - Asia, Hong Kong - Amazon Web Services: Hong Kong
-  * - east asia
+    - Asia, Hong Kong 
+  * - East Asia
     - ``aws-ap-northeast-1``
-    - Asia, Japan - Amazon Web Services: Tokyo
-  * - east asia
+    - Asia, Japan 
+  * - East Asia
     - ``aws-ap-northeast-2``
-    - Asia, Korea - Amazon Web Services: Seoul
-  * - europe
+    - Asia, Korea 
+  * - Europe
     - ``aws-eu-central-1``
-    - Europe, Germany - Amazon Web Services: Frankfurt
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``aws-eu-north-1``
-    - Europe, Sweden - Amazon Web Services: Stockholm
-  * - europe
+    - Europe, Sweden 
+  * - Europe
     - ``aws-eu-south-1``
-    - Europe, Italy - Amazon Web Services: Milan
-  * - europe
+    - Europe, Italy 
+  * - Europe
     - ``aws-eu-west-1``
-    - Europe, Ireland - Amazon Web Services: Ireland
-  * - europe
+    - Europe, Ireland 
+  * - Europe
     - ``aws-eu-west-2``
-    - Europe, England - Amazon Web Services: London
-  * - europe
+    - Europe, England 
+  * - Europe
     - ``aws-eu-west-3``
-    - Europe, France - Amazon Web Services: Paris
-  * - north america
+    - Europe, France 
+  * - North America
     - ``aws-ca-central-1``
-    - Canada, Quebec - Amazon Web Services: Canada Central
-  * - north america
+    - Canada, Quebec 
+  * - North America
     - ``aws-us-east-1``
-    - United States, Virginia - Amazon Web Services: N. Virginia
-  * - north america
+    - United States, Virginia 
+  * - North America
     - ``aws-us-east-2``
-    - United States, Ohio - Amazon Web Services: Ohio
-  * - north america
+    - United States, Ohio 
+  * - North America
     - ``aws-us-west-1``
-    - United States, California - Amazon Web Services: N. California
-  * - north america
+    - United States, California 
+  * - North America
     - ``aws-us-west-2``
-    - United States, Oregon - Amazon Web Services: Oregon
-  * - south america
+    - United States, Oregon 
+  * - South America
     - ``aws-sa-east-1``
-    - South America, Brazil - Amazon Web Services: São Paulo
-  * - south asia
+    - South America, Brazil 
+  * - South Asia
     - ``aws-ap-south-1``
-    - Asia, India - Amazon Web Services: Mumbai
-  * - south asia
+    - Asia, India 
+  * - South Asia
     - ``aws-me-south-1``
-    - Asia, Bahrain - Amazon Web Services: Bahrain
-  * - southeast asia
+    - Asia, Bahrain 
+  * - Southeast Asia
     - ``aws-ap-southeast-1``
-    - Asia, Singapore - Amazon Web Services: Singapore
-  * - southeast asia
+    - Asia, Singapore 
+  * - Southeast Asia
     - ``aws-ap-southeast-3``
-    - Asia, Jakarta - Amazon Web Services: Jakarta
+    - Asia, Jakarta 
 
-azure
+Azure
 -----------------------------------------------------
 .. list-table::
   :header-rows: 1
@@ -79,113 +79,113 @@ azure
   * - Region
     - Cloud
     - Description
-  * - africa
+  * - Africa
     - ``azure-south-africa-north``
-    - Africa, South Africa - Azure: South Africa North
-  * - australia
+    - Africa, South Africa 
+  * - Australia
     - ``azure-australia-central``
-    - Australia, Canberra - Azure: Australia Central
-  * - australia
+    - Australia, Canberra 
+  * - Australia
     - ``azure-australiaeast``
-    - Australia, New South Wales - Azure: Australia East
-  * - australia
+    - Australia, New South Wales 
+  * - Australia
     - ``azure-australiasoutheast``
-    - Australia, Victoria - Azure: Australia Southeast
-  * - east asia
+    - Australia, Victoria 
+  * - East Asia
     - ``azure-japaneast``
-    - Asia, Japan - Azure: Japan East
-  * - east asia
+    - Asia, Japan 
+  * - East Asia
     - ``azure-japanwest``
-    - Asia, Japan - Azure: Japan West
-  * - east asia
+    - Asia, Japan 
+  * - East Asia
     - ``azure-korea-central``
-    - Asia, Korea - Azure: Korea Central
-  * - east asia
+    - Asia, Korea 
+  * - East Asia
     - ``azure-korea-south``
-    - Asia, Korea - Azure: Korea South
-  * - europe
+    - Asia, Korea 
+  * - Europe
     - ``azure-france-central``
-    - Europe, France - Azure: France Central
-  * - europe
+    - Europe, France 
+  * - Europe
     - ``azure-germany-north``
-    - Europe, Germany - Azure: Germany North
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``azure-germany-westcentral``
-    - Europe, Germany - Azure: Germany West Central
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``azure-northeurope``
-    - Europe, Ireland - Azure: North Europe
-  * - europe
+    - Europe, Ireland 
+  * - Europe
     - ``azure-norway-east``
-    - Europe, Norway - Azure: Norway East
-  * - europe
+    - Europe, Norway 
+  * - Europe
     - ``azure-norway-west``
-    - Europe, Norway - Azure: Norway West
-  * - europe
+    - Europe, Norway 
+  * - Europe
     - ``azure-switzerland-north``
-    - Europe, Switzerland - Azure: Switzerland North
-  * - europe
+    - Europe, Switzerland 
+  * - Europe
     - ``azure-uksouth``
-    - Europe, England - Azure: UK South
-  * - europe
+    - Europe, England 
+  * - Europe
     - ``azure-ukwest``
-    - Europe, Wales - Azure: UK West
-  * - europe
+    - Europe, Wales 
+  * - Europe
     - ``azure-westeurope``
-    - Europe, Netherlands - Azure: West Europe
-  * - middle east
+    - Europe, Netherlands 
+  * - Middle East
     - ``azure-uae-north``
-    - Middle East, United Arab Emirates - Azure: Middle East
-  * - north america
+    - Middle East, United Arab Emirates 
+  * - North America
     - ``azure-canadacentral``
-    - Canada, Ontario - Azure: Canada Central
-  * - north america
+    - Canada, Ontario 
+  * - North America
     - ``azure-canadaeast``
-    - Canada, Quebec - Azure: Canada East
-  * - north america
+    - Canada, Quebec 
+  * - North America
     - ``azure-centralus``
-    - United States, Iowa - Azure: Central US
-  * - north america
+    - United States, Iowa 
+  * - North America
     - ``azure-eastus``
-    - United States, Virginia - Azure: East US
-  * - north america
+    - United States, Virginia 
+  * - North America
     - ``azure-eastus2``
-    - United States, Virginia - Azure: East US 2
-  * - north america
+    - United States, Virginia 
+  * - North America
     - ``azure-northcentralus``
-    - United States, Illinois - Azure: North Central US
-  * - north america
+    - United States, Illinois 
+  * - North America
     - ``azure-southcentralus``
-    - United States, Texas - Azure: South Central US
-  * - north america
+    - United States, Texas 
+  * - North America
     - ``azure-westcentralus``
-    - United States, Wyoming - Azure: West Central US
-  * - north america
+    - United States, Wyoming 
+  * - North America
     - ``azure-westus``
-    - United States, California - Azure: West US
-  * - north america
+    - United States, California 
+  * - North America
     - ``azure-westus2``
-    - United States, Washington - Azure: West US 2
-  * - south america
+    - United States, Washington 
+  * - South America
     - ``azure-brazilsouth``
-    - South America, Brazil - Azure: Brazil South
-  * - south asia
+    - South America, Brazil 
+  * - South Asia
     - ``azure-india-central``
-    - Asia, India - Azure: Central India
-  * - south asia
+    - Asia, India 
+  * - South Asia
     - ``azure-india-south``
-    - Asia, India - Azure: South India
-  * - south asia
+    - Asia, India 
+  * - South Asia
     - ``azure-india-west``
-    - Asia, India - Azure: West India
-  * - southeast asia
+    - Asia, India 
+  * - Southeast Asia
     - ``azure-eastasia``
-    - Asia, Hong Kong - Azure: East Asia
-  * - southeast asia
+    - Asia, Hong Kong 
+  * - Southeast Asia
     - ``azure-southeastasia``
-    - Asia, Singapore - Azure: Southeast Asia
+    - Asia, Singapore 
 
-do
+DigitalOcean
 -----------------------------------------------------
 .. list-table::
   :header-rows: 1
@@ -193,32 +193,32 @@ do
   * - Region
     - Cloud
     - Description
-  * - europe
+  * - Europe
     - ``do-ams``
-    - Europe, Netherlands - DigitalOcean: Amsterdam
-  * - europe
+    - Europe, Netherlands 
+  * - Europe
     - ``do-fra``
-    - Europe, Germany - DigitalOcean: Frankfurt
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``do-lon``
-    - Europe, England - DigitalOcean: London
-  * - north america
+    - Europe, England 
+  * - North America
     - ``do-nyc``
-    - United States, New York - DigitalOcean: New York
-  * - north america
+    - United States, New York 
+  * - North America
     - ``do-sfo``
-    - United States, California - DigitalOcean: San Francisco
-  * - north america
+    - United States, California 
+  * - North America
     - ``do-tor``
-    - Canada, Ontario - DigitalOcean: Toronto
-  * - south asia
+    - Canada, Ontario 
+  * - South Asia
     - ``do-blr``
-    - Asia, India - DigitalOcean: Bangalore
-  * - southeast asia
+    - Asia, India 
+  * - Southeast Asia
     - ``do-sgp``
-    - Asia, Singapore - DigitalOcean: Singapore
+    - Asia, Singapore 
 
-google
+Google Cloud
 -----------------------------------------------------
 .. list-table::
   :header-rows: 1
@@ -226,95 +226,95 @@ google
   * - Region
     - Cloud
     - Description
-  * - australia
+  * - Australia
     - ``google-australia-southeast1``
-    - Australia, New South Wales - Google Cloud: Sydney
-  * - australia
+    - Australia, New South Wales 
+  * - Australia
     - ``google-australia-southeast2``
-    - Australia, Victoria - Google Cloud: Melbourne
-  * - east asia
+    - Australia, Victoria 
+  * - East Asia
     - ``google-asia-east1``
-    - Asia, Taiwan - Google Cloud: Taiwan
-  * - east asia
+    - Asia, Taiwan 
+  * - East Asia
     - ``google-asia-east2``
-    - Asia, Hong Kong - Google Cloud: Hong Kong
-  * - east asia
+    - Asia, Hong Kong 
+  * - East Asia
     - ``google-asia-northeast1``
-    - Asia, Japan - Google Cloud: Tokyo
-  * - east asia
+    - Asia, Japan 
+  * - East Asia
     - ``google-asia-northeast2``
-    - Asia, Japan - Google Cloud: Osaka
-  * - east asia
+    - Asia, Japan 
+  * - East Asia
     - ``google-asia-northeast3``
-    - Asia, Korea - Google Cloud: Seoul
-  * - europe
+    - Asia, Korea 
+  * - Europe
     - ``google-europe-central2``
-    - Europe, Poland - Google Cloud: Warsaw
-  * - europe
+    - Europe, Poland 
+  * - Europe
     - ``google-europe-north1``
-    - Europe, Finland - Google Cloud: Finland
-  * - europe
+    - Europe, Finland 
+  * - Europe
     - ``google-europe-west1``
-    - Europe, Belgium - Google Cloud: Belgium
-  * - europe
+    - Europe, Belgium 
+  * - Europe
     - ``google-europe-west2``
-    - Europe, England - Google Cloud: London
-  * - europe
+    - Europe, England 
+  * - Europe
     - ``google-europe-west3``
-    - Europe, Germany - Google Cloud: Frankfurt
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``google-europe-west4``
-    - Europe, Netherlands - Google Cloud: Netherlands
-  * - europe
+    - Europe, Netherlands 
+  * - Europe
     - ``google-europe-west6``
-    - Europe, Switzerland - Google Cloud: Zürich
-  * - north america
+    - Europe, Switzerland 
+  * - North America
     - ``google-northamerica-northeast1``
-    - Canada, Quebec - Google Cloud: Montréal
-  * - north america
+    - Canada, Quebec 
+  * - North America
     - ``google-northamerica-northeast2``
-    - Canada, Ontario - Google Cloud: Toronto
-  * - north america
+    - Canada, Ontario 
+  * - North America
     - ``google-us-central1``
-    - United States, Iowa - Google Cloud: Iowa
-  * - north america
+    - United States, Iowa 
+  * - North America
     - ``google-us-east1``
-    - United States, South Carolina - Google Cloud: South Carolina
-  * - north america
+    - United States, South Carolina 
+  * - North America
     - ``google-us-east4``
-    - United States, Virginia - Google Cloud: Northern Virginia
-  * - north america
+    - United States, Virginia 
+  * - North America
     - ``google-us-west1``
-    - United States, Oregon - Google Cloud: Oregon
-  * - north america
+    - United States, Oregon 
+  * - North America
     - ``google-us-west2``
-    - United States, California - Google Cloud: Los Angeles
-  * - north america
+    - United States, California 
+  * - North America
     - ``google-us-west3``
-    - United States, Utah - Google Cloud: Salt Lake City
-  * - north america
+    - United States, Utah 
+  * - North America
     - ``google-us-west4``
-    - United States, Nevada - Google Cloud: Las Vegas
-  * - south america
+    - United States, Nevada 
+  * - South America
     - ``google-southamerica-east1``
-    - South America, Brazil - Google Cloud: Sao Paulo
-  * - south america
+    - South America, Brazil 
+  * - South America
     - ``google-southamerica-west1``
-    - South America, Chile - Google Cloud: Santiago
-  * - south asia
+    - South America, Chile 
+  * - South Asia
     - ``google-asia-south1``
-    - Asia, India - Google Cloud: Mumbai
-  * - south asia
+    - Asia, India 
+  * - South Asia
     - ``google-asia-south2``
-    - Asia, India - Google Cloud: Delhi
-  * - southeast asia
+    - Asia, India 
+  * - Southeast Asia
     - ``google-asia-southeast1``
-    - Asia, Singapore - Google Cloud: Singapore
-  * - southeast asia
+    - Asia, Singapore 
+  * - Southeast Asia
     - ``google-asia-southeast2``
-    - Asia, Indonesia - Google Cloud: Jakarta
+    - Asia, Indonesia 
 
-upcloud
+UpCloud
 -----------------------------------------------------
 .. list-table::
   :header-rows: 1
@@ -322,33 +322,35 @@ upcloud
   * - Region
     - Cloud
     - Description
-  * - australia
+  * - Australia
     - ``upcloud-au-syd``
-    - Australia, New South Wales - UpCloud: Sydney
-  * - europe
+    - Australia, New South Wales 
+  * - Europe
     - ``upcloud-de-fra``
-    - Europe, Germany - UpCloud: Frankfurt
-  * - europe
+    - Europe, Germany 
+  * - Europe
     - ``upcloud-es-mad``
-    - Europe, Spain - UpCloud: Madrid
-  * - europe
+    - Europe, Spain 
+  * - Europe
     - ``upcloud-fi-hel``
-    - Europe, Finland - UpCloud: Helsinki
-  * - europe
+    - Europe, Finland 
+  * - Europe
     - ``upcloud-nl-ams``
-    - Europe, Netherlands - UpCloud: Amsterdam
-  * - europe
+    - Europe, Netherlands 
+  * - Europe
     - ``upcloud-pl-waw``
-    - Europe, Poland - UpCloud: Warsaw
-  * - north america
+    - Europe, Poland 
+  * - North America
     - ``upcloud-us-chi``
-    - United States, Illinois - UpCloud: Chicago
-  * - north america
+    - United States, Illinois 
+  * - North America
     - ``upcloud-us-nyc``
-    - United States, New York - UpCloud: New York
-  * - north america
+    - United States, New York 
+  * - North America
     - ``upcloud-us-sjo``
-    - United States, California - UpCloud: San Jose
-  * - southeast asia
+    - United States, California 
+  * - Southeast Asia
     - ``upcloud-sg-sin``
-    - Asia, Singapore - UpCloud: Singapore
+    - Asia, Singapore 
+
+List of clouds retrieved at **2022-04-07 11:00:20.499579**

--- a/scripts/aiven/clouds.py
+++ b/scripts/aiven/clouds.py
@@ -1,5 +1,4 @@
 import requests
-import datetime
 
 
 def print_cloud_entry(cloud):
@@ -43,9 +42,6 @@ def main():
             print("    - Description")
 
         print_cloud_entry(cloud)
-
-    print("")
-    print("List of clouds retrieved at **{}**".format(datetime.datetime.now()))
 
 
 if __name__ == '__main__':

--- a/scripts/aiven/clouds.py
+++ b/scripts/aiven/clouds.py
@@ -1,0 +1,23 @@
+import requests
+
+
+def print_cloud_entry(cloud):
+    print("  * - ``{}``".format(cloud['cloud_name']))
+    print("    - {}".format(cloud['cloud_description']))
+
+
+def main():
+    response = requests.get("https://api.aiven.io/v1/clouds")
+    data = response.json()
+    print(".. list-table::")
+    print("  :header-rows: 1")
+    print("")
+
+    print("  * - Cloud")
+    print("    - Description")
+    for cloud in data['clouds']:
+        print_cloud_entry(cloud)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/aiven/clouds.py
+++ b/scripts/aiven/clouds.py
@@ -1,10 +1,12 @@
 import requests
+import datetime
 
 
 def print_cloud_entry(cloud):
-    print("  * - {}".format(cloud['geo_region']))
+    print("  * - {}".format(cloud['geo_region'].title()))
     print("    - ``{}``".format(cloud['cloud_name']))
-    print("    - {}".format(cloud['cloud_description']))
+    prefix = cloud['cloud_description'][0: cloud['cloud_description'].find('-')]
+    print("    - {}".format(prefix))
 
 
 def main():
@@ -16,7 +18,7 @@ def main():
 
     prevCloud = None
     for cloud in data:
-        currCloud = cloud["cloud_name"][0: cloud["cloud_name"].find('-')]
+        currCloud = cloud["cloud_description"][cloud["cloud_description"].find('-')+2: cloud["cloud_description"].find(':')]
         if currCloud != prevCloud:
             prevCloud = currCloud
             print("")
@@ -32,6 +34,9 @@ def main():
             print("    - Description")
 
         print_cloud_entry(cloud)
+
+    print("")
+    print("List of clouds retrieved at **{}**".format(datetime.datetime.now()))
 
 
 if __name__ == '__main__':

--- a/scripts/aiven/clouds.py
+++ b/scripts/aiven/clouds.py
@@ -2,20 +2,35 @@ import requests
 
 
 def print_cloud_entry(cloud):
-    print("  * - ``{}``".format(cloud['cloud_name']))
+    print("  * - {}".format(cloud['geo_region']))
+    print("    - ``{}``".format(cloud['cloud_name']))
     print("    - {}".format(cloud['cloud_description']))
 
 
 def main():
     response = requests.get("https://api.aiven.io/v1/clouds")
-    data = response.json()
-    print(".. list-table::")
-    print("  :header-rows: 1")
-    print("")
+    data = response.json()["clouds"]
 
-    print("  * - Cloud")
-    print("    - Description")
-    for cloud in data['clouds']:
+    # Sorting the data by vendor and region
+    data = sorted(data, key=lambda k: k["cloud_name"][0: k["cloud_name"].find('-')] + " " + k['geo_region'] + k["cloud_name"])
+
+    prevCloud = None
+    for cloud in data:
+        currCloud = cloud["cloud_name"][0: cloud["cloud_name"].find('-')]
+        if currCloud != prevCloud:
+            prevCloud = currCloud
+            print("")
+            print(currCloud)
+            print("-----------------------------------------------------")
+
+            print(".. list-table::")
+            print("  :header-rows: 1")
+            print("")
+
+            print("  * - Region")
+            print("    - Cloud")
+            print("    - Description")
+
         print_cloud_entry(cloud)
 
 

--- a/scripts/aiven/clouds.py
+++ b/scripts/aiven/clouds.py
@@ -3,8 +3,10 @@ import datetime
 
 
 def print_cloud_entry(cloud):
+    # Printing in title case to make it look better
     print("  * - {}".format(cloud['geo_region'].title()))
     print("    - ``{}``".format(cloud['cloud_name']))
+    # Printing
     prefix = cloud['cloud_description'][0: cloud['cloud_description'].find('-')]
     print("    - {}".format(prefix))
 
@@ -14,11 +16,18 @@ def main():
     data = response.json()["clouds"]
 
     # Sorting the data by vendor and region
+    # * Vendor is contained in the cloud_name field, between the start and the '-' symbol
+    # * geographical region is contained in the geo_region field
+    # * the cloud name itself is contained in the cloud_name field
     data = sorted(data, key=lambda k: k["cloud_name"][0: k["cloud_name"].find('-')] + " " + k['geo_region'] + k["cloud_name"])
 
+    # This helps creating a new section every time there is a change in the Cloud vendor
     prevCloud = None
     for cloud in data:
+        # Extracting the cloud vendor information available in the cloud_description field between the `-` symbol and the `:` symbol
         currCloud = cloud["cloud_description"][cloud["cloud_description"].find('-')+2: cloud["cloud_description"].find(':')]
+
+        # If currentCloud is different than  the previous cloud, let's create a new title, section, table
         if currCloud != prevCloud:
             prevCloud = currCloud
             print("")


### PR DESCRIPTION
# What changed, and why it matters

I often wish I had a reference list of clouds to look at. This adds exactly that functionality, but we'll need to update it from time to time by re-running the script. I would like feedback on this PR but is is **incomplete** until I add `make` commands to run the script and update the include file (following the same pattern as the advanced parameters docs do) so please don't merge.


