### PR TITLE
Update Redis maxclients for maximum connections

### DIFF
--- a/docs/products/redis/howto/estimate-max-number-of-connections.rst
+++ b/docs/products/redis/howto/estimate-max-number-of-connections.rst
@@ -18,3 +18,10 @@ where ``m`` represents the memory in megabytes. With at least 10,000 connections
 .. note::
     
     Make sure to convert the memory figure ``m`` to megabytes.
+
+
+This number is estimated by the exact available memory so it varies between different plans and cloud providers, to see the exact maximum connections allowed, use * :doc:`redis-cli <./connect-redis-cli>` and ``info`` command as the following:
+
+.. code-block::
+
+    echo "info" | redis-cli -u REDIS_URI | grep maxclients


### PR DESCRIPTION
Updated Redis documentation to state this number is an estimated number based on memory avaiable, using CLI example to see the exact maximum connections number.