### PR TITLE
Revert "Change database fork to service fork to provide better relevant search and navigation experience"

### DIFF
--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -16,9 +16,9 @@ Learn about some of the key concepts for working with Aiven platform:
   Learn about Aiven's access control, encryption, network security, data privacy and operator access.
 
 
-* :doc:`Service forking </docs/platform/concepts/service-forking>`.
+* :doc:`Database forking </docs/platform/concepts/database-forking>`.
 
-  Quickly and safely make a copy of your database or other service for testing, dry run upgrades, or anything else, without affecting your existing service.
+  Quickly and safely make a copy of your database for testing, dry run upgrades, or anything else, without affecting your existing service.
 
 * :doc:`Projects and access management </docs/platform/concepts/projects_accounts_access>`.
 

--- a/docs/platform/concepts/database-forking.rst
+++ b/docs/platform/concepts/database-forking.rst
@@ -1,7 +1,7 @@
-Service forking
+Database forking
 ================
 
-:doc:`Fork your Aiven service </docs/platform/howto/console-fork-service>` in order to make a copy of the service. You can use it to create a development copy of your production environment, set up a snapshot to analyze an issue or test an upgrade, or create an instance in a different cloud/geographical location/under a different plan.
+Fork your Aiven service in order to make a copy of the database. You can use it to create a development copy of your production environment, set up a snapshot to analyze an issue or test an upgrade, or create an instance in a different cloud/geographical location/under a different plan.
 
 When you fork a service, the following items are copied into the new service:
 

--- a/docs/platform/howto/console-fork-service.rst
+++ b/docs/platform/howto/console-fork-service.rst
@@ -1,9 +1,9 @@
-Fork your service
+Fork your database
 ==================
 
-Fork your Aiven service in order to make a copy of the service. You can use it to create a development copy of your production environment, set up a snapshot to analyze an issue or test an upgrade, or create an instance in a different cloud/geographical location/under a different plan.
+Fork your Aiven service in order to make a copy of the database. You can use it to create a development copy of your production environment, set up a snapshot to analyze an issue or test an upgrade, or create an instance in a different cloud/geographical location/under a different plan.
 
-Learn more :doc:`about service forking <../concepts/service-forking>`.
+Learn more :doc:`about database forking <../concepts/database-forking>`.
 
 Fork a service using the console
 --------------------------------

--- a/docs/products/opensearch/howto/upgrade-to-opensearch.rst
+++ b/docs/products/opensearch/howto/upgrade-to-opensearch.rst
@@ -8,7 +8,7 @@ For current Aiven for Elasticsearch customers, we recommend you upgrade as soon 
 
 There are three approaches that you can use to upgrade an existing service:
 
-* Create a :doc:`fork </docs/platform/concepts/service-forking>` of Aiven for OpenSearch from your existing Aiven for Elasticsearch service. This is a good way to get a fast preview of how Aiven for OpenSearch will work for you.
+* Create a :doc:`fork </docs/platform/concepts/database-forking>` of Aiven for OpenSearch from your existing Aiven for Elasticsearch service. This is a good way to get a fast preview of how Aiven for OpenSearch will work for you.
 * Create a fork of Aiven for Elasticsearch from your existing Aiven for Elasticsearch service. This gives you the opportunity to test the process of upgrading an existing Elasticsearch service to OpenSearch without experimenting on your live database.
 * Upgrade from Aiven for Elasticsearch to Aiven for OpenSearch to move either a test or production database to the upgraded state.
 


### PR DESCRIPTION
Reverts aiven/devportal#702

@ftisiot pointed out that external resources might still be linking to https://developer.aiven.io/docs/platform/howto/console-fork-database.html, which the original PR changed to https://developer.aiven.io/docs/platform/howto/console-fork-service.html

Reverting to consider how to do this better.