### PR TITLE
How to enable Aiven password

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -24,6 +24,7 @@ entries:
       - file: docs/platform/howto/create_new_service
       - file: docs/platform/howto/create_new_service_user
       - file: docs/platform/howto/create_authentication_token
+      - file: docs/platform/howto/enable-aiven-password
       - file: docs/platform/howto/disable-user-2fa
       - file: docs/platform/howto/download-ca-cert
       - file: docs/platform/howto/console-fork-service.rst

--- a/docs/platform/howto/enable-aiven-password.rst
+++ b/docs/platform/howto/enable-aiven-password.rst
@@ -1,0 +1,20 @@
+Enable Aiven password
+=====================
+
+Enable your Aiven password to be able to log in via :doc:`Aiven CLI </docs/tools/cli>`. For example::
+
+    avn user login <user@aiven.io>
+
+Follow these steps to enable your password:
+
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+2. Click **User information**, then select **Authentication** tab
+3. Scroll down on **Authentication methods**, and select **Aiven Password**
+4. Enable your **Aiven Password**
+
+To make sure it works:
+
+1. Log out from the `Aiven web console <https://console.aiven.io/>`_.
+2. Log in to the `Aiven web console <https://console.aiven.io/>`_, and select **Log in with Password** option.
+
+If you can log in using your Aiven password, then it worked. Otherwise, contact the support team via `support@aiven.io` to assist you.

--- a/docs/platform/howto/enable-aiven-password.rst
+++ b/docs/platform/howto/enable-aiven-password.rst
@@ -1,7 +1,7 @@
 Enable Aiven password
 =====================
 
-If you prefer to authenticate directly in the `Aiven web console <https://console.aiven.io/>`_ without using a third party information, it is possible. You can log in directly by enabling your Aiven password. You can follow these steps to enable your password:
+If you prefer to authenticate directly in the `Aiven web console <https://console.aiven.io/>`_ without using third party information, it is possible. You can log in directly by enabling your Aiven password. You can follow these steps to enable your password:
 
 1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
 2. Click **User information**, then select **Authentication** tab

--- a/docs/platform/howto/enable-aiven-password.rst
+++ b/docs/platform/howto/enable-aiven-password.rst
@@ -1,11 +1,7 @@
 Enable Aiven password
 =====================
 
-Enable your Aiven password to be able to log in via :doc:`Aiven CLI </docs/tools/cli>`. For example::
-
-    avn user login <user@aiven.io>
-
-Follow these steps to enable your password:
+If you prefer to authenticate directly in the `Aiven web console <https://console.aiven.io/>`_ without using a third party information, it is possible. You can log in directly by enabling your Aiven password. You can follow these steps to enable your password:
 
 1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
 2. Click **User information**, then select **Authentication** tab

--- a/docs/platform/howto/enable-aiven-password.rst
+++ b/docs/platform/howto/enable-aiven-password.rst
@@ -17,4 +17,4 @@ To make sure it works:
 1. Log out from the `Aiven web console <https://console.aiven.io/>`_.
 2. Log in to the `Aiven web console <https://console.aiven.io/>`_, and select **Log in with Password** option.
 
-If you can log in using your Aiven password, then it worked. Otherwise, contact the support team via `support@aiven.io` to assist you.
+If you can log in using your Aiven password, then it worked. Otherwise, contact the support team via ``support@aiven.io`` to assist you.

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -27,12 +27,12 @@ There are two options for authenticating. The first is to use your username, and
 
   avn user login <you@example.com>
 
-.. important::
-  Enable your Aiven password to log in via your user e-mail. Find more information on :doc:`How to create Aiven password </docs/platform/howto/enable-aiven-password>`.
-
-You can also use an access token (this is the recommended route if you use SSO), with a command like::
+For security reasons, it is recommended to use an access token, especially if you use SSO. You can use a command like::
 
   avn user login <you@example.com> --token
+
+.. tip::
+  To learn how to create an authentication token refer to :doc:`../platform/howto/create_authentication_token`
 
 This command will prompt you for a token rather than a password.
 

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -27,6 +27,9 @@ There are two options for authenticating. The first is to use your username, and
 
   avn user login <you@example.com>
 
+.. important::
+  Enable your Aiven password to log in via your user e-mail. Find more information on :doc:`How to create Aiven password </docs/platform/howto/enable-aiven-password>`.
+
 You can also use an access token (this is the recommended route if you use SSO), with a command like::
 
   avn user login <you@example.com> --token


### PR DESCRIPTION
This is needed if the user wants to authenticate and log in directly without using any 3rd parties by using Aiven username and password.


fixes:https://github.com/aiven/devportal/issues/677