### PR TITLE
Fix registered marking in title

### DIFF
--- a/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.rst
+++ b/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.rst
@@ -1,5 +1,5 @@
-Use Kafka® Streams with Aiven for Apache Kafka
-==============================================
+Use Apache Kafka® Streams with Aiven for Apache Kafka®
+======================================================
 
 `Apache Kafka® streams <https://kafka.apache.org/documentation/streams/>`_ and streams API allows streaming data through the heart of Apache Kafka: the brokers. 
 


### PR DESCRIPTION
In the previous PR, I did not notice that we needed to be a bit more careful in our use of naming and ® in the article title. This fixes that.

