### PR TITLE
Add howto guide for m3db as prometheus storage

### DIFF
--- a/docs/products/m3db/howto/grafana.rst
+++ b/docs/products/m3db/howto/grafana.rst
@@ -1,21 +1,21 @@
 Visualize M3DB data with Grafana®
 =================================
 
-Since M3DB is best for time series data, consisting of many individual metrics, then it's nicer to visualise the data than try to view it in a table or log. Luckily, Aiven can set up the Grafana® and the integration between the two services for you.
+Since M3DB is best for time series data, consisting of many individual metrics, then it's nicer to visualize the data than try to view it in a table or log. Luckily, Aiven can set up the Grafana® and the integration between the two services for you.
 
 Integrate M3DB and Grafana
 --------------------------
 
-1. On the service overview page for your M3DB service, go to "Manage Integrations" and choose the "Dashboard" option.
+1. On the service overview page for your M3DB service, go to **Manage Integrations** and choose the **Data Source** option.
 
 2. Choose either a new or existing service.
 
    - A new service will ask you to select the cloud, region and plan to use. You should also give your service a name. The service overview page shows the nodes rebuilding, and then indicates when they are ready.
    - If you're already using Grafana on Aiven, you can integrate your M3DB as a data source for that existing Grafana.
 
-3. On the service overview page for your Grafana service, click the "Service URI" link. The username and password for your Grafana service is also available on the service overview page.
+3. On the service overview page for your Grafana service, click the **Service URI** link. The username and password for your Grafana service is also available on the service overview page.
 
-Now your Grafana service is connected to M3DB as a data source and you can go ahead and visualise your data.
+Now your Grafana service is connected to M3DB as a data source and you can go ahead and visualize your data.
 
 Visualizing M3DB data in Grafana
 --------------------------------
@@ -24,12 +24,12 @@ In Grafana, create a new dashboard and add a panel to it.
 
 The datasource dropdown shows ``--Grafana--`` by default, but your M3DB service will be listed here with a Prometheus logo. Prometheus is managing the communication between M3DB and Grafana.
 
-With your M3DB service selected, the "Query" section will show the metrics from the database in its dropdown.
+With your M3DB service selected, the **Query** section will show the metrics from the database in its dropdown.
 
 .. tip::
    If no metrics are shown, check that there is data in the database
 
-Once you are happy with your panel, give it a title and click "Save" in the top right hand corner.
+Once you are happy with your panel, give it a title and click **Save** in the top right hand corner.
 
 .. image:: /images/products/m3db/m3db-grafana.png
    :alt: Screenshot of a Grafana panel

--- a/docs/products/m3db/howto/prometheus-storage.rst
+++ b/docs/products/m3db/howto/prometheus-storage.rst
@@ -1,0 +1,33 @@
+Use M3DB as remote storage for Prometheus
+#########################################
+
+M3DB is an excellent candidate for a highly scalable remote storage solution for your `Prometheus <https://prometheus.io/>`_ monitoring system. Many organisations are already using Prometheus and come to M3DB when they have outgrown their existing storage setup. With the ability to scale as needed and store large quantities of time series data, serving as back end storage for Prometheus is one of the main use cases for M3DB.
+
+Configure M3DB to store data in Prometheus
+------------------------------------------
+
+1. Configure Prometheus to write its data to local storage. Copy the **Service URI** value from the **Prometheus (Write)** tab. In your Prometheus configuration file (mine is called ``prometheus.yml``), add the following section, replacing ``<PROM_WRITE_URL>`` with the URL you copied.
+
+.. code:: yaml
+
+    remote_write:
+      - url: "<PROM_WRITE_URL>"
+
+Prometheus is now configured to send data to your Aiven for M3 service.
+
+2. So that you can still access the data using your existing Prometheus service, configure Prometheus with the ``remote_read`` configuration to read data from the remote storage. Copy the **Service URI** value from the **Prometheus (Read)** tab. In your Prometheus configuration file, add the following section, replacing ``<PROM_READ_URL>`` with the URL you copied.
+
+.. code:: yaml
+
+    remote_read:
+      - url: "<PROM_READ_URL>"
+        read_recent: true
+
+The ``read_recent`` parameter makes Prometheus read all data from the remote storage; this is useful so that you can test that the setup is working. Without this setting, Prometheus will return the most recent data from local storage if it still has it there.
+
+3. Run Prometheus, and check that data is flowing
+
+.. tip::
+
+    Try :doc:`visualizing your data with Grafana <grafana>` by following our guide.
+

--- a/docs/products/m3db/howto/prometheus-storage.rst
+++ b/docs/products/m3db/howto/prometheus-storage.rst
@@ -3,10 +3,12 @@ Use M3DB as remote storage for Prometheus
 
 M3DB is an excellent candidate for a highly scalable remote storage solution for your `Prometheus <https://prometheus.io/>`_ monitoring system. Many organisations are already using Prometheus and come to M3DB when they have outgrown their existing storage setup. With the ability to scale as needed and store large quantities of time series data, serving as back end storage for Prometheus is one of the main use cases for M3DB.
 
+The steps here are designed to use with an existing Prometheus setup; for a quick example to try things out, try the `Prometheus getting started guide <https://prometheus.io/docs/prometheus/latest/getting_started/>`_ which uses Prometheus to monitor itself as a starting point.
+
 Configure M3DB to store data in Prometheus
 ------------------------------------------
 
-1. Configure Prometheus to write its data to local storage. Copy the **Service URI** value from the **Prometheus (Write)** tab. In your Prometheus configuration file (mine is called ``prometheus.yml``), add the following section, replacing ``<PROM_WRITE_URL>`` with the URL you copied.
+1. Configure Prometheus to **write data to remote storage**. Copy the **Service URI** value from the **Prometheus (Write)** tab. In your Prometheus configuration file (mine is called ``prometheus.yml``), add the following section, replacing ``<PROM_WRITE_URL>`` with the URL you copied.
 
 .. code:: yaml
 
@@ -15,7 +17,7 @@ Configure M3DB to store data in Prometheus
 
 Prometheus is now configured to send data to your Aiven for M3 service.
 
-2. So that you can still access the data using your existing Prometheus service, configure Prometheus with the ``remote_read`` configuration to read data from the remote storage. Copy the **Service URI** value from the **Prometheus (Read)** tab. In your Prometheus configuration file, add the following section, replacing ``<PROM_READ_URL>`` with the URL you copied.
+2. So that you can still access the data using your existing Prometheus service, configure Prometheus with the ``remote_read`` configuration to **read data from the remote storage**. Copy the **Service URI** value from the **Prometheus (Read)** tab. In your Prometheus configuration file, add the following section, replacing ``<PROM_READ_URL>`` with the URL you copied.
 
 .. code:: yaml
 
@@ -25,9 +27,5 @@ Prometheus is now configured to send data to your Aiven for M3 service.
 
 The ``read_recent`` parameter makes Prometheus read all data from the remote storage; this is useful so that you can test that the setup is working. Without this setting, Prometheus will return the most recent data from local storage if it still has it there.
 
-3. Run Prometheus, and check that data is flowing
-
-.. tip::
-
-    Try :doc:`visualizing your data with Grafana <grafana>` by following our guide.
+3. **Run Prometheus**, and check that it starts successfully. After giving it some time to scrape a few metrics, you should see data in the Prometheus web interface. Verify that there is data in M3, either by querying the database directly or by :doc:`using Grafana to visualize the data <grafana>` stored there.
 

--- a/docs/products/m3db/howto/prometheus-storage.rst
+++ b/docs/products/m3db/howto/prometheus-storage.rst
@@ -1,14 +1,14 @@
 Use M3DB as remote storage for Prometheus
 #########################################
 
-M3DB is an excellent candidate for a highly scalable remote storage solution for your `Prometheus <https://prometheus.io/>`_ monitoring system. Many organisations are already using Prometheus and come to M3DB when they have outgrown their existing storage setup. With the ability to scale as needed and store large quantities of time series data, serving as back end storage for Prometheus is one of the main use cases for M3DB.
+M3DB is an excellent candidate for a highly scalable remote storage solution for your `Prometheus <https://prometheus.io/>`_ monitoring system. Many organizations are already using Prometheus and come to M3DB when they have outgrown their existing storage setup. With the ability to scale as needed and store large quantities of time series data, serving as backend storage for Prometheus is one of the main use cases for M3DB.
 
 The steps here are designed to use with an existing Prometheus setup; for a quick example to try things out, try the `Prometheus getting started guide <https://prometheus.io/docs/prometheus/latest/getting_started/>`_ which uses Prometheus to monitor itself as a starting point.
 
 Configure M3DB to store data in Prometheus
 ------------------------------------------
 
-1. Configure Prometheus to **write data to remote storage**. Copy the **Service URI** value from the **Prometheus (Write)** tab. In your Prometheus configuration file (mine is called ``prometheus.yml``), add the following section, replacing ``<PROM_WRITE_URL>`` with the URL you copied.
+1. Configure Prometheus to **write data to remote storage**. Copy the *Service URI* value from the **Prometheus (Write)** tab. In your Prometheus configuration file (mine is called ``prometheus.yml``), add the following section, replacing ``<PROM_WRITE_URL>`` with the URL you copied.
 
 .. code:: yaml
 
@@ -17,7 +17,7 @@ Configure M3DB to store data in Prometheus
 
 Prometheus is now configured to send data to your Aiven for M3 service.
 
-2. So that you can still access the data using your existing Prometheus service, configure Prometheus with the ``remote_read`` configuration to **read data from the remote storage**. Copy the **Service URI** value from the **Prometheus (Read)** tab. In your Prometheus configuration file, add the following section, replacing ``<PROM_READ_URL>`` with the URL you copied.
+2. So that you can still access the data using your existing Prometheus service, configure Prometheus with the ``remote_read`` configuration to **read data from the remote storage**. Copy the *Service URI* value from the **Prometheus (Read)** tab. In your Prometheus configuration file, add the following section, replacing ``<PROM_READ_URL>`` with the URL you copied.
 
 .. code:: yaml
 


### PR DESCRIPTION
# What changed, and why it matters

One big use case for M3 is using it as backend storage for Prometheus, so here's an article on configuring prometheus to do exactly that.

