### PR TITLE
Tidy up titles, both on pages and in navigation

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -90,7 +90,9 @@ entries:
     title: Apache Kafka
     entries:
       - file: docs/products/kafka/getting-started
+        title: Get started
       - file: docs/products/kafka/howto/fake-sample-data
+        title: Sample data generator
       - file: docs/products/kafka/concepts
         entries:
           - file: docs/products/kafka/concepts/acl
@@ -144,7 +146,11 @@ entries:
       - file: docs/products/kafka/reference
         title: Reference
         entries:
-          - glob: docs/products/kafka/reference/*
+          - file: docs/products/kafka/reference/advanced-params
+            title: Advanced parameters
+          - file: docs/products/kafka/reference/kafka-metrics-prometheus
+            title: Metrics available via Prometheus
+
       - file: docs/products/kafka/kafka-connect/index
         title: Apache Kafka Connect
         entries:
@@ -193,6 +199,7 @@ entries:
               - file: docs/products/kafka/kafka-connect/reference/s3-sink-additional-parameters-confluent
             - file: docs/products/kafka/kafka-connect/reference/gcs-sink-formats
             - file: docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus
+              title: Metrics available via Prometheus
 
       - file: docs/products/kafka/kafka-mirrormaker/index
         title: Apache Kafka MirrorMaker2
@@ -217,7 +224,9 @@ entries:
     title: PostgreSQL
     entries:
       - file: docs/products/postgresql/getting-started
+        title: Get started
       - file: docs/products/postgresql/howto/pagila
+        title: "Sample dataset: Pagila"
       - file: docs/products/postgresql/concepts
         title: Concepts
         entries:
@@ -265,12 +274,24 @@ entries:
       - file: docs/products/postgresql/reference
         title: Reference
         entries:
-          - glob: docs/products/postgresql/reference/*
+          - file: docs/products/postgresql/reference/list-of-advanced-params
+            title: Advanced parameters
+          - file: docs/products/postgresql/reference/list-of-extensions
+            title: Extensions
+          - file: docs/products/postgresql/reference/pg-metrics
+            title: Metrics exposed to Grafana
+          - file: docs/products/postgresql/reference/pg-connection-limits
+            title: Connection limits per plan
+          - file: docs/products/postgresql/reference/resource-capability
+            title: Resource capability per plan
+          - file: docs/products/postgresql/reference/terminology
+            title: Terminology
 
   - file: docs/products/flink/index
     title: Apache Flink
     entries:
       - file: docs/products/flink/getting-started
+        title: Get started
       - file: docs/products/flink/concepts
         title: Concepts
         entries:
@@ -297,12 +318,14 @@ entries:
       - file: docs/products/flink/reference
         title: Reference
         entries:
-          - glob: docs/products/flink/reference/*
+          - file: docs/products/flink/reference/advanced-params
+            title: Advanced parameters
 
   - file: docs/products/clickhouse/index
     title: ClickHouse
     entries:
       - file: docs/products/clickhouse/getting-started
+        title: Get started
       - file: docs/products/clickhouse/sample-dataset
       - file: docs/products/clickhouse/concepts
         title: Concepts
@@ -322,13 +345,14 @@ entries:
       - file: docs/products/clickhouse/reference
         title: Reference
         entries:
-          - glob: docs/products/clickhouse/reference/*
+          - file: docs/products/clickhouse/reference/supported-table-engines
+            title: Supported table engines
 
   - file: docs/products/opensearch/index
     title: OpenSearch
     entries:
       - file: docs/products/opensearch/getting-started
-        title: Getting started
+        title: Get started
       - file: docs/products/opensearch/howto/sample-dataset
       - file: docs/products/opensearch/concepts
         title: Concepts
@@ -371,12 +395,13 @@ entries:
           - file: docs/products/opensearch/reference/plugins
             title: Plugins
           - file: docs/products/opensearch/reference/advanced-params
-            title: Advanced Parameters
+            title: Advanced parameters
 
   - file: docs/products/m3db/index
     title: M3DB
     entries:
       - file: docs/products/m3db/getting-started
+        title: Get started
       - file: docs/products/m3db/concepts
         title: Concepts
         entries:
@@ -388,12 +413,16 @@ entries:
       - file: docs/products/m3db/reference
         title: Reference
         entries:
-          - glob: docs/products/m3db/reference/*
+          - file: docs/products/m3db/reference/terminology
+            title: Terminology
+          - file: docs/products/m3db/reference/advanced-params
+            title: Advanced parameters
 
   - file: docs/products/mysql/index
     title: MySQL
     entries:
       - file: docs/products/mysql/get-started
+        title: Get started
       - file: docs/products/mysql/howto
         title: HowTo
         entries:
@@ -401,13 +430,17 @@ entries:
       - file: docs/products/mysql/reference
         title: Reference
         entries:
-          - glob: docs/products/mysql/reference/*
+          - file: docs/products/mysql/reference/advanced-params
+            title: Advanced parameters
+          - file: docs/products/mysql/reference/resource-capability
+            title: Resource capability per plan
+
 
   - file: docs/products/redis/index
     title: Redis
     entries:
       - file: docs/products/redis/get-started
-        title: Getting started
+        title: Get started
       - file: docs/products/redis/concepts
         title: Concepts
         entries:
@@ -433,7 +466,8 @@ entries:
       - file: docs/products/redis/reference
         title: Reference
         entries:
-          - glob: docs/products/redis/reference/*
+          - file: docs/products/redis/reference/advanced-params
+            title: Advanced parameters
 
   - file: docs/products/cassandra/index
     title: Apache Cassandra
@@ -442,6 +476,7 @@ entries:
     title: Grafana
     entries:
       - file: docs/products/grafana/get-started
+        title: Get started
       - file: docs/products/grafana/howto
         title: HowTo
         entries:
@@ -449,7 +484,10 @@ entries:
       - file: docs/products/grafana/reference
         title: Reference
         entries:
-          - glob: docs/products/grafana/reference/*
+          - file: docs/products/grafana/reference/advanced-params
+            title: Advanced paramters
+          - file: docs/products/grafana/reference/plugins
+            title: Plugins
 
   # -------- AUXILIARY
   - file: docs/community

--- a/docs/products/clickhouse/getting-started.rst
+++ b/docs/products/clickhouse/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started
-===============
+Getting started with Aiven for ClickHouse®
+==========================================
 
 The first step in using Aiven for ClickHouse® is to create a service and a database that you can use to try out the service. You can do this in the `Aiven web console <https://console.aiven.io/>`_.
 

--- a/docs/products/clickhouse/reference/supported-table-engines.rst
+++ b/docs/products/clickhouse/reference/supported-table-engines.rst
@@ -1,5 +1,5 @@
-Supported table engines
-=======================
+Supported table engines in Aiven for ClickHouse®
+================================================
 
 This article lists the table engines that are currently supported in Aiven for ClickHouse®.
 

--- a/docs/products/flink/getting-started.rst
+++ b/docs/products/flink/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started
-===============
+Getting started with Aiven for Apache Flink®
+============================================
 
 The first step in using Aiven for Apache Flink® is to create a service. You can do this in the `Aiven web console <https://console.aiven.io/>`_ or with the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
 

--- a/docs/products/flink/reference/advanced-params.rst
+++ b/docs/products/flink/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for Apache Flink®
+===============================================
 
 Below you can find a summary of every configuration option available for Aiven for Apache Flink® service:
 

--- a/docs/products/grafana/reference/advanced-params.rst
+++ b/docs/products/grafana/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for Grafana®
+==========================================
 
 Below you can find a summary of every configuration option available for Aiven for Grafana® service:
 

--- a/docs/products/grafana/reference/plugins.rst
+++ b/docs/products/grafana/reference/plugins.rst
@@ -1,5 +1,5 @@
-List of available plugins
-=========================
+Plugins for Aiven for Grafana®
+==============================
 
 The following plugins are available in all installations of Aiven for Grafana®, and they are updated at intervals. To request additional plugins, please reach out to our support team at ``support@aiven.io``.
 

--- a/docs/products/kafka/getting-started.rst
+++ b/docs/products/kafka/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started
-===============
+Getting started with Aiven for Apache Kafka®
+============================================
 
 Aiven services are managed in the Aiven `web
 console <https://console.aiven.io/>`__ . When you first log in to the

--- a/docs/products/kafka/howto/fake-sample-data.rst
+++ b/docs/products/kafka/howto/fake-sample-data.rst
@@ -1,7 +1,7 @@
-Fake sample dataset
-===================
+Sample dataset generator for Aiven for Apache Kafka®
+====================================================
 
-Learning streaming is way more fun with data, so to get you started on your Apache Kafka® journey we help you create fake streaming data to a topic.
+Learning to work with streaming data is much more fun with data, so to get you started on your Apache Kafka® journey we help you create fake streaming data to a topic.
 
 .. Note::
 

--- a/docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus.rst
+++ b/docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus.rst
@@ -1,5 +1,5 @@
-List of metrics available via Prometheus integration
-==================================================================
+Metrics for Aiven for Apache Kafka® Connect available via Prometheus
+====================================================================
 
 Below you can find a summary of every metric available via Prometheus for an Aiven for Apache Kafka® Connect service. You can review the list of metrics available via Prometheus for the Aiven for Apache Kafka® service in the :doc:`dedicated document </docs/products/kafka/reference/kafka-metrics-prometheus>`.
 

--- a/docs/products/kafka/reference/advanced-params.rst
+++ b/docs/products/kafka/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for Apache Kafka®
+===============================================
 
 Below you can find a summary of every configuration option available for Aiven for Apache Kafka® service:
 

--- a/docs/products/kafka/reference/kafka-metrics-prometheus.rst
+++ b/docs/products/kafka/reference/kafka-metrics-prometheus.rst
@@ -1,5 +1,5 @@
-List of metrics available via Prometheus integration
-==================================================================
+Aiven for Apache Kafka® metrics available via Prometheus
+========================================================
 
 The following list only contains the most common metrics available via Prometheus for an Aiven for Apache Kafka® service.
 

--- a/docs/products/m3db/getting-started.rst
+++ b/docs/products/m3db/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started
-===============
+Getting started with Aiven for M3DB
+===================================
 
 There are two M3-related services available in the `Aiven console <https://console.aiven.io>`_. Get started with an **M3DB** service; this is the part that stores data.
 

--- a/docs/products/m3db/reference/advanced-params.rst
+++ b/docs/products/m3db/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for M3DB
+======================================
 
 Below you can find a summary of every configuration option available for Aiven for M3DB service:
 

--- a/docs/products/mysql/reference/advanced-params.rst
+++ b/docs/products/mysql/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for MySQL
+=======================================
 
 Below you can find a summary of every configuration option available for Aiven for MySQL service:
 

--- a/docs/products/mysql/reference/resource-capability.rst
+++ b/docs/products/mysql/reference/resource-capability.rst
@@ -1,5 +1,5 @@
-Resource capability of plans
-============================
+Resource capability of Aiven for MySQL® plans
+=============================================
 
 When creating or updating an Aiven service, the plan that you choose will drive the specific resources (CPU / memory / disk IOPS / etc) powering your service.  Aiven is a cloud data platform, so the underlying instance types are chosen appropriately for the type of service - elements like local NVMe SSDs, sufficient memory for the expected workloads, fast access to backup storage, ability to encrypt the disks, etc all contribute to the choice of which instance types to use on which cloud platforms.  In addition, particular instance types are sometimes not available in a specific cloud region.  There is no one-size-fits-all when it comes to choosing the optimal instance type, so Aiven takes all of these things into account to select the right instance type for a given service.
 

--- a/docs/products/opensearch/reference/advanced-params.rst
+++ b/docs/products/opensearch/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for OpenSearch®
+=============================================
 
 Below you can find a summary of every configuration option available for Aiven for OpenSearch® service:
 

--- a/docs/products/postgresql/getting-started.rst
+++ b/docs/products/postgresql/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started
-===============
+Getting started with Aiven for PostgreSQL®
+==========================================
 
 Aiven for PostgreSQL® is available in the `Aiven console <https://console.aiven.io>`_.
 

--- a/docs/products/postgresql/howto/pagila.rst
+++ b/docs/products/postgresql/howto/pagila.rst
@@ -1,5 +1,5 @@
-Sample dataset: Pagila
-======================
+Sample dataset for PostgreSQL®: Pagila
+======================================
 
 Aiven provides a sample database you can import in your Aiven for PostgreSQL® service. This page covers information about the database and the procedure to get it up and running.
 

--- a/docs/products/postgresql/reference/list-of-advanced-params.rst
+++ b/docs/products/postgresql/reference/list-of-advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for PostgreSQL®
+=============================================
 
 On creating a PostgreSQL® database, you can customize it using a series of the following advanced parameters:
 

--- a/docs/products/postgresql/reference/list-of-extensions.rst
+++ b/docs/products/postgresql/reference/list-of-extensions.rst
@@ -1,5 +1,5 @@
-List of available extensions
-============================
+Extensions on Aiven for PostgreSQL®
+===================================
 
 The following PostgreSQL® extensions are available. Please note that some of the extensions have dependencies and they need to be created in the proper order. Some extensions may require disconnecting the client connection and reconnecting before they are fully available.  To check the details, including the version number of the extension, run ``select * from pg_available_extensions`` in your Aiven for PostgreSQL server.
 

--- a/docs/products/postgresql/reference/pg-connection-limits.rst
+++ b/docs/products/postgresql/reference/pg-connection-limits.rst
@@ -1,5 +1,5 @@
-Connection limits per plan
-=====================================
+Connection limits per plan for Aiven for PostgreSQL®
+====================================================
 
 Aiven for PostgreSQL® instances limit the number of allowed connections to make sure that the database is able to serve them all. The ``max_connections`` setting varies according to the service plan as follows:
 

--- a/docs/products/postgresql/reference/resource-capability.rst
+++ b/docs/products/postgresql/reference/resource-capability.rst
@@ -1,5 +1,5 @@
-Resource capability of plans
-============================
+Resource capability of Aiven for PostgreSQL® plans
+==================================================
 
 When creating or updating an Aiven service, the plan that you choose will drive the specific resources (CPU / memory / disk IOPS / etc) powering your service.  Aiven is a cloud data platform, so the underlying instance types are chosen appropriately for the type of service - elements like local NVMe SSDs, sufficient memory for the expected workloads, fast access to backup storage, ability to encrypt the disks, etc all contribute to the choice of which instance types to use on which cloud platforms.  In addition, particular instance types are sometimes not available in a specific cloud region.  There is no one-size-fits-all when it comes to choosing the optimal instance type, so Aiven takes all of these things into account to select the right instance type for a given service.
 

--- a/docs/products/redis/reference/advanced-params.rst
+++ b/docs/products/redis/reference/advanced-params.rst
@@ -1,5 +1,5 @@
-List of advanced parameters
-============================
+Advanced parameters for Aiven for Redis™*
+=========================================
 
 Below you can find a summary of every configuration option available for Aiven for Redis™* service:
 


### PR DESCRIPTION
Fixes #580. Also improves #652 although there is probably more to do on that one.

No page URLs were harmed in the making of this PR. The aim was to have:
 - Descriptive page titles if they are viewed in isolation, e.g. in search results, or when landing directly on a page from a referral link
 - Consistent (but short and without trademark decoration) titles in all the product sections for the navigation bar

It's a lot of changes, hopefully it's not too much to review at once, I couldn't think of a logical way to split this.