### PR TITLE
Add vale easy install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,10 @@ If the spellchecker is rejecting words that are valid (such as technology terms)
 
 Installing Vale
 """""""""""""""
-On Fedora (F34), you can install Vale easily (without a package manager) using the following:::
+
+The `Vale installation page <https://docs.errata.ai/vale/install>`_ has instructions for all platforms including docker; this will be updated if the approach changes between versions.
+
+On Fedora (F34), here's a tip for installing Vale (current version 2.16) (without a package manager) using the following:::
 
     package=$(curl -s https://api.github.com/repos/errata-ai/vale/releases/latest \
     | jq -r ' .assets[] | select(.name | contains("Linux"))'); output=$(mktemp -d); \

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,20 @@ To run the spell check locally, you will need to have `Vale <https://github.com/
 
 If the spellchecker is rejecting words that are valid (such as technology terms), double check the spelling and capitalisation, then add the word to ``.github/styles/Vocab/Docs/accept.txt``.
 
+Installing Vale
+"""""""""""""""
+On Fedora (F34), you can install Vale easily (without a package manager) using the following:::
+
+    package=$(curl -s https://api.github.com/repos/errata-ai/vale/releases/latest \
+    | jq -r ' .assets[] | select(.name | contains("Linux"))'); output=$(mktemp -d); \
+    echo $package | jq -r '.browser_download_url' | xargs curl -L --output-dir $output -O; \
+    echo $package | jq -r '.name' | sed -r "s#(.*)#$output/\1#g" | xargs cat \
+    | tar xzf - -C $output; cp -v $output/vale $HOME/bin
+
+Then add ``$HOME/bin`` to ``$PATH`` (e.g. in ``.bashrc``, where ``vale`` is downloaded to via the above command)
+
+Alternatively, use ``snap`` or ``brew``: `https://vale.sh/docs/vale-cli/installation/`
+
 Navigation structure
 ''''''''''''''''''''
 


### PR DESCRIPTION
Added a quick command to get the latest Vale from tar.gz and then untar it to $HOME/bin

This is because I don't want to use brew or snap to install it, and their doco only seems to have a simple example that uses the current dir instead of tmp dirs and $HOME/bin: https://vale.sh/docs/vale-cli/installation/#github-releases

I'm not sure if this is more suitable elsewhere.