### PR TITLE
Add OpenSearch and available options for service forking

### DIFF
--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -20,6 +20,7 @@ You can fork the following Aiven services:
 - Redis™*
 - Apache Cassandra® (Limitation: you cannot fork to a lower amount of nodes)
 - Elasticsearch
+- OpenSearch®
 - InfluxDB®
 - M3DB
 - Grafana®

--- a/docs/platform/howto/console-fork-service.rst
+++ b/docs/platform/howto/console-fork-service.rst
@@ -24,10 +24,15 @@ Fork a service using the Aiven client (CLI)
 
 1. Prepare the command to create a new service, this will contain the new copy of your data store.
 
-2. Add the ``service_to_fork_from`` parameter to specify the service to use as the source. For example, if you want to create a fork of your ``forker`` service, and name it ``forked``, the command would be something like::
+2. Add the ``service_to_fork_from`` parameter to specify the service to use as the source. 
+Change service type accordingly with ``-t``, run the following command to see available options::
+
+    avn service types        
+
+For example, if you want to create a fork of your ``forker`` PostgreSQL® service, and name it ``forked``, the command would be something like::
 
     avn service create forked -t pg --plan business-4 -c service_to_fork_from=forker
-
+    
 You have now copied your Aiven service.
 
 You can now apply any integrations you may need for the copy.

--- a/docs/products/clickhouse/sample-dataset.rst
+++ b/docs/products/clickhouse/sample-dataset.rst
@@ -20,7 +20,7 @@ Download the original dataset directly from `the dataset documentation page <htt
 .. note::
     The ``nproc`` Linux command, which prints the number of processing units, is not available on macOS. To use the above command, add an alias for ``nproc`` into your  ``~/.zshrc`` file: ``alias nproc="sysctl -n hw.logicalcpu"``.
 
-This command allows you to download and extract data from the URLs specified in the `ClickHouse documentation <https://clickhouse.com/docs/en/getting-started/example-datasets/metrica/#obtaining-tables-from-compressed-tsv-file>`_.
+This command allows you to download and extract data from the URLs specified in the `ClickHouse documentation <https://clickhouse.com/docs/en/getting-started/example-datasets/metrica/#download-the-visits-compressed-tsv-file>`_.
 
 Once done, you should have two files available: ``hits_v1.tsv`` and ``visits_v1.tsv``.
 
@@ -44,7 +44,7 @@ To connect to the server, use the connection details that you can find in the *C
 Create tables
 ---------------
 
-The next step is to add a new table to your newly created database. The ClickHouse documentation includes a sample ``CREATE TABLE`` command with `the recommended table structure <https://clickhouse.com/docs/en/getting-started/example-datasets/metrica/#obtaining-tables-from-compressed-tsv-file>`_.
+The next step is to add a new table to your newly created database. The ClickHouse documentation includes a sample ``CREATE TABLE`` command with `the recommended table structure <https://clickhouse.com/docs/en/getting-started/example-datasets/metrica/#download-the-visits-compressed-tsv-file>`_.
 
 To use the command through Docker, run the following commands to create the tables for both ``hits_v1`` and ``visits_v1``::
 


### PR DESCRIPTION
Add OpenSearch and available options for service forking
- OpenSearch was missing from the service forking documentation
- Added available service types for avn cli
