### PR TITLE
Fix an error with the notfound configuration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ extensions = [
 
 # Not Found configuration
 # see all options at https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html
-notfound_urls_prefix = None
+notfound_urls_prefix = ''
 
 # OpenGraph configuration
 # see all options at https://github.com/wpilibsuite/sphinxext-opengraph#options


### PR DESCRIPTION
The docs say to use None, but there's an open issue for the resulting
error and the workaround is to use '' (which does remove the error I see in my logs)


