### PR TITLE
Remove reference to PostgreSQL extension `file_fdw`

### DIFF
--- a/docs/products/postgresql/reference/list-of-extensions.rst
+++ b/docs/products/postgresql/reference/list-of-extensions.rst
@@ -160,9 +160,6 @@ Connectivity
 ``dblink`` - https://www.postgresql.org/docs/current/contrib-dblink-function.html
     Connect to other PostgreSQL databases from within a database.
 
-``file_fdw`` - https://www.postgresql.org/docs/current/file-fdw.html
-    Foreign-data wrapper for flat file access.
-
 ``postgres_fdw`` - https://www.postgresql.org/docs/current/postgres-fdw.html
     Foreign-data wrapper for remote PostgreSQL servers.
 


### PR DESCRIPTION
Remove reference to PostgreSQL extension `file_fdw` in the list of PostgreSQL extensions

It's questionable whether a user can actually make use of this extension, and using it has security implications. Remove the description so users don't expect it to be supported.

Fix: https://github.com/aiven/devportal/issues/705


