### PR TITLE
add meta description in base template with max 160 char based on body

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -4,6 +4,7 @@
 {{ super() }}
 
 <link rel="canonical" href="https://developer.aiven.io/{{ pagename }}" />
+<meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
# What changed, and why it matters
Related to [Issue 533](https://github.com/aiven/devportal/issues/533), add missing `meta description` with max 160 char.

Sphinx has this [meta directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#html-metadata) but it need to be be added manually in each RST document.

.. meta::
   :description: The Sphinx documentation builder
   :keywords: Sphinx, documentation, builder

To add the meta description to the template, using Jinga template filter similar to existing `twitter:description` but with max 160 chars.

Preview: [view-source:https://deploy-preview-775--developer-aiven-io-preview.netlify.app/](view-source:https://deploy-preview-775--developer-aiven-io-preview.netlify.app/)
<img width="1820" alt="Screenshot 2022-05-09 at 15 03 35" src="https://user-images.githubusercontent.com/3796599/167406587-45168f0b-8e9e-43d9-b254-d7acca1be86a.png">

