### PR TITLE
Migrate REST API endpoint access information

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -415,6 +415,7 @@ entries:
           - file: docs/products/opensearch/reference/advanced-params
             title: Advanced parameters
           - file: docs/products/opensearch/reference/index-replication
+          - file: docs/products/opensearch/reference/restapi-limited-access
 
   - file: docs/products/m3db/index
     title: M3DB

--- a/docs/products/opensearch/reference/restapi-limited-access.rst
+++ b/docs/products/opensearch/reference/restapi-limited-access.rst
@@ -1,6 +1,6 @@
 REST API endpoint access
 ===============================================
-Aiven for OpenSearch® limits access to REST API endpoints. Below you can find which endpoints you can access.
+For operational reasons, Aiven for OpenSearch® limits access to REST API endpoints. Below you can find which endpoints you can access.
 
 The following endpoints are allowed:
 

--- a/docs/products/opensearch/reference/restapi-limited-access.rst
+++ b/docs/products/opensearch/reference/restapi-limited-access.rst
@@ -1,0 +1,25 @@
+REST API endpoint access
+===============================================
+Aiven for OpenSearch® limits access to REST API endpoints. Below you can find which endpoints you can access.
+
+The following endpoints are allowed:
+
+::
+
+   GET /_cluster/health
+   GET /_cluster/pending_tasks
+   GET /_cluster/settings
+   GET /_cluster/stats
+   GET /_nodes
+   GET /_scripts
+
+
+The following API endpoint hierarchies are
+blocked:
+
+::
+
+   /_cat/repositories
+   /_cluster
+   /_snapshot
+


### PR DESCRIPTION
Migrated https://help.aiven.io/en/articles/2026734-elasticsearch-rest-api-limited-access-endpoints. 