### PR TITLE
Add ``--disk-space-gib`` as option for ``avn service create``

### DIFF
--- a/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
+++ b/docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters.rst
@@ -40,7 +40,7 @@ By default, data is stored in one record per line in S3 in CSV format.
 
 .. Tip::
 
-    You can change the output data format to JSON or `Parquet <https://parquet.apache.org/documentation/latest/>`_ by setting the ``format.output.type``. More details can be found in the `GitHub connector repository documentation <https://github.com/aiven/aiven-kafka-connect-s3>`_
+    You can change the output data format to JSON or `Parquet <https://parquet.apache.org/docs/>`_ by setting the ``format.output.type``. More details can be found in the `GitHub connector repository documentation <https://github.com/aiven/aiven-kafka-connect-s3>`_
 
 You can define the output data fields with the ``format.output.fields`` connector configuration. The message key and value, if included in the output, are encoded in ``Base64``. 
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -97,7 +97,7 @@ Creates a new service.
   * - ``--cloud``
     - The cloud region name; check :ref:`avn-cloud-list` for more information
   * - ``--disk-space-gib``
-    - Extra amount of disk space for data storage (GiB)
+    - Total amount of disk space for data storage (GiB)
   * - ``--no-fail-if-exists``
     - The create command will not fail if a service with the same name already exists
   * - ``--project-vpc-id``
@@ -113,7 +113,7 @@ Creates a new service.
 
 * the ``business-4`` plan 
 * Kafka Connect enabled
-* 600 GiB of additional storage capacity
+* 600 GiB of total storage capacity
 
 ::
   
@@ -605,7 +605,7 @@ Updates the settings for an Aiven service.
   * - ``--cloud``
     - The name of the cloud region where to deploy the service; check :ref:`avn-cloud-list` for more information
   * - ``--disk-space-gib``
-    - Extra amount of disk space for data storage (GiB)
+    - Total amount of disk space for data storage (GiB)
   * - ``--plan``
     - Aiven subscription plan name; check :ref:`avn_service_plan` for more information
   * - ``--power-on``

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -96,6 +96,8 @@ Creates a new service.
     - Aiven subscription plan name; check :ref:`avn_service_plan` for more information
   * - ``--cloud``
     - The cloud region name; check :ref:`avn-cloud-list` for more information
+  * - ``--disk-space-gib``
+    - Extra amount of disk space for data storage (GiB)
   * - ``--no-fail-if-exists``
     - The create command will not fail if a service with the same name already exists
   * - ``--project-vpc-id``
@@ -107,7 +109,11 @@ Creates a new service.
   * - ``-c KEY=VALUE``
     - Any additional configuration settings for your service; check our documentation for more information, or use the :ref:`service types command <avn-cli-service-type>` which has a verbose mode that shows all options.
 
-**Example:** Create a new Aiven for Kafka® service named ``kafka-demo`` in the region ``google-europe-west3`` with the plan ``business-4`` and enable Kafka Connect.
+**Example:** Create a new Aiven for Kafka® service named ``kafka-demo`` in the region ``google-europe-west3`` with: 
+
+* the ``business-4`` plan 
+* Kafka Connect enabled
+* 600 GiB of additional storage capacity
 
 ::
   
@@ -115,7 +121,8 @@ Creates a new service.
     --service-type kafka                    \
     --cloud google-europe-west3             \
     --plan business-4                       \
-    -c kafka_connect=true                   
+    -c kafka_connect=true                   \
+    --disk-space-gib 600              
 
 ``avn service credentials-reset``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -598,7 +605,7 @@ Updates the settings for an Aiven service.
   * - ``--cloud``
     - The name of the cloud region where to deploy the service; check :ref:`avn-cloud-list` for more information
   * - ``--disk-space-gib``
-    - Amount of disk space for data storage (GiB)
+    - Extra amount of disk space for data storage (GiB)
   * - ``--plan``
     - Aiven subscription plan name; check :ref:`avn_service_plan` for more information
   * - ``--power-on``


### PR DESCRIPTION
# What changed, and why it matters
Adding the missing `--disk-space-gib` option for `avn service create`
Fix #670 
