### PR TITLE
Fix extra symbol added in commands

### DIFF
--- a/docs/products/grafana/howto/send-emails.rst
+++ b/docs/products/grafana/howto/send-emails.rst
@@ -30,7 +30,7 @@ To configure the Aiven for Grafana service:
 
 1. Open the Aiven client, and log in::
 
-    $ avn user login <you@example.com> --token
+    avn user login <you@example.com> --token
 
 2. configure the service using your own SMTP values::
 

--- a/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.rst
+++ b/docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka.rst
@@ -47,7 +47,7 @@ The following example shows how to customise the ``KafkaMusicExample`` available
 
    .. code:: shell
 
-      $ git clone https://github.com/confluentinc/kafka-streams-examples.git
+      git clone https://github.com/confluentinc/kafka-streams-examples.git
 
 2. Build the packages using Maven
 

--- a/docs/products/redis/howto/migrate-aiven-redis.rst
+++ b/docs/products/redis/howto/migrate-aiven-redis.rst
@@ -102,4 +102,4 @@ Remove migration from configuration
 
 Migration is one-time operation - once the status is ``done``, the migration cannot be restarted. If you need to run migration again, you should first remove it from the configuration, and then configure it again::
 
-    $ avn service update --project test --remove-option migration redis
+    avn service update --project test --remove-option migration redis


### PR DESCRIPTION
According to the README of devportal:

Do not include a `$` before a command that the user should run,
because it will get copied into the user's clipboard and cause
the command to fail (this has been a common standard in the past).

For this reason, I'd like to remove from all the commands the symbol.

# What changed, and why it matters


