### PR TITLE
Add alt text for images

### DIFF
--- a/docs/platform/howto/change-your-email-address.rst
+++ b/docs/platform/howto/change-your-email-address.rst
@@ -21,9 +21,11 @@ Step by step:
 3. Click "Send Invitation"
 
 .. image:: /images/platform/invite-member.png
+   :alt: Specify email address of user to invite and their role
 
 Your new email address will receive an invitation to create an Aiven account which will then have access to the project. You need to do this for each of your projects. If your projects are managed by another user as part of an organization, then you may need to ask the administrator of those projects to add your new account and remove your old one.
 
 Once you have confirmed, your new account has correct privileges, you can remove your old email account from each of your projects by clicking on "Remove user":
 
 .. image:: /images/platform/remove-user.png
+   :alt: The "Remove user" button is at the right of each Member entry


### PR DESCRIPTION
The images on the page at https://developer.aiven.io/docs/platform/howto/change-your-email-address.html did not have `alt` text for their images. This causes errors form vale (using `make lint`):
```
 docs/platform/howto/change-your-email-address.rst
 29:41  warning  'png' does not seem to be a     Aiven.aiven_spelling
                 recognised word
```
This is a known problem. The workaround is to add the `:alt:` data.

