### PR TITLE
Fixing canonical for index pages

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -3,7 +3,11 @@
 {%- block extrahead %}
 {{ super() }}
 
-<link rel="canonical" href="https://developer.aiven.io/{{ pagename }}" />
+
+<link rel="canonical" href="https://developer.aiven.io/{% if '{}'.format(pagename).split('/')[-1] == 'index' %}{{ pagename | replace('/index','') }}{% else %}{{ pagename }}{% endif %}" />
+<!-- The replace('/index/','') was done to make google happy with index page canonicals -->
+
+
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
 
 <!-- Twitter Cards -->

--- a/_templates/base.html
+++ b/_templates/base.html
@@ -6,6 +6,7 @@
 
 <link rel="canonical" href="https://developer.aiven.io/{% if '{}'.format(pagename).split('/')[-1] == 'index' %}{{ pagename | replace('/index','') }}{% else %}{{ pagename }}{% endif %}" />
 <!-- The replace('/index/','') was done to make google happy with index page canonicals -->
+<!-- The '{}'.format(pagename).split('/')[-1] == 'index'  extracts the page name from the full page url and checks if the name matches 'index' -->
 
 
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">


### PR DESCRIPTION
# What changed, and why it matters

We have been reported that devportal index pages create canonical links that are not working therefore being asked to remove the `index` part from the canonical. This PR is an attempt to do it
