### PR TITLE
Migrate article about opensearch replication factors

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -410,6 +410,7 @@ entries:
             title: Plugins
           - file: docs/products/opensearch/reference/advanced-params
             title: Advanced parameters
+          - file: docs/products/opensearch/reference/index-replication
 
   - file: docs/products/m3db/index
     title: M3DB

--- a/docs/products/opensearch/reference/index-replication.rst
+++ b/docs/products/opensearch/reference/index-replication.rst
@@ -1,7 +1,7 @@
 Automatic adjustment of replication factors
 ===========================================
 
-Aiven for OpenSearch automatically adjusts index replication factors
+Aiven for OpenSearch® automatically adjusts index replication factors
 to ensure data availability and service functionality.
 
 When is the replication factor automatically adjusted?

--- a/docs/products/opensearch/reference/index-replication.rst
+++ b/docs/products/opensearch/reference/index-replication.rst
@@ -4,33 +4,13 @@ Automatic adjustment of replication factors
 Aiven for OpenSearch automatically adjusts index replication factors
 to ensure data availability and service functionality.
 
-When replication factor is automatically adjusted?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When is the replication factor automatically adjusted?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  If ``number_of_replicas`` is too large for current cluster size, it
-   is automatically lowered to maximum possible value (number of nodes
-   on the cluster - 1).
+The maximum value for ``number_of_replicas`` is the number of nodes in the cluster - 1, as it is not possible to replicate indexes (shards) to a larger number of nodes than exist on the cluster
 
--  If ``number_of_replicas`` is 0 on a multi-node cluster, it is
-   automatically increased to 1.
+For example, for a 3-node cluster, the maximum ``number_of_replicas`` is 2, which means all shards on the index are replicated to all 3 nodes.
 
--  If ``number_of_replicas`` is anywhere between 1 and maximum value, it
-   is not automatically adjusted.
-
-Lowering replication factor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When replication factor ( ``number_of_replicas`` ) is set to larger than
-size of the cluster, ``number_of_replicas`` is automatically lowered, as
-it is not possible to replicate indexes (shards) to a larger number of
-nodes than what exists on the cluster. Do note number replication factor
-is ``number_of_replicas`` + 1. For example, for three-node cluster,
-maximum ``number_of_replicas`` is 2, which means all shards on the index
-are replicated to all three nodes.
-
-Increasing replication factor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For multi-node clusters, Aiven for OpenSearch automatically increases
-``number_of_replicas`` to 1, if it is set to 0. This is to ensure no
+If ``number_of_replicas`` is set to 0 in a multi-node cluster, it is
+   automatically increased to 1 to ensure no
 data-loss occurs if one node is lost.

--- a/docs/products/opensearch/reference/index-replication.rst
+++ b/docs/products/opensearch/reference/index-replication.rst
@@ -1,0 +1,36 @@
+Automatic adjustment of replication factors
+===========================================
+
+Aiven for OpenSearch automatically adjusts index replication factors
+to ensure data availability and service functionality.
+
+When replication factor is automatically adjusted?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  If ``number_of_replicas`` is too large for current cluster size, it
+   is automatically lowered to maximum possible value (number of nodes
+   on the cluster - 1).
+
+-  If ``number_of_replicas`` is 0 on a multi-node cluster, it is
+   automatically increased to 1.
+
+-  If ``number_of_replicas`` is anywhere between 1 and maximum value, it
+   is not automatically adjusted.
+
+Lowering replication factor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When replication factor ( ``number_of_replicas`` ) is set to larger than
+size of the cluster, ``number_of_replicas`` is automatically lowered, as
+it is not possible to replicate indexes (shards) to a larger number of
+nodes than what exists on the cluster. Do note number replication factor
+is ``number_of_replicas`` + 1. For example, for three-node cluster,
+maximum ``number_of_replicas`` is 2, which means all shards on the index
+are replicated to all three nodes.
+
+Increasing replication factor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For multi-node clusters, Aiven for OpenSearch automatically increases
+``number_of_replicas`` to 1, if it is set to 0. This is to ensure no
+data-loss occurs if one node is lost.

--- a/docs/products/opensearch/reference/index-replication.rst
+++ b/docs/products/opensearch/reference/index-replication.rst
@@ -11,6 +11,4 @@ The maximum value for ``number_of_replicas`` is the number of nodes in the clust
 
 For example, for a 3-node cluster, the maximum ``number_of_replicas`` is 2, which means all shards on the index are replicated to all 3 nodes.
 
-If ``number_of_replicas`` is set to 0 in a multi-node cluster, it is
-   automatically increased to 1 to ensure no
-data-loss occurs if one node is lost.
+If ``number_of_replicas`` is set to 0 in a multi-node cluster, it is automatically increased to 1 to ensure no data-loss occurs if one node is lost.


### PR DESCRIPTION
# What changed, and why it matters

Migration of https://help.aiven.io/en/articles/2342117-automatic-adjustment-of-elasticsearch-index-replication-factors

Note, advanced property disable_replication_factor_adjustment is deprecated and in dev-sandbox / dev-advocates no longer available. That's why I excluded the part where we recommend setting this value. 

