### PR TITLE
amend opensearch dashboard alerting

### DIFF
--- a/docs/products/opensearch/dashboards/howto/opensearch-alerting-dashboard.rst
+++ b/docs/products/opensearch/dashboards/howto/opensearch-alerting-dashboard.rst
@@ -47,7 +47,8 @@ Destination is a location for notifications to be delivered when an action is tr
    Destination Type can be: ``Amazon Chime``, ``Slack``, ``Custom webhook`` or ``Email``
 
 .. important::
-   When using email you need to have a SMTP server configured for a valid domain to deliver email notifications
+   - When using email you need to have a SMTP server configured for a valid domain to deliver email notifications
+   - Please note that the authentication of a sender account is currently not supported. That is, when an alert is being created, the email destination does not support the encryption methods SSL/TLS. 
 
 Create a monitor
 ****************


### PR DESCRIPTION
The article has been amended to reflect the fact that it is currently not possible to authenticate a sender account when creating an email destination in Opensearch alerts. That is, we do not offer a way to set username and password in Opensearch keystore. To do so one needs to run the command ./bin/opensearch-keystore in all the nodes and we do not expose a way to achieve the same result.

I have mentioned this aspect among the important notes.

