### PR TITLE
Fixed year in the footer to 2022

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Aiven Developer'
-copyright = '2021, Aiven Team'
+copyright = '2022, Aiven Team'
 author = 'Aiven Team'
 html_title = 'Aiven'
 


### PR DESCRIPTION
Fix to close issue #780 

Changed year in the footer from 2021 to 2022
![Changed Year to 2022](https://user-images.githubusercontent.com/76956031/168430089-fc8ee420-1ee6-499f-b32c-5c02b089af91.JPG)
