### PR TITLE
main content link color update to red

### DIFF
--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -79,6 +79,10 @@ a:hover {
   text-decoration-color: var(--linkActive) !important;
 }
 
+main > .content p:not(.card-text) a:not(.btn) {
+  color: var(--linkActive) !important;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: var(--bgDark);
@@ -98,6 +102,10 @@ a:hover {
   a {
     color: var(--linkDark) !important;
     font-family: Inter;
+  }
+
+  main > .content p:not(.card-text) a:not(.btn) {
+    color: var(--linkDark) !important;
   }
 
   .sidebar-drawer {


### PR DESCRIPTION
# What changed, and why it matters
Related to [Issue 347](https://github.com/aiven/devportal/issues/347), update main content paragraph text link color to the same red as hover style. [Preview](https://deploy-preview-719--developer-aiven-io-preview.netlify.app/) 


