### PR TITLE
sitemap.xml links should not include `/en`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,6 +61,12 @@ gitstamp_fmt = "%B %Y"
 
 # sitemap config
 html_baseurl = 'https://developer.aiven.io'
+# Since we have `language='en'` set (further down) the URLs in the sitemap will
+# default to "{version}{lang}{link}", producing things like
+#    <url><loc>https://developer.aiven.io/en/docs/platform/howto/create_authentication_token.html</loc></url>
+# That doesn't work because we do not produce pages with the `/en` in the URL.
+# We need to be explicit that we don't want {version} or {language} in the URLs
+sitemap_url_scheme = "{link}"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Tell the sitemap extension not to put the language (`/en`) into the URLs in the `sitemap.xml` file

**Before** looks like https://developer.aiven.io/sitemap.xml, with instance, entries like:
```
<url>
<loc>https://developer.aiven.io/en/docs/community.html</loc>
</url>
```
(there's no such page)

**After** loses the `/en` and looks like https://deploy-preview-693--developer-aiven-io-preview.netlify.app/sitemap.xml, with entries like:
```
<url>
<loc>https://developer.aiven.io/docs/community.html</loc>
</url>
```
which is a page that exists.

Fix https://github.com/aiven/devportal/issues/692


