### PR TITLE
Organised Platform -> Howtos in categories

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -24,26 +24,39 @@ entries:
     - file: docs/platform/howto
       title: HowTo
       entries:
-      - file: docs/platform/howto/create_new_service
-      - file: docs/platform/howto/create_new_service_user
-      - file: docs/platform/howto/create_authentication_token
-      - file: docs/platform/howto/change-your-email-address
-      - file: docs/platform/howto/enable-aiven-password
-      - file: docs/platform/howto/disable-user-2fa
-      - file: docs/platform/howto/download-ca-cert
-      - file: docs/platform/howto/console-fork-service.rst
-      - file: docs/platform/howto/tag-resources.rst
-      - file: docs/platform/howto/pause-from-cli.rst
-      - file: docs/platform/howto/public-access-in-vpc.rst
-      - file: docs/platform/howto/private-ip-resolution.rst
-      - file: docs/platform/howto/add-storage-space
-      - file: docs/platform/howto/restrict-access
-      - file: docs/platform/howto/scale-services
-      - file: docs/platform/howto/migrate-services
-      - file: docs/platform/howto/monitoring-services
-      - file: docs/platform/howto/integrations/prometheus-metrics
-      - file: docs/platform/howto/integrations/datadog-increase-metrics-limit
-      - file: docs/platform/howto/static-ip-addresses.rst
+      - file: docs/platform/howto/list-user
+        title: User/Access management
+        entries:
+          - file: docs/platform/howto/change-your-email-address
+          - file: docs/platform/howto/create_authentication_token
+          - file: docs/platform/howto/create_new_service_user
+          - file: docs/platform/howto/enable-aiven-password
+          - file: docs/platform/howto/disable-user-2fa            
+      - file: docs/platform/howto/list-service
+        title: Service management
+        entries:
+          - file: docs/platform/howto/create_new_service
+          - file: docs/platform/howto/console-fork-service.rst
+          - file: docs/platform/howto/pause-from-cli.rst
+          - file: docs/platform/howto/scale-services
+          - file: docs/platform/howto/migrate-services
+          - file: docs/platform/howto/add-storage-space
+          - file: docs/platform/howto/tag-resources.rst
+      - file: docs/platform/howto/list-network
+        title: Network management
+        entries:
+          - file: docs/platform/howto/download-ca-cert
+          - file: docs/platform/howto/restrict-access
+          - file: docs/platform/howto/public-access-in-vpc.rst
+          - file: docs/platform/howto/static-ip-addresses.rst
+          - file: docs/platform/howto/private-ip-resolution.rst
+      - file: docs/platform/howto/list-monitoring
+        title: Monitoring management
+        entries:
+          - file: docs/platform/howto/monitoring-services
+          - file: docs/platform/howto/integrations/prometheus-metrics
+          - file: docs/platform/howto/integrations/datadog-increase-metrics-limit
+      
     - file: docs/platform/reference
       title: Reference
       entries:

--- a/docs/platform/howto/create_new_service.rst
+++ b/docs/platform/howto/create_new_service.rst
@@ -1,5 +1,5 @@
-﻿Create a new Aiven service
-==========================
+﻿Create a new service
+====================
 
 You can add services for the various Aiven products in the Aiven web console.
 

--- a/docs/platform/howto/list-monitoring.rst
+++ b/docs/platform/howto/list-monitoring.rst
@@ -1,0 +1,4 @@
+Monitoring
+==================
+
+.. tableofcontents::

--- a/docs/platform/howto/list-network.rst
+++ b/docs/platform/howto/list-network.rst
@@ -1,0 +1,4 @@
+Network tasks
+=============
+
+.. tableofcontents::

--- a/docs/platform/howto/list-service.rst
+++ b/docs/platform/howto/list-service.rst
@@ -1,0 +1,4 @@
+Service management
+==================
+
+.. tableofcontents::

--- a/docs/platform/howto/list-user.rst
+++ b/docs/platform/howto/list-user.rst
@@ -1,0 +1,4 @@
+User/authentication management
+==============================
+
+.. tableofcontents::

--- a/docs/platform/howto/pause-from-cli.rst
+++ b/docs/platform/howto/pause-from-cli.rst
@@ -1,5 +1,5 @@
-How to pause or terminate your service
-======================================
+Pause or terminate your service
+===============================
 
 One of the nice things about cloud services is that they can be created and destroyed easily, or just paused while you aren't using them so that you aren't being charged (or using up your trial credits).
 

--- a/docs/platform/howto/restrict-access.rst
+++ b/docs/platform/howto/restrict-access.rst
@@ -1,5 +1,5 @@
-Restricting access to your service
-==================================
+Restrict network access to your service
+=======================================
 
 It is possible to restrict access to your service to a single IP, and address block, or any combination of both. By default the service is publicly accessible.
 

--- a/docs/platform/howto/scale-services.rst
+++ b/docs/platform/howto/scale-services.rst
@@ -1,5 +1,5 @@
-Scaling services
-================
+Scale your service
+==================
 
 When creating a new Aiven service, you are not tied to a plan. Your services can be adjusted to better match your needs. Services can be moved to a higher or lower plan, and to a different tier—Startup, Business or Premium.
 


### PR DESCRIPTION
# What changed, and why it matters

This PR aims at creating subcategories for the Platform HowTo section of the devportal. 
While changing the organisation I also amended some titles to be consistent

Fixes #915


