### PR TITLE
Enable misspelling words to return relevant results

### DIFF
--- a/netlify/functions/search/search.js
+++ b/netlify/functions/search/search.js
@@ -42,6 +42,14 @@ const handler = async (event) => {
                 },
               },
               {
+                match: {
+                  title: {
+                    query: query,
+                    fuzziness: "AUTO"
+                  },
+                },
+              },
+              {
                 match_phrase_prefix: {
                   description: {
                     query: query,


### PR DESCRIPTION
Fixes: #686 

Test:
<img width="1470" alt="Screenshot 2022-03-29 at 20 43 45" src="https://user-images.githubusercontent.com/36624597/160683772-6b6a1a73-bad1-41ab-8953-97ccde9699d9.png">
