### PR TITLE
Third Terraform Recipe - Kafka and Flink

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -107,6 +107,8 @@ entries:
               title: Apache Kafka and OpenSearch
             - file: docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe
               title: Multicloud PostgreSQL 
+            - file: docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe
+              title: Add the power of Apache Flink® to Apache Kafka® for stateful stream processing  
       - file: docs/tools/kubernetes
         title: Aiven Operator for Kubernetes
 

--- a/_toc.yml
+++ b/_toc.yml
@@ -108,7 +108,7 @@ entries:
             - file: docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe
               title: Multicloud PostgreSQL 
             - file: docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe
-              title: Add the power of Apache Flink® to Apache Kafka® for stateful stream processing  
+              title: Apache Kafka and Apache Flink  
       - file: docs/tools/kubernetes
         title: Aiven Operator for Kubernetes
 

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -1,0 +1,112 @@
+Add the power of Apache Flink® to Apache Kafka® for stateful stream processing
+==============================================================================
+
+Whether it's an event-driven application or a data pipeline, Apache Flink® is an excellent choice due to its ability to perform computations at in-memory speed and at any scale. 
+We can use Apache Kafka® as a highly-available, fault-tolerant platform and leverage the power of Flink's stateful data transformations alongside. This example shows how to set up an Aiven for Apache Kafka
+with an Aiven for Apache Flink integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
+
+Describe the setup
+------------------
+
+The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration and  related resources. The parameters and configurations will vary for your case and you can find
+links to the advanced parameters as a reference at the end of this document.
+
+
+``services.tf`` file:
+
+.. code:: bash
+
+  resource "aiven_flink" "flink" {
+   project      = data.aiven_project.dev-advocates.project
+   cloud_name   = "google-europe-west1"
+   plan         = "business-8"
+   service_name = "demo-flink"
+  }
+
+  resource "aiven_kafka" "kafka" {
+   project      = data.aiven_project.dev-advocates.project
+   cloud_name   = "google-europe-west1"
+   plan         = "business-8"
+   service_name = "demo-kafka"
+  }
+
+  resource "aiven_service_integration" "flink_to_kafka" {
+   project                  = data.aiven_project.dev-advocates.project
+   integration_type         = "flink"
+   destination_service_name = aiven_flink.flink.service_name
+   source_service_name      = aiven_kafka.kafka.service_name
+  }
+
+  resource "aiven_kafka_topic" "source" {
+   project      = data.aiven_project.dev-advocates.project
+   service_name = aiven_kafka.kafka.service_name
+   partitions   = 2
+   replication  = 3
+   topic_name   = "source_topic"
+  }
+
+  resource "aiven_kafka_topic" "sink" {
+   project      = data.aiven_project.dev-advocates.project
+   service_name = aiven_kafka.kafka.service_name
+   partitions   = 2
+   replication  = 3
+   topic_name   = "sink_topic"
+  }
+
+  resource "aiven_flink_table" "source" {
+   project        = data.aiven_project.dev-advocates.project
+   service_name   = aiven_flink.flink.service_name
+   integration_id = aiven_service_integration.flink_to_kafka.integration_id
+   table_name     = "source_table"
+   kafka_topic    = aiven_kafka_topic.source.topic_name
+   schema_sql     = <<EOF
+    `cpu` INT,
+    `node` INT,
+    `occurred_at` TIMESTAMP(3) METADATA FROM 'timestamp',
+    WATERMARK FOR `occurred_at` AS `occurred_at` - INTERVAL '5' SECOND
+   EOF
+  }
+
+  resource "aiven_flink_table" "sink" {
+   project        = data.aiven_project.dev-advocates.project
+   service_name   = aiven_flink.flink.service_name
+   integration_id = aiven_service_integration.flink_to_kafka.integration_id
+   table_name     = "sink_table"
+   kafka_topic    = aiven_kafka_topic.sink.topic_name
+   schema_sql     = <<EOF
+     `cpu` INT,
+     `node` INT,
+     `occurred_at` TIMESTAMP(3)
+   EOF
+  }
+
+  resource "aiven_flink_job" "flink_job" {
+   project      = data.aiven_project.dev-advocates.project
+   service_name = aiven_flink.flink.service_name
+   job_name     = "my_job"
+   table_ids = [
+     aiven_flink_table.source.table_id,
+     aiven_flink_table.sink.table_id
+   ]
+   statement = <<EOF
+     INSERT INTO ${aiven_flink_table.sink.table_name}
+     SELECT * FROM ${aiven_flink_table.source.table_name}
+     WHERE `cpu` > 70
+   EOF
+  }
+
+
+The resource names are self-descriptive in terms of what they're doing. The resource ``"aiven_flink"`` creates an Aiven for Apache Flink resource with the project name, choice of cloud, an Aiven service plan, and
+a specified service name. Similarly, the ``"aiven_service_integration"`` resource creates the integration between Apache Kafka and the Apache Flink service. Two ``"aiven_flink_table"``
+resources are created - a **source** and a **sink** with a specified schema. Once the Terraform script is run, an Apache Flink job is started that copies data from the **source** Flink table to the **sink** Flink 
+table where the **cpu** threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
+called **sink**.
+
+More resources
+--------------
+
+You might find these related resources useful too:
+
+- `Build a Streaming SQL Pipeline with Apache Flink® and Apache Kafka® <https://aiven.io/blog/build-a-streaming-sql-pipeline-with-flink-and-kafka>`_
+- `Advanced parameters for Aiven for Apache Kafka® <https://developer.aiven.io/docs/products/kafka/reference/advanced-params.html>`_
+- `Advanced parameters for Aiven for Apache Flink® <https://developer.aiven.io/docs/products/flink/reference/advanced-params.html>`_

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -73,7 +73,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     project        = var.project_name
     service_name   = aiven_flink.flink.service_name
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
-    table_name     = "source_table"
+    table_name     = "iot_measurements_table"
     kafka_topic    = aiven_kafka_topic.source.topic_name
     schema_sql = <<EOF
       hostname STRING,
@@ -89,7 +89,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     project        = var.project_name
     service_name   = aiven_flink.flink.service_name
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
-    table_name     = "sink_table"
+    table_name     = "cpu_high_usage_table"
     kafka_topic    = aiven_kafka_topic.sink.topic_name
     schema_sql     = <<EOF
       time_ltz TIMESTAMP(3),

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -1,7 +1,7 @@
-Apache Kafka as source and sink for Apache Flink job
+Apache Kafka® as source and sink for Apache Flink® job
 ====================================================
 
-This example shows how to set up an Aiven for Apache Kafka® with an Aiven for Apache Flink® integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
+This example shows how to set up an Aiven for Apache Kafka with an Aiven for Apache Flink integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
 An Apache Kafka source topic is used as a data source, and Apache Flink processes the data to do filtering or transformation, and finally write the transformed output to a different target topic.
 
 Let's cook!
@@ -25,7 +25,7 @@ Before looking at the Terraform script, let's visually realize how the services 
 
 If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
 
-The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apacha Kafka topics, an Apache Flink job and two Apache Flink tables. 
+The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job and two Apache Flink tables. 
 
 ``services.tf`` file:
 

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -125,7 +125,7 @@ resources are created - a **source** and a **sink** with a specified schema. Onc
 table where the ``usage`` threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
 called **sink**.
 
-To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="source-topic"`` (same topic name defined in the resource ``"aiven_kafka_topic"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials.
+To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="source-topic"`` (same topic name defined in the resource ``"aiven_kafka_topic" "source"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials. In the destination topic, defined in the resource ``"aiven_kafka_topic" "sink"``, you should see only data samples having ``usage`` above 70.
 
 More resources
 --------------

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -2,7 +2,7 @@ Apache Kafka® as source and sink for Apache Flink® job
 ======================================================
 
 This example shows how to set up an Aiven for Apache Kafka with an Aiven for Apache Flink integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
-An Apache Kafka source topic is used as a data source, and Apache Flink processes the data to do filtering or transformation, and finally write the transformed output to a different target topic.
+An Apache Kafka source topic is used as a data source, and Apache Flink processes the data to do filtering or transformation, and finally write the transformed output to a sink topic.
 
 Let's cook!
 -----------
@@ -20,7 +20,7 @@ Before looking at the Terraform script, let's visually realize how the services 
       FlinkSourceTable-->|Filter/Transform|FlinkTargetTable
       end
       subgraph Apache Kafka
-      FlinkTargetTable-->|FlinkJob|TargetTopic
+      FlinkTargetTable-->|FlinkJob|SinkTopic
       end
 
 If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
@@ -120,7 +120,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
   }
 
 The resource ``"aiven_flink"`` creates an Aiven for Apache Flink resource with the project name, choice of cloud, an Aiven service plan, and a specified service name. 
-``"aiven_kafka"`` resource creates an Apache Kafka cluster and two Apache Kafka topics (**source** and a **sink**) are created using the ``"aiven_kafka_topic"`` resource.
+``"aiven_kafka"`` resource creates an Apache Kafka cluster and two Apache Kafka topics (**sourc_topice** and a **sink_topic**) are created using the ``"aiven_kafka_topic"`` resource.
 Similarly, the ``"aiven_service_integration"`` resource creates the integration between Apache Kafka and the Apache Flink service. Two ``"aiven_flink_table"``
 resources are created - a **source** and a **sink** with a specified schema. Once the Terraform script is run, an Apache Flink job is started that copies data from the **source** Flink table to the **sink** Flink 
 table where the ``usage`` threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -25,8 +25,8 @@ Before looking at the Terraform script, let's visually realize how the services 
 
 If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
 
-Imagine that you are collecting CPU usages for hundreds of machines in your data centre and these metrics are populated in an Apache Kafka topic called **source**. But you're interested to learn about those machines with CPU usages higher than 85%.
-For this, you'd like to run an Apache Flink job and write the filtered messaged into a topic called **sink**. The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job and two Apache Flink tables. 
+Imagine that you are collecting CPU usage for hundreds of machines in your data centre and these metrics are populated in an Apache Kafka topic called **source_topic**. But you're interested in learning about those machines with CPU usages higher than 85%.
+For this, you'd like to run an Apache Flink job and write the filtered messages into a topic called **sink_topic**. The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job, and two Apache Flink tables. 
 
 ``services.tf`` file:
 

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -1,112 +1,128 @@
-Add the power of Apache Flink® to Apache Kafka® for stateful stream processing
-==============================================================================
+Apache Kafka as source and sink for Apache Flink job
+====================================================
 
-Whether it's an event-driven application or a data pipeline, Apache Flink® is an excellent choice due to its ability to perform computations at in-memory speed and at any scale. 
-We can use Apache Kafka® as a highly-available, fault-tolerant platform and leverage the power of Flink's stateful data transformations alongside. This example shows how to set up an Aiven for Apache Kafka
-with an Aiven for Apache Flink integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
+This example shows how to set up an Aiven for Apache Kafka® with an Aiven for Apache Flink® integration using the `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_.
+An Apache Kafka source topic is used as a data source, and Apache Flink processes the data to do filtering or transformation, and finally write the transformed output to a different target topic.
 
-Describe the setup
-------------------
+Let's cook!
+-----------
 
-The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration and  related resources. The parameters and configurations will vary for your case and you can find
-links to the advanced parameters as a reference at the end of this document.
+Before looking at the Terraform script, let's visually realize how the services will be connected:
 
+.. mermaid::
+
+   flowchart LR
+      subgraph Apache Kafka
+      SourceTopic
+      end
+      subgraph Apache Flink
+      SourceTopic-->|FlinkJob|FlinkSourceTable
+      FlinkSourceTable-->|Filter/Transform|FlinkTargetTable
+      end
+      subgraph Apache Kafka
+      FlinkTargetTable-->|FlinkJob|TargetTopic
+      end
+
+If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
+
+The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apacha Kafka topics, an Apache Flink job and two Apache Flink tables. 
 
 ``services.tf`` file:
 
 .. code:: bash
 
   resource "aiven_flink" "flink" {
-   project      = data.aiven_project.dev-advocates.project
-   cloud_name   = "google-europe-west1"
-   plan         = "business-8"
-   service_name = "demo-flink"
+    project      = var.project_name
+    cloud_name   = "google-europe-west1"
+    plan         = "business-8"
+    service_name = "demo-flink"
   }
 
   resource "aiven_kafka" "kafka" {
-   project      = data.aiven_project.dev-advocates.project
-   cloud_name   = "google-europe-west1"
-   plan         = "business-8"
-   service_name = "demo-kafka"
+    project      = var.project_name
+    cloud_name   = "google-europe-west1"
+    plan         = "business-8"
+    service_name = "demo-kafka"
   }
 
   resource "aiven_service_integration" "flink_to_kafka" {
-   project                  = data.aiven_project.dev-advocates.project
-   integration_type         = "flink"
-   destination_service_name = aiven_flink.flink.service_name
-   source_service_name      = aiven_kafka.kafka.service_name
+    project                  = var.project_name
+    integration_type         = "flink"
+    destination_service_name = aiven_flink.flink.service_name
+    source_service_name      = aiven_kafka.kafka.service_name
   }
 
   resource "aiven_kafka_topic" "source" {
-   project      = data.aiven_project.dev-advocates.project
-   service_name = aiven_kafka.kafka.service_name
-   partitions   = 2
-   replication  = 3
-   topic_name   = "source_topic"
+    project      = var.project_name
+    service_name = aiven_kafka.kafka.service_name
+    partitions   = 2
+    replication  = 3
+    topic_name   = "source_topic"
   }
 
   resource "aiven_kafka_topic" "sink" {
-   project      = data.aiven_project.dev-advocates.project
-   service_name = aiven_kafka.kafka.service_name
-   partitions   = 2
-   replication  = 3
-   topic_name   = "sink_topic"
+    project      = var.project_name
+    service_name = aiven_kafka.kafka.service_name
+    partitions   = 2
+    replication  = 3
+    topic_name   = "sink_topic"
   }
 
   resource "aiven_flink_table" "source" {
-   project        = data.aiven_project.dev-advocates.project
-   service_name   = aiven_flink.flink.service_name
-   integration_id = aiven_service_integration.flink_to_kafka.integration_id
-   table_name     = "source_table"
-   kafka_topic    = aiven_kafka_topic.source.topic_name
-   schema_sql     = <<EOF
-    `cpu` INT,
-    `node` INT,
-    `occurred_at` TIMESTAMP(3) METADATA FROM 'timestamp',
-    WATERMARK FOR `occurred_at` AS `occurred_at` - INTERVAL '5' SECOND
-   EOF
+    project        = var.project_name
+    service_name   = aiven_flink.flink.service_name
+    integration_id = aiven_service_integration.flink_to_kafka.integration_id
+    table_name     = "source_table"
+    kafka_topic    = aiven_kafka_topic.source.topic_name
+    schema_sql = <<EOF
+      `cpu` INT,
+      `node` INT,
+      `occurred_at` TIMESTAMP(3) METADATA FROM 'timestamp',
+      WATERMARK FOR `occurred_at` AS `occurred_at` - INTERVAL '5' SECOND
+    EOF
   }
 
   resource "aiven_flink_table" "sink" {
-   project        = data.aiven_project.dev-advocates.project
-   service_name   = aiven_flink.flink.service_name
-   integration_id = aiven_service_integration.flink_to_kafka.integration_id
-   table_name     = "sink_table"
-   kafka_topic    = aiven_kafka_topic.sink.topic_name
-   schema_sql     = <<EOF
-     `cpu` INT,
-     `node` INT,
-     `occurred_at` TIMESTAMP(3)
-   EOF
+    project        = var.project_name
+    service_name   = aiven_flink.flink.service_name
+    integration_id = aiven_service_integration.flink_to_kafka.integration_id
+    table_name     = "sink_table"
+    kafka_topic    = aiven_kafka_topic.sink.topic_name
+    schema_sql     = <<EOF
+      `cpu` INT,
+      `node` INT,
+      `occurred_at` TIMESTAMP(3)
+    EOF
   }
 
   resource "aiven_flink_job" "flink_job" {
-   project      = data.aiven_project.dev-advocates.project
-   service_name = aiven_flink.flink.service_name
-   job_name     = "my_job"
-   table_ids = [
-     aiven_flink_table.source.table_id,
-     aiven_flink_table.sink.table_id
-   ]
-   statement = <<EOF
-     INSERT INTO ${aiven_flink_table.sink.table_name}
-     SELECT * FROM ${aiven_flink_table.source.table_name}
-     WHERE `cpu` > 70
-   EOF
+    project      = var.project_name
+    service_name = aiven_flink.flink.service_name
+    job_name     = "my_job"
+    table_ids = [
+      aiven_flink_table.source.table_id,
+      aiven_flink_table.sink.table_id
+    ]
+    statement = <<EOF
+      INSERT INTO ${aiven_flink_table.sink.table_name}
+      SELECT * FROM ${aiven_flink_table.source.table_name}
+      WHERE `cpu` > 70
+    EOF
   }
 
-
-The resource names are self-descriptive in terms of what they're doing. The resource ``"aiven_flink"`` creates an Aiven for Apache Flink resource with the project name, choice of cloud, an Aiven service plan, and
-a specified service name. Similarly, the ``"aiven_service_integration"`` resource creates the integration between Apache Kafka and the Apache Flink service. Two ``"aiven_flink_table"``
+The resource ``"aiven_flink"`` creates an Aiven for Apache Flink resource with the project name, choice of cloud, an Aiven service plan, and a specified service name. 
+``"aiven_kafka"`` resource creates an Apache Kafka cluster and two Apache Kafka topics (**source** and a **sink**) are created using the ``"aiven_kafka_topic"`` resource.
+Similarly, the ``"aiven_service_integration"`` resource creates the integration between Apache Kafka and the Apache Flink service. Two ``"aiven_flink_table"``
 resources are created - a **source** and a **sink** with a specified schema. Once the Terraform script is run, an Apache Flink job is started that copies data from the **source** Flink table to the **sink** Flink 
-table where the **cpu** threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
+table where the ``cpu`` threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
 called **sink**.
 
 More resources
 --------------
 
-You might find these related resources useful too:
+The parameters and configurations will vary for your case. Please refer below for Apache Kafka and Apache Flink advanced parameters, a related blog, and how to get started with Aiven Terraform Provider:
 
 - `Build a Streaming SQL Pipeline with Apache Flink® and Apache Kafka® <https://aiven.io/blog/build-a-streaming-sql-pipeline-with-flink-and-kafka>`_
+- `Set up your first Aiven Terraform project <https://developer.aiven.io/docs/tools/terraform/get-started.html>`_
 - `Advanced parameters for Aiven for Apache Kafka® <https://developer.aiven.io/docs/products/kafka/reference/advanced-params.html>`_
 - `Advanced parameters for Aiven for Apache Flink® <https://developer.aiven.io/docs/products/flink/reference/advanced-params.html>`_

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -25,7 +25,8 @@ Before looking at the Terraform script, let's visually realize how the services 
 
 If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
 
-The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job and two Apache Flink tables. 
+Imagine that you are collecting CPU usages for hundreds of machines in your data centre and these metrics are populated in an Apache Kafka topic called **source**. But you're interested to learn about those machines with CPU usages higher than 85%.
+For this, you'd like to run an Apache Flink job and write the filtered messaged into a topic called **sink**. The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job and two Apache Flink tables. 
 
 ``services.tf`` file:
 
@@ -114,7 +115,7 @@ The following Terraform script stands up both Apache Kafka and Apache Flink serv
         cpu,
         usage
       FROM ${aiven_flink_table.source.table_name}
-      WHERE usage > 70
+      WHERE usage > 85
     EOF
   }
 
@@ -125,7 +126,8 @@ resources are created - a **source** and a **sink** with a specified schema. Onc
 table where the ``usage`` threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
 called **sink**.
 
-To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="source-topic"`` (same topic name defined in the resource ``"aiven_kafka_topic" "source"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials. In the destination topic, defined in the resource ``"aiven_kafka_topic" "sink"``, you should see only data samples having ``usage`` above 70.
+To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="source-topic"`` (same topic name defined in the resource ``"aiven_kafka_topic" "source"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials.
+In the destination topic, defined in the resource ``"aiven_kafka_topic" "sink"``, you should see only data samples having ``usage`` above 85. A note that the fake data generates CPU usages higher than 70.
 
 More resources
 --------------

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -16,17 +16,17 @@ Before looking at the Terraform script, let's visually realize how the services 
       SourceTopic
       end
       subgraph Apache Flink
-      SourceTopic-->|FlinkJob|FlinkSourceTable
+      SourceTopic-->|FlinkTableMapping|FlinkSourceTable
       FlinkSourceTable-->|Filter/Transform|FlinkTargetTable
       end
       subgraph Apache Kafka
-      FlinkTargetTable-->|FlinkJob|SinkTopic
+      FlinkTargetTable-->|FlinkTableMapping|SinkTopic
       end
 
 If you relate the above diagram to the following example, both source and target Apache Kafka topics are part of the same Apache Kafka cluster.
 
-Imagine that you are collecting CPU usage for hundreds of machines in your data centre and these metrics are populated in an Apache Kafka topic called **source_topic**. But you're interested in learning about those machines with CPU usages higher than 85%.
-For this, you'd like to run an Apache Flink job and write the filtered messages into a topic called **sink_topic**. The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job, and two Apache Flink tables. 
+Imagine that you are collecting CPU usage for hundreds of machines in your data centre and these metrics are populated in an Apache Kafka topic called **cpu_measurements**. But you're interested in learning about those machines with CPU usages higher than 85%.
+For this, you'd like to run an Apache Flink job and write the filtered messages into a topic called **cpu_high_usage**. The following Terraform script stands up both Apache Kafka and Apache Flink services, creates the service integration, source and target Apache Kafka topics, an Apache Flink job, and two Apache Flink tables. 
 
 ``services.tf`` file:
 
@@ -58,7 +58,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     service_name = aiven_kafka.kafka.service_name
     partitions   = 2
     replication  = 3
-    topic_name   = "source_topic"
+    topic_name   = "iot_measurements"
   }
 
   resource "aiven_kafka_topic" "sink" {
@@ -66,7 +66,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     service_name = aiven_kafka.kafka.service_name
     partitions   = 2
     replication  = 3
-    topic_name   = "sink_topic"
+    topic_name   = "cpu_high_usage"
   }
 
   resource "aiven_flink_table" "source" {
@@ -120,13 +120,13 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
   }
 
 The resource ``"aiven_flink"`` creates an Aiven for Apache Flink resource with the project name, choice of cloud, an Aiven service plan, and a specified service name. 
-``"aiven_kafka"`` resource creates an Apache Kafka cluster and two Apache Kafka topics (**sourc_topice** and a **sink_topic**) are created using the ``"aiven_kafka_topic"`` resource.
+``"aiven_kafka"`` resource creates an Apache Kafka cluster and two Apache Kafka topics (**cpu_measurements** and a **cpu_high_usage**) are created using the ``"aiven_kafka_topic"`` resource.
 Similarly, the ``"aiven_service_integration"`` resource creates the integration between Apache Kafka and the Apache Flink service. Two ``"aiven_flink_table"``
 resources are created - a **source** and a **sink** with a specified schema. Once the Terraform script is run, an Apache Flink job is started that copies data from the **source** Flink table to the **sink** Flink 
 table where the ``usage`` threshold is over a certain limit. The data originates at the resource ``"aiven_kafka_topic"`` called **source** and the processed data is put into another resource ``"aiven_kafka_topic"`` 
 called **sink**.
 
-To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="source-topic"`` (same topic name defined in the resource ``"aiven_kafka_topic" "source"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials.
+To test the data streaming pipeline, you can use the `fake data producer for Apache Kafka on Docker <https://github.com/aiven/fake-data-producer-for-apache-kafka-docker>`_ making sure that in the ``conf/env.conf`` file you specify ``TOPIC="cpu_measurements"`` (same topic name defined in the resource ``"aiven_kafka_topic" "source"``) and ``SUBJECT="metric"`` together with the appropriate project name, service name and required credentials.
 In the destination topic, defined in the resource ``"aiven_kafka_topic" "sink"``, you should see only data samples having ``usage`` above 85. A note that the fake data generates CPU usages higher than 70.
 
 More resources


### PR DESCRIPTION
# What changed, and why it matters

resolves https://github.com/aiven/devportal/issues/883

## Feedback requested:

- Please run the Terraform code and ensure that it works (I did multiple times and works from my end)
- **source** and **sink** names are used both for Kafka topics and Flink tables. Should we have distinct naming?
- I tried to write the paragraph just below the code block to describe what's happening in this setup. Please let me know if you'd like this paragraph to be above the code block
- The explanation of the setup - is it accurate or did I miss anything?
- Did I miss anything according to the DevPortal style guide? I'm a bit confused with the Terraform resources which I wrote like literals with double-quotes inside ``"aiven_service_integration"``
- The learner might be confused to see ``data.aiven_project.dev-advocates.project`` and use the value without changing. Do you suggest I use something like ``data.aiven_project.[YOUR-PROJECT-NAME].project``?
- Anything else that you find would improve this recipe


