### PR TITLE
cloud-security: Clarify LUKS2 format is used

### DIFF
--- a/docs/platform/concepts/cloud-security.rst
+++ b/docs/platform/concepts/cloud-security.rst
@@ -25,7 +25,7 @@ Data encryption
 
 Aiven at-rest data encryption covers both active service instances as well as service backups in cloud object storage.
 
-Service instances and the underlying VMs use full volume encryption using LUKS with a randomly generated ephemeral key per each instance and each volume. The key is never re-used and will be trashed at the destruction of the instance, so there's a natural key rotation with roll-forward upgrades. We use the LUKS default mode aes-xts-plain64:sha256 with a 512-bit key.
+Service instances and the underlying VMs use full volume encryption using LUKS with a randomly generated ephemeral key per each instance and each volume. The key is never re-used and will be trashed at the destruction of the instance, so there's a natural key rotation with roll-forward upgrades. We use the LUKS2 default mode aes-xts-plain64:sha256 with a 512-bit key.
 
 Backups are encrypted with a randomly generated key per file. These keys are in turn encrypted with RSA key-encryption key-pair and stored in the header section of each backup segment. The file encryption is performed with AES-256 in CTR mode with HMAC-SHA256 for integrity protection. The RSA key-pair is randomly generated for each service. The key lengths are 256-bit for block encryption, 512-bit for the integrity protection and 3072-bits for the RSA key. 
 


### PR DESCRIPTION
# What changed, and why it matters

Someone asked whether we use LUKS1 or LUKS2 format. Say it out aloud.
