### PR TITLE
add notfound extension to generate custom 404 page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,7 +34,12 @@ extensions = [
     'sphinx_copybutton',
     'sphinx_gitstamp',
     'sphinxext.opengraph',
+    'notfound.extension',
 ]
+
+# Not Found configuration
+# see all options at https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html
+notfound_urls_prefix = None
 
 # OpenGraph configuration
 # see all options at https://github.com/wpilibsuite/sphinxext-opengraph#options

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.25.1
 psycopg2-binary==2.9.1
 sphinxext-opengraph==0.4.2
 sphinx-sitemap==2.2.0
+sphinx-notfound-page==0.8


### PR DESCRIPTION
# What changed, and why it matters
Related to [issue 548](https://github.com/aiven/devportal/issues/548), enable custom 404 page instead of Netlify branded.
Using [sphinx-notfound-page extension](https://github.com/readthedocs/sphinx-notfound-page)
<img width="1708" alt="Screenshot 2022-05-09 at 17 30 44" src="https://user-images.githubusercontent.com/3796599/167432672-f428b244-5f25-48e6-a464-c0c564f10169.png">

preview: https://deploy-preview-776--developer-aiven-io-preview.netlify.app/404

