### PR TITLE
Removed the Elasticsearch reference.

### DIFF
--- a/docs/platform/index.rst
+++ b/docs/platform/index.rst
@@ -11,7 +11,6 @@ Apache Kafka®,
 Apache Cassandra®,
 PostgreSQL®,
 MySQL,
-Elasticsearch,
 Redis™*,
 InfluxDB®,
 Grafana®,
@@ -29,7 +28,3 @@ Learn more about the Aiven platform
 
     💻 :doc:`howto`
 
-
-------
-
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*


### PR DESCRIPTION
# What changed, and why it matters

Removed the Elasticsearch service references from the Aiven platform definition page since it is no longer available as a service.

Fixes: https://github.com/aiven/devportal/issues/841