### PR TITLE
Improve venv instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,13 @@ Local Development
 
 We recommend using a virtual environment like `venv <https://docs.python.org/3/library/venv.html>`_::
 
-    python3 -m venv /path/to/new/virtual/environment
+    python3 -m venv venv
 
-If you call it something other than `venv` or `env`, make sure to add your preferred name to `<.gitignore>`_.
+If you call the directory (the last parameter above) something other than `venv` or `env`, make sure to add the directory name to `<.gitignore>`_.
 
-Activate your virtual environment using the `activate` script for your environment.
+Activate your virtual environment using the `activate` script for your environment::
+
+    source venv/bin/activate
 
 Install the dependencies::
 

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,6 @@ We recommend using a virtual environment like `venv <https://docs.python.org/3/l
 
     python3 -m venv venv
 
-If you call the directory (the last parameter above) something other than `venv` or `env`, make sure to add the directory name to `<.gitignore>`_.
-
 Activate your virtual environment using the `activate` script for your environment::
 
     source venv/bin/activate


### PR DESCRIPTION
Replaces PR #866 that had strange issues in the checks.

Simplify the venv create command.
Clarify the .gitignore-related note.
Add the exact command to activate the venv.
