### PR TITLE
Add details around backups and link to tools for "self service"

### DIFF
--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -103,3 +103,20 @@ Aiven for InfluxDB®
 '''''''''''''''''''
 We offer backups that are taken every 12 hours with 2.5 days of retention. 
 We automatically backup InfluxDB®, encrypt it and then upload it to our S3 account in the same region. When an instance has to be rebuilt, we download the backup and restore it to create the new instance.
+
+
+Access to backups
+'''''''''''''''''
+The Aiven platform provides a centralised, managed platform for the services outlined above to run across many different cloud providers and regions. Tooling that we have built to provide these backups are open source and available for you to use in your own infrastructure. 
+
+The nature of the Aiven platform is to manage the operational tasks of running complex software at scale so that you are able to focus your efforts on using the services, not maintaining them. This means that we take care of the availability, security, connectivity and backups.
+Access to backups of your services are not possible. The backups are encrypted and stored in object storage. If you do need to backup your services, this can be done with the standard tooling for that service. Below, we provide a list of the backup tools used for each service type.
+
+Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
+
+- `PostgreSQL: pgdump <https://www.postgresql.org/docs/14/app-pgdump.html>`
+- `MySQL: mysqldump <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`
+- `Redis: redis-cli <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`
+- `Cassandra: cqlsh <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`
+- `OpenSearch: elasticdump <https://github.com/elasticsearch-dump/elasticsearch-dump>`
+- `InfluxDB: influxd <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -114,20 +114,9 @@ Access to backups of your services is not possible. The backups are encrypted an
 
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 
-.. |pgdump| replace:: ``pgdump``
-.. _`pgdump`: https://www.postgresql.org/docs/14/app-pgdump.html
-.. |redis-cli| replace:: ``redis-cli``
-.. _`redis-cli`: https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files
-.. |cqlsh| replace:: ``cqlsh``
-.. _`cqlsh`: https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html
-.. |elasticdump| replace:: ``elasticdump``
-.. _`elasticdump`: https://github.com/elasticsearch-dump/elasticsearch-dump
-.. |influxd| replace:: ``influxd``
-.. _`influxd`: https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/
-
-- PostgreSQL: pgdump
-- MySQL: mysqldump
-- Redis: redis-cli
-- Cassandra: cqlsh
-- OpenSearch: elasticdump
-- InfluxDB: influxd
+- PostgreSQL: ``pgdump``, see `dedicated documentation <https://www.postgresql.org/docs/14/app-pgdump.html>`_
+- MySQL: ``mysqldump``, see `dedicated documentation <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_ 
+- Redis: ``redis-cli``, see `dedicated documentation <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_
+- Cassandra: ``cqlsh``, see `dedicated documentation <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_
+- OpenSearch: ``elasticdump``, see `dedicated GitHub repository <https://github.com/elasticsearch-dump/elasticsearch-dump>`_
+- InfluxDB: ``influxd``, see `dedicated documentation <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`_

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -114,9 +114,9 @@ Access to backups of your services is not possible. The backups are encrypted an
 
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 
-- PostgreSQL: ``pgdump``, see `dedicated documentation <https://www.postgresql.org/docs/14/app-pgdump.html>`_
-- MySQL: ``mysqldump``, see `dedicated documentation <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_ 
-- Redis: ``redis-cli``, see `dedicated documentation <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_
-- Cassandra: ``cqlsh``, see `dedicated documentation <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_
-- OpenSearch: ``elasticdump``, see `dedicated GitHub repository <https://github.com/elasticsearch-dump/elasticsearch-dump>`_
-- InfluxDB: ``influxd``, see `dedicated documentation <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`_
+- `PostgreSQL <https://www.postgresql.org/docs/14/app-pgdump.html>`__: ``pgdump``
+- `MySQL <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_: ``mysqldump``
+- `Redis <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_: ``redis-cli`` 
+- `Cassandra <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_: ``cqlsh`` 
+- `OpenSearch <https://github.com/elasticsearch-dump/elasticsearch-dump>`_: ``elasticdump``
+- `InfluxDB <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`_: ``influxd``

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -114,9 +114,9 @@ Access to backups of your services is not possible. The backups are encrypted an
 
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 
-- `PostgreSQL: pgdump <https://www.postgresql.org/docs/14/app-pgdump.html>`
-- `MySQL: mysqldump <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`
-- `Redis: redis-cli <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`
-- `Cassandra: cqlsh <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`
-- `OpenSearch: elasticdump <https://github.com/elasticsearch-dump/elasticsearch-dump>`
-- `InfluxDB: influxd <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`
+- PostgreSQL: `pgdump <https://www.postgresql.org/docs/14/app-pgdump.html>`_
+- MySQL: `mysqldump <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_
+- Redis: `redis-cli <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_
+- Cassandra: `cqlsh <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_
+- OpenSearch: `elasticdump <https://github.com/elasticsearch-dump/elasticsearch-dump>`_
+- InfluxDB: `influxd <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`_

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -115,11 +115,19 @@ Access to backups of your services is not possible. The backups are encrypted an
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 
 .. |pgdump| replace:: ``pgdump``
-.. _`pgdump`: https://www.postgresql.org/docs/14/app-pgdump.htm
+.. _`pgdump`: https://www.postgresql.org/docs/14/app-pgdump.html
+.. |redis-cli| replace:: ``redis-cli``
+.. _`redis-cli`: https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files
+.. |cqlsh| replace:: ``cqlsh``
+.. _`cqlsh`: https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html
+.. |elasticdump| replace:: ``elasticdump``
+.. _`elasticdump`: https://github.com/elasticsearch-dump/elasticsearch-dump
+.. |influxd| replace:: ``influxd``
+.. _`influxd`: https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/
 
 - PostgreSQL: pgdump
-- MySQL: `mysqldump <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_
-- Redis: `redis-cli <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_
-- Cassandra: `cqlsh <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_
-- OpenSearch: `elasticdump <https://github.com/elasticsearch-dump/elasticsearch-dump>`_
-- InfluxDB: `influxd <https://docs.influxdata.com/influxdb/v1.8/tools/influx-cli/>`_
+- MySQL: mysqldump
+- Redis: redis-cli
+- Cassandra: cqlsh
+- OpenSearch: elasticdump
+- InfluxDB: influxd

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -110,7 +110,7 @@ Access to backups
 The Aiven platform provides a centralised, managed platform for the services outlined above to run across many different cloud providers and regions. Tooling that we have built to provide these backups are open source and available for you to use in your own infrastructure. 
 
 The nature of the Aiven platform is to manage the operational tasks of running complex software at scale so that you are able to focus your efforts on using the services, not maintaining them. This means that we take care of the availability, security, connectivity and backups.
-Access to backups of your services are not possible. The backups are encrypted and stored in object storage. If you do need to backup your services, this can be done with the standard tooling for that service. Below, we provide a list of the backup tools used for each service type.
+Access to backups of your services is not possible. The backups are encrypted and stored in object storage. If you do need to backup your services, this can be done with the standard tooling for that service. Below, we provide a list of the backup tools used for each service type.
 
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -114,7 +114,10 @@ Access to backups of your services is not possible. The backups are encrypted an
 
 Please note that these tools are merely recommendations and not intended to create a snapshot of your Aiven service; purely to provide access to the data.
 
-- PostgreSQL: `pgdump <https://www.postgresql.org/docs/14/app-pgdump.html>`_
+.. |pgdump| replace:: ``pgdump``
+.. _`pgdump`: https://www.postgresql.org/docs/14/app-pgdump.htm
+
+- PostgreSQL: pgdump
 - MySQL: `mysqldump <https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html>`_
 - Redis: `redis-cli <https://redis.io/docs/manual/cli/#remote-backups-of-rdb-files>`_
 - Cassandra: `cqlsh <https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlshCopy.html>`_


### PR DESCRIPTION
# What changed, and why it matters

add clarification around backups and that we do not provide access, with links to standard tools that do allow exporting of data in common formats from the services we run.
