### PR TITLE
Update filename reference to fix broken link for Redis.

### DIFF
--- a/docs/products/redis/howto/migrate-aiven-redis.rst
+++ b/docs/products/redis/howto/migrate-aiven-redis.rst
@@ -13,7 +13,7 @@ In the following steps, we show you how to create a new Aiven for Redis service,
 What you'll need
 ----------------
 
-* A target Aiven for Redis service. See :doc:`/docs/products/redis/getting-started` to create one, or follow the instructions below.
+* A target Aiven for Redis service. See :doc:`/docs/products/redis/get-started` to create one, or follow the instructions below.
 
 * The hostname, port and password of the source Redis service. 
 

--- a/docs/products/redis/index.rst
+++ b/docs/products/redis/index.rst
@@ -18,7 +18,7 @@ Read more about `the introduction to Redis <https://redis.io/topics/introduction
 Get started with Aiven for Redis
 ---------------------------------
 
-Take your first steps with Aiven for Redis by following our :doc:`getting-started` article, or browse through our full list of articles:
+Take your first steps with Aiven for Redis by following our :doc:`getting started guide <get-started>`, or browse through our full list of articles:
 
 
 .. panels::


### PR DESCRIPTION
# What changed, and why it matters

Based on a previous PR, the Redis getting started guide filename changed which caused two broken links for https://developer.aiven.io/docs/products/redis/howto/migrate-aiven-redis.html page and https://developer.aiven.io/docs/products/redis/index.html page. This PR fixes those broken references. 
