### PR TITLE
Second TF recipe - multicloud PG

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -75,6 +75,8 @@ entries:
             entries:
             - file: docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe
               title: Apache Kafka and OpenSearch
+            - file: docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe
+              title: Multicloud PostgreSQL 
       - file: docs/tools/kubernetes
         title: Aiven Operator for Kubernetes
 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -43,7 +43,8 @@ Add the following to a new ``provider.tf`` file:
       api_token = var.aiven_api_token
    }
 
-
+You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+ 
 2.  The following Terraform script deploys a single-node Redis service. This is a minimal example which you can swap out with your own Terraform scripts or other advanced recipes from :doc:`the Terraform cookbook <reference/cookbook>`.
 
 The contents of the ``redis.tf`` file should look like this:

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -1,0 +1,71 @@
+Deploy PostgreSQL® services to multiple clouds and regions
+==========================================================
+
+There are many reasons why businesses need to distribute their databases geographically. One of the primary reason is data residency/regulation which mandates user data to stay within certain regions. 
+This example shows a use case where a sysadmin needs to setup three highly-available PostgreSQL databases in three regions and across different cloud providers for data regulation and compliance.
+In addition, these databases must be configured in a way that they are protected against database deletion. `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ can help create multiple services programmatically. 
+
+The following image shows that the Aiven Terraform Provider calls the Aiven API under the hood to create three PostgreSQL services on AWS (Europe), DigitalOcean (US), and Google Cloud Platform(Asia):
+
+.. mermaid::
+
+   graph LR
+      A[Aiven Terraform Provider]
+      A --> B[(AWS EU)]
+      A --> C[(DO US)]
+      A --> D[(GCP Asia)]
+
+Describe the setup
+------------------
+
+Here is the sample Terraform file to deploy all three services. Keep in mind that some parameters and configurations will vary for your case. A reference to some of the advanced PostgreSQL configurations is added at the end of this document.
+
+``services.tf`` file:
+
+.. code:: bash
+
+   # European Postgres Service
+   resource "aiven_pg" "aws-eu-pg" {
+   project      = var.project_name
+   cloud_name   = "aws-eu-west-2" # London
+   plan         = "business-8"    # Primary + read replica
+   service_name = "postgres-eu-aws"
+   termination_protection = true
+   }
+
+   # US Postgres Service
+   resource "aiven_pg" "do-us-pg" {
+   project      = var.project_name
+   cloud_name   = "do-nyc"     # New York
+   plan         = "business-8" # Primary + read replica
+   service_name = "postgres-us-do"
+   termination_protection = true
+   }
+
+   # Asia Postgres Service
+   resource "aiven_pg" "gcp-as-pg" {
+   project      = var.project_name
+   cloud_name   = "google-asia-southeast1" # Singapore
+   plan         = "business-8"             # Primary + read replica
+   service_name = "postgres-as-gcp"
+   termination_protection = true
+   }
+
+This file creates three Aiven for PostgreSQL services across three cloud providers and in three different regions. The ``termination_protection = true`` property ensures that these databases are protected against accidental or unauthorized deletion.
+
+With termination protection enabled, a ``terraform destroy`` command will result in the following error message:
+
+.. code:: bash
+
+   Error: 403: {"errors":[{"message":"Service is protected against termination and shutdown. Remove termination protection first.","status":403}],"message":"Service is protected against termination and shutdown. Remove termination protection first."}
+
+To proceed, you need to update the script with ``termination_protection = false`` and then execute a ``terraform apply`` followed by a ``terraform destroy``.
+
+More resources
+--------------
+
+You might find these related resources useful too:
+
+- `Configuration options for PostgreSQL <https://developer.aiven.io/docs/products/postgresql/reference/list-of-advanced-params.html>`_
+
+

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -9,11 +9,10 @@ The following image shows that the Aiven Terraform Provider calls the Aiven API 
 
 .. mermaid::
 
-   graph LR
-      A[Terraform Script]
-      A --> B[(Aiven for PostgreSQL - AWS EU)]
-      A --> C[(Aiven for PostgreSQL - DigitalOcean NA)]
-      A --> D[(Aiven for PostgreSQL - GCP Asia)]
+   graph TD
+      B[(Aiven for PostgreSQL - AWS EU)]
+      C[(Aiven for PostgreSQL - DigitalOcean NA)]
+      D[(Aiven for PostgreSQL - GCP Asia)]
 
 Describe the setup
 ------------------

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -64,4 +64,4 @@ You might find these related resources useful too:
 
 - `Configuration options for PostgreSQL <https://developer.aiven.io/docs/products/postgresql/reference/list-of-advanced-params.html>`_
 - `Set up your first Aiven Terraform project <https://developer.aiven.io/docs/tools/terraform/get-started.html>`_
-- `Benefits and challenges of multicloud <https://aiven.io/blog/getting-the-most-of-multi-cloud>`_
+- `Benefits and challenges of multi-cloud <https://aiven.io/blog/getting-the-most-of-multi-cloud>`_

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -10,10 +10,10 @@ The following image shows that the Aiven Terraform Provider calls the Aiven API 
 .. mermaid::
 
    graph LR
-      A[Aiven Terraform Provider]
-      A --> B[(AWS EU)]
-      A --> C[(DO US)]
-      A --> D[(GCP Asia)]
+      A[Terraform Script]
+      A --> B[(Aiven for PostgreSQL - AWS EU)]
+      A --> C[(Aiven for PostgreSQL - DigitalOcean NA)]
+      A --> D[(Aiven for PostgreSQL - GCP Asia)]
 
 Describe the setup
 ------------------
@@ -26,40 +26,36 @@ Here is the sample Terraform file to deploy all three services. Keep in mind tha
 
    # European Postgres Service
    resource "aiven_pg" "aws-eu-pg" {
-   project      = var.project_name
-   cloud_name   = "aws-eu-west-2" # London
-   plan         = "business-8"    # Primary + read replica
-   service_name = "postgres-eu-aws"
-   termination_protection = true
+     project      = var.project_name
+     cloud_name   = "aws-eu-west-2" # London
+     plan         = "business-8"    # Primary + read replica
+     service_name = "postgres-eu-aws"
+     termination_protection = true
    }
 
    # US Postgres Service
    resource "aiven_pg" "do-us-pg" {
-   project      = var.project_name
-   cloud_name   = "do-nyc"     # New York
-   plan         = "business-8" # Primary + read replica
-   service_name = "postgres-us-do"
-   termination_protection = true
+     project      = var.project_name
+     cloud_name   = "do-nyc"     # New York
+     plan         = "business-8" # Primary + read replica
+     service_name = "postgres-us-do"
+     termination_protection = true
    }
 
    # Asia Postgres Service
    resource "aiven_pg" "gcp-as-pg" {
-   project      = var.project_name
-   cloud_name   = "google-asia-southeast1" # Singapore
-   plan         = "business-8"             # Primary + read replica
-   service_name = "postgres-as-gcp"
-   termination_protection = true
+     project      = var.project_name
+     cloud_name   = "google-asia-southeast1" # Singapore
+     plan         = "business-8"             # Primary + read replica
+     service_name = "postgres-as-gcp"
+     termination_protection = true
    }
 
 This file creates three Aiven for PostgreSQL services across three cloud providers and in three different regions. The ``termination_protection = true`` property ensures that these databases are protected against accidental or unauthorized deletion.
 
-With termination protection enabled, a ``terraform destroy`` command will result in the following error message:
+With termination protection enabled, a ``terraform destroy`` command will result in a 403 response and an error message "Service is protected against termination and shutdown. Remove termination protection first.".
 
-.. code:: bash
-
-   Error: 403: {"errors":[{"message":"Service is protected against termination and shutdown. Remove termination protection first.","status":403}],"message":"Service is protected against termination and shutdown. Remove termination protection first."}
-
-To proceed, you need to update the script with ``termination_protection = false`` and then execute a ``terraform apply`` followed by a ``terraform destroy``.
+To destroy resources with termination protection, you need to update the script with ``termination_protection = false`` and then execute a ``terraform apply`` followed by a ``terraform destroy``.
 
 More resources
 --------------
@@ -67,5 +63,5 @@ More resources
 You might find these related resources useful too:
 
 - `Configuration options for PostgreSQL <https://developer.aiven.io/docs/products/postgresql/reference/list-of-advanced-params.html>`_
-
-
+- `Set up your first Aiven Terraform project <https://developer.aiven.io/docs/tools/terraform/get-started.html>`_
+- `Benefits and challenges of multicloud <https://aiven.io/blog/getting-the-most-of-multi-cloud>`_

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -2,8 +2,8 @@ Deploy PostgreSQL® services to multiple clouds and regions
 ==========================================================
 
 There are many reasons why businesses need to distribute their databases geographically. One of the primary reason is data residency/regulation which mandates user data to stay within certain regions. 
-This example shows a use case where a sysadmin needs to setup three highly-available PostgreSQL databases in three regions and across different cloud providers for data regulation and compliance.
-In addition, these databases must be configured in a way that they are protected against database deletion. `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ can help create multiple services programmatically. 
+This example shows how to set up three highly-available PostgreSQL databases in three regions and across different cloud providers for data regulation and compliance. In addition, these databases must be configured in a way that they are protected against database deletion.
+`Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ can help create multiple services programmatically. 
 
 The following image shows that the Aiven Terraform Provider calls the Aiven API under the hood to create three PostgreSQL services on AWS (Europe), DigitalOcean (US), and Google Cloud Platform(Asia):
 


### PR DESCRIPTION
# What changed, and why it matters

1. Adding the second Terraform recipe as part of https://github.com/aiven/devportal/issues/559

This recipe creates three highly available Postgres services across clouds/regions.

2. Adding an option to include Aiven API token as an env variable as part of the getting started guide.