### PR TITLE
Migrate help for Kafka Python examples

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -129,6 +129,10 @@ entries:
       - file: docs/products/kafka/howto
         title: HowTo
         entries:
+          - file: docs/products/kafka/howto/list-code-samples
+            entries:
+              - file: docs/products/kafka/howto/connect-with-python
+                title: Connect with Python
           - file: docs/products/kafka/howto/list-tools
             title: Tools
             entries:
@@ -154,7 +158,6 @@ entries:
               - file: docs/products/kafka/howto/configure-log-cleaner
               - file: docs/products/kafka/howto/prevent-full-disks
               - file: docs/products/kafka/howto/use-zookeeper
-          
 
           - file: docs/products/kafka/howto/list-integration
             title: Integrations

--- a/_toc.yml
+++ b/_toc.yml
@@ -158,7 +158,6 @@ entries:
               - file: docs/products/kafka/howto/configure-log-cleaner
               - file: docs/products/kafka/howto/prevent-full-disks
               - file: docs/products/kafka/howto/use-zookeeper
-
           - file: docs/products/kafka/howto/list-integration
             title: Integrations
             entries:

--- a/conf.py
+++ b/conf.py
@@ -74,6 +74,14 @@ html_baseurl = 'https://developer.aiven.io'
 # We need to be explicit that we don't want {version} or {language} in the URLs
 sitemap_url_scheme = "{link}"
 
+# ``make linkcheck`` is not perfect.
+# The following pages are known to cause it problems.
+linkcheck_ignore = [
+    # Kafka documentation anchors do not seem to be detected. We use the following:
+   'https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset',
+    'https://kafka.apache.org/documentation/#design_consumerposition',
+]
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -91,7 +91,7 @@ Variable              Description
                         partition
 =================     =============================================================
 
-For more information on ``auto_offset_reset``, see the Kafka documentation on [auto.offset.rest](https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset) and [Consumer Position](https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset)
+For more information on ``auto_offset_reset``, see the Kafka documentation on `auto.offset.rest <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_ and `Consumer Position <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_.
 
 
 Connect a producer

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -1,8 +1,10 @@
 Connect to Aiven for Apache Kafka® with Python
 ==============================================
 
-These examples show how to connect to an Aiven for Apache Kafka® service using the
-`kafka-python <https://pypi.org/project/kafka-python/>`__ library, as either a producer or consumer.
+.. |kafka-python| replace:: ``kafka-python``
+.. _`kafka-python`: https://pypi.org/project/kafka-python/
+
+These examples show how to connect to an Aiven for Apache Kafka® service using the |kafka-python|_ library, as either a producer or consumer.
 
 .. note:: The examples given here provide different options for the different authentication
    methods. For more information on the supported methods, see `our article on Kafka
@@ -11,7 +13,7 @@ These examples show how to connect to an Aiven for Apache Kafka® service using 
 Pre-requisites
 --------------
 
-Install the Python  `kafka-python <https://pypi.org/project/kafka-python/>`__ library:
+Install the Python |kafka-python|_ library:
 
 .. code:: bash
 

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -95,7 +95,10 @@ Variable              Description
                         partition
 =================     =============================================================
 
-For more information on ``auto_offset_reset``, see the Kafka documentation on `auto.offset.reset <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_ and `Consumer Position <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_.
+For more information on ``auto_offset_reset``, see the Kafka documentation on
+`auto.offset.reset <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_
+and
+`Consumer Position <https://kafka.apache.org/documentation/#design_consumerposition>`_.
 
 
 Connect a producer

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -91,7 +91,7 @@ Using SASL authentication
 
          from kafka import KafkaProducer
 
-         # Choose an appropriate SASL mechanism
+         # Choose an appropriate SASL mechanism, for instance:
          SASL_MECHANISM = 'SCRAM-SHA-256'
 
          producer = KafkaProducer(
@@ -132,7 +132,7 @@ Using SASL authentication
 
         from kafka import KafkaConsumer
 
-        # Choose an appropriate SASL mechanism
+        # Choose an appropriate SASL mechanism, for instance:
         SASL_MECHANISM = 'SCRAM-SHA-256'
 
         consumer = KafkaConsumer(

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -44,9 +44,12 @@ Go to the *Overview* page of your Aiven for Apache Kafka service.
 
 Note that the *CA Certificate* ``ca.pem`` file has the same contents by either route.
 
-Alternatively, you can use the `Aiven command line tool <https://developer.aiven.io/docs/tools/cli.html>`_ to download the files. See the documentation for `avn service user-creds-download <https://developer.aiven.io/docs/tools/cli/service/user.html#avn-service-user-creds-download>`_
+.. Warning::
 
-In the examples, we just show the name of the file, but in actual use, the full path should be used.
+  In the below examples, we just pass the name of the certificate files, but in actual use, the full path should be used.
+
+You can also use the `Aiven command line tool <https://developer.aiven.io/docs/tools/cli.html>`_ to download the files. See the documentation for `avn service user-creds-download <https://developer.aiven.io/docs/tools/cli/service/user.html#avn-service-user-creds-download>`_
+
 
 Variables
 ---------
@@ -104,7 +107,7 @@ and
 Connect a producer
 ------------------
 
-Using SSL authentication
+With SSL authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
@@ -119,7 +122,7 @@ Using SSL authentication
             ssl_keyfile="service.key",
         )
 
-Using SASL authentication
+With SASL authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
@@ -141,7 +144,7 @@ Using SASL authentication
 Connect a consumer
 ------------------
 
-Using SSL authentication
+With SSL authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
@@ -160,7 +163,8 @@ Using SSL authentication
             ssl_keyfile="service.key",
         )
 
-Using SASL authentication
+
+With SASL authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -1,0 +1,149 @@
+Connect to Aiven for Apache Kafka® with Python
+==============================================
+
+These examples show how to connect to an Aiven for Apache Kafka® service using the
+`kafka-python <https://pypi.org/project/kafka-python/>`__ library, as either a producer or consumer.
+
+.. note:: The examples given here provide different options for the different authentication
+   methods. For more information on the supported methods, see `our article on Kafka
+   authentication types <https://developer.aiven.io/docs/products/kafka/concepts/auth-types>`_.
+
+Pre-requisites
+--------------
+
+Install the Python  `kafka-python <https://pypi.org/project/kafka-python/>`__ library:
+
+.. code:: bash
+
+    pip install kafka-python
+
+Go to the *Overview* page of your Aiven for Apache Kafka service.
+
+* If you are going to connect with SSL authentication:
+
+  * In the *Connection information* section:
+
+    #. If **Authentication Method** is shown, choose **Client Certificate**
+    #. Next to *Access Key*, click **Download** and save the ``service.key`` file.
+    #. Next to *Access Certificate*, click **Download** and save the ``service.cert`` file.
+    #. Next to *CA Certificate*, click **Download** and save the ``ca.pem`` file.
+
+* If you are going to connect using SASL authentication:
+
+  #. Follow the instructions at `Use SASL Authentication with Apache Kafka® <https://developer.aiven.io/docs/products/kafka/howto/kafka-sasl-auth.html>`_ to enable SASL.
+
+  #. In the *Connection Information* section
+
+     #. Select **SASL** as the **Authentication Method**
+     #. Next to *CA Certificate*, click **Download** and save the ``ca.pem`` file
+
+Variables
+---------
+
+These are the placeholders you will need to replace in the code samples. The values are from the *Connection information* on the service overview page.
+
+If you are using SSL (remember to choose **Client Certificate** if **Authentication Method** is shown):
+
+=============     =============================================================
+Variable          Description
+=============     =============================================================
+``HOST``          Host name for the connection
+-------------     -------------------------------------------------------------
+``SSL_PORT``      Port number to use
+=============     =============================================================
+
+If you are using SASL (**Authentication Method** should be **SASL**):
+
+=================     =============================================================
+Variable              Description
+=================     =============================================================
+``HOST``              Host name for the connection
+-----------------     -------------------------------------------------------------
+``SASL_PORT``         Port number to use
+-----------------     -------------------------------------------------------------
+``SASL_USERNAME``     User to connect with
+-----------------     -------------------------------------------------------------
+``SASL_PASSWORD``     Password for this user
+=================     =============================================================
+
+Connect a producer
+------------------
+
+Using SSL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+        from kafka import KafkaProducer
+
+        producer = KafkaProducer(
+            bootstrap_servers=f"{HOST}:{SSL_PORT}",
+            security_protocol="SSL",
+            ssl_cafile="ca.pem",
+            ssl_certfile="service.cert",
+            ssl_keyfile="service.key",
+        )
+
+Using SASL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+         from kafka import KafkaProducer
+
+         # Choose an appropriate SASL mechanism
+         SASL_MECHANISM = 'SCRAM-SHA-256'
+
+         producer = KafkaProducer(
+            bootstrap_servers=f"{HOST}:{SASL_PORT}",
+            sasl_mechanism = SASL_MECHANISM,
+            sasl_plain_username = SASL_USERNAME,
+            sasl_plain_password = SASL_PASSWORD,
+            security_protocol="SASL_SSL",
+            ssl_cafile="ca.pem",
+         )
+
+Connect a consumer
+------------------
+
+Using SSL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+        from kafka import KafkaConsumer
+
+        consumer = KafkaConsumer(
+            "demo-topic",
+            auto_offset_reset="earliest",
+            bootstrap_servers=f"{HOST}:{SSL_PORT}",
+            client_id = CONSUMER_CLIENT_ID,
+            group_id = CONSUMER_GROUP_ID,
+            security_protocol="SSL",
+            ssl_cafile="ca.pem",
+            ssl_certfile="service.cert",
+            ssl_keyfile="service.key",
+        )
+
+Using SASL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+        from kafka import KafkaConsumer
+
+        # Choose an appropriate SASL mechanism
+        SASL_MECHANISM = 'SCRAM-SHA-256'
+
+        consumer = KafkaConsumer(
+            "demo-topic",
+            auto_offset_reset = "earliest",
+            bootstrap_servers = f'{HOST}:{SASL_PORT}',
+            client_id = CONSUMER_CLIENT_ID,
+            group_id = CONSUMER_GROUP_ID,
+            sasl_mechanism = SASL_MECHANISM,
+            sasl_plain_username = SASL_USERNAME,
+            sasl_plain_password = SASL_PASSWORD,
+            security_protocol = "SASL_SSL",
+            ssl_cafile = "ca.pem"
+        )

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -1,6 +1,9 @@
 Connect to Aiven for Apache Kafka® with Python
 ==============================================
 
+.. See https://docs.google.com/document/d/1PqNbBMzeED_AFeIFzfdcoR_P2bUJrNdcv4uHheeCh6I/edit
+   for an explanation of the following
+
 .. |kafka-python| replace:: ``kafka-python``
 .. _`kafka-python`: https://pypi.org/project/kafka-python/
 

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -73,7 +73,7 @@ Variable              Description
 ``SASL_PASSWORD``     Password for this user
 =================     =============================================================
 
-For consumers:
+For consumers you will also need:
 
 =================     =============================================================
 Variable              Description

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -42,12 +42,16 @@ Go to the *Overview* page of your Aiven for Apache Kafka service.
      #. Select **SASL** as the **Authentication Method**
      #. Next to *CA Certificate*, click **Download** and save the ``ca.pem`` file
 
+Note that the *CA Certificate* ``ca.pem`` file has the same contents by either route.
+
+Alternatively, you can use the `Aiven command line tool <https://developer.aiven.io/docs/tools/cli.html>`_ to download the files. See the documentation for `avn service user-creds-download <https://developer.aiven.io/docs/tools/cli/service/user.html#avn-service-user-creds-download>`_
+
 In the examples, we just show the name of the file, but in actual use, the full path should be used.
 
 Variables
 ---------
 
-These are the placeholders you will need to replace in the code samples. The values are from the *Connection information* on the service overview page.
+These are the placeholders you will need to replace in the code samples. The values are from the ``Connection information`` on the service overview page.
 
 If you are using SSL (remember to choose **Client Certificate** if **Authentication Method** is shown):
 
@@ -91,7 +95,7 @@ Variable              Description
                         partition
 =================     =============================================================
 
-For more information on ``auto_offset_reset``, see the Kafka documentation on `auto.offset.rest <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_ and `Consumer Position <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_.
+For more information on ``auto_offset_reset``, see the Kafka documentation on `auto.offset.reset <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_ and `Consumer Position <https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset>`_.
 
 
 Connect a producer

--- a/docs/products/kafka/howto/connect-with-python.rst
+++ b/docs/products/kafka/howto/connect-with-python.rst
@@ -42,6 +42,8 @@ Go to the *Overview* page of your Aiven for Apache Kafka service.
      #. Select **SASL** as the **Authentication Method**
      #. Next to *CA Certificate*, click **Download** and save the ``ca.pem`` file
 
+In the examples, we just show the name of the file, but in actual use, the full path should be used.
+
 Variables
 ---------
 
@@ -70,6 +72,27 @@ Variable              Description
 -----------------     -------------------------------------------------------------
 ``SASL_PASSWORD``     Password for this user
 =================     =============================================================
+
+For consumers:
+
+=================     =============================================================
+Variable              Description
+=================     =============================================================
+``TOPIC_NAME``        The name of the topic to read from
+-----------------     -------------------------------------------------------------
+``START_FROM``        The value to use for the ``auto_offset_reset`` parameter,
+                      which says which message to start consuming from.
+
+                      Allowed values are:
+
+                      * ``latest`` - consume from the end of the topic partition.
+                        This is the default.
+                      * ``earliest`` - consume from the beginning of the topic
+                        partition
+=================     =============================================================
+
+For more information on ``auto_offset_reset``, see the Kafka documentation on [auto.offset.rest](https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset) and [Consumer Position](https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset)
+
 
 Connect a producer
 ------------------
@@ -119,8 +142,8 @@ Using SSL authentication
         from kafka import KafkaConsumer
 
         consumer = KafkaConsumer(
-            "demo-topic",
-            auto_offset_reset="earliest",
+            "TOPIC_NAME",
+            auto_offset_reset="START_FROM",
             bootstrap_servers=f"{HOST}:{SSL_PORT}",
             client_id = CONSUMER_CLIENT_ID,
             group_id = CONSUMER_GROUP_ID,
@@ -141,8 +164,8 @@ Using SASL authentication
         SASL_MECHANISM = 'SCRAM-SHA-256'
 
         consumer = KafkaConsumer(
-            "demo-topic",
-            auto_offset_reset = "earliest",
+            "TOPIC_NAME",
+            auto_offset_reset = "START_FROM",
             bootstrap_servers = f'{HOST}:{SASL_PORT}',
             client_id = CONSUMER_CLIENT_ID,
             group_id = CONSUMER_GROUP_ID,

--- a/docs/products/kafka/howto/list-code-samples.rst
+++ b/docs/products/kafka/howto/list-code-samples.rst
@@ -1,0 +1,4 @@
+Code samples
+============
+
+.. tableofcontents::


### PR DESCRIPTION
Migrate the "how to connect" part of
https://help.aiven.io/en/articles/5343895-python-examples-for-testing-aiven-for-apache-kafka

I have removed the "example" code, as it's very hard to make good general example code, and I think it's better for the user to look elsewhere. This follows what we've done for the "connect with XXX" pages for other products. In the process, I've made it closer in style to (for instance) the MySQL page.

I've merged the paired SASL examples, as I don't think we need to provide examples that only differ in the `sasl_mechanism`.

Fixes: https://github.com/aiven/devportal/issues/782

