### PR TITLE
Update Redis ACL documentation link

### DIFF
--- a/docs/products/redis/howto/configure-acl-permissions.rst
+++ b/docs/products/redis/howto/configure-acl-permissions.rst
@@ -3,7 +3,7 @@ Configure ACL permissions in Aiven for Redis™*
 
 Use the Aiven console or the Aiven client to create custom Access Control Lists (ACLs). 
 
-Redis™* uses `ACLs <https://redis.io/topics/acl>`_ to restrict the usage of commands and keys available for connecting for a specific username and password. Aiven for Redis™*, however, does not allow use of the  `ACL * <https://redis.io/commands/acl-list>`_ commands directly in order to guarantee the reliability of replication, configuration management, or backups for disaster recovery for the default user. You can use the console or the client to create custom ACLs instead.
+Redis™* uses `ACLs <https://redis.io/docs/manual/security/acl/>`_ to restrict the usage of commands and keys available for connecting for a specific username and password. Aiven for Redis™*, however, does not allow use of the  `ACL * <https://redis.io/commands/acl-list>`_ commands directly in order to guarantee the reliability of replication, configuration management, or backups for disaster recovery for the default user. You can use the console or the client to create custom ACLs instead.
 
 
 Create an ACL using the Aiven console


### PR DESCRIPTION
Updated Redis ACL documentation link to the new one.  Redis has changed its documentation link causing a 404, which makes link check fail for new PRs.
