### PR TITLE
Datasource integration between two PG services

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -247,6 +247,7 @@ entries:
               - file: docs/products/postgresql/howto/visualize-grafana
               - file: docs/products/postgresql/howto/report-metrics-grafana
               - file: docs/products/postgresql/howto/monitor-with-pgwatch2
+              - file: docs/products/postgresql/howto/datasource-integration
       - file: docs/products/postgresql/reference
         title: Reference
         entries:

--- a/docs/products/postgresql/howto/datasource-integration.rst
+++ b/docs/products/postgresql/howto/datasource-integration.rst
@@ -1,7 +1,7 @@
 Connect two PostgreSQL services
 ===============================
 
-There are 2 types of datasource integrations you can use with Aiven for PostgreSQL®: `Aiven for Grafana® <visualize-grafana>`_, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to `query across them <use-dblink-extension>`_, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
+There are 2 types of datasource integrations you can use with Aiven for PostgreSQL®: :doc:`Aiven for Grafana® <visualize-grafana>`, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to :doc:`query across them <use-dblink-extension>`, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
 
 Whenever a service node needs to be recycled, e.g. for maintenance, a new node is created with a new IP address.  As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ``Datasource`` service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.
 

--- a/docs/products/postgresql/howto/datasource-integration.rst
+++ b/docs/products/postgresql/howto/datasource-integration.rst
@@ -1,0 +1,16 @@
+Connect two PostgreSQL services
+===============================
+
+There are 2 types of datasource integrations you can use with Aiven for PostgreSQL®: `Aiven for Grafana® <visualize-grafana>`_, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to `query across them <use-dblink-extension>`_, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
+
+Whenever a service node needs to be recycled, e.g. for maintenance, a new node is created with a new IP address.  As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ``Datasource`` service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.
+
+Integrate two PostgreSQL services
+---------------------------------
+
+1. On the service overview page for your PostgreSQL service, go to **Manage Integrations** and choose the **datasource** option.
+
+2. Choose either a new or existing PostgreSQL service.
+
+Now your PostgreSQL will allow IP traffic from the chosen PostgreSQL service, regardless of what its IP address is.
+

--- a/docs/products/postgresql/howto/datasource-integration.rst
+++ b/docs/products/postgresql/howto/datasource-integration.rst
@@ -1,7 +1,7 @@
-Connect two PostgreSQL services
-===============================
+Connect two PostgreSQL services via datasource integration
+==========================================================
 
-There are 2 types of datasource integrations you can use with Aiven for PostgreSQL®: :doc:`Aiven for Grafana® <visualize-grafana>`, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to :doc:`query across them <use-dblink-extension>`, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
+There are two types of datasource integrations you can use with Aiven for PostgreSQL®: :doc:`Aiven for Grafana® <visualize-grafana>`, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to :doc:`query across them <use-dblink-extension>`, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
 
 Whenever a service node needs to be recycled, e.g. for maintenance, a new node is created with a new IP address.  As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ``Datasource`` service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.
 


### PR DESCRIPTION
# What changed, and why it matters

Added a short doc explaining what the "PostgreSQL" option does under the "datasource" integration type when selected on a PG service.

I'm not wild about the title of the doc, feel free to change it if you can think of something better.
