### PR TITLE
How to enable Karapace for Kafka

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -165,6 +165,7 @@ entries:
             title: Administration tasks
             entries:
               - file: docs/products/kafka/howto/best-practices
+              - file: docs/products/kafka/howto/enable-karapace
               - file: docs/products/kafka/howto/configure-with-kafka-cli
               - file: docs/products/kafka/howto/set-kafka-parameters
               - file: docs/products/kafka/howto/viewing-resetting-offset

--- a/docs/products/kafka/howto/enable-karapace.rst
+++ b/docs/products/kafka/howto/enable-karapace.rst
@@ -1,0 +1,18 @@
+Use Karapace with Aiven for Apache Kafka®
+=========================================
+
+Karapace is an Aiven-built open source tool that adds quality-of-life improvements to your Aiven for Apache Kafka® service. It consists of both a schema registry, and a REST API; all Aiven for Apache Kafka services support either of both of these features if you want to use them.
+
+Enable Karapace on Aiven for Apache Kafka
+-----------------------------------------
+
+1. Visit the service overview page for the service, and look for the two configuration settings for Karapace.
+
+2. Enable either or both of the REST API and Schema Registry settings in the web console.
+
+.. tip::
+
+   If you are using any of our automation or other integrations, the parameters to enable these on your service are named ``schema_registry`` and ``kafka_rest``.
+
+3. Visit the `Karapace homepage <https://karapace.io>`_ and `GitHub project <https://github.com/aiven/karapace>`_ to learn more about the features of Karapace.
+

--- a/docs/products/kafka/howto/enable-karapace.rst
+++ b/docs/products/kafka/howto/enable-karapace.rst
@@ -6,7 +6,7 @@ Karapace is an Aiven-built open source tool that adds quality-of-life improvemen
 Enable Karapace on Aiven for Apache Kafka
 -----------------------------------------
 
-1. Visit the service overview page for the service, and look for the two configuration settings for Karapace.
+1. In the `Aiven Console <https://console.aiven.io/>`_, visit the service overview page for the service, and look for the two configuration settings for Karapace.
 
 2. Enable either or both of the REST API and Schema Registry settings in the web console.
 


### PR DESCRIPTION
# What changed, and why it matters

We had a question from a customer about whether they had to run Karapace themselves, because they couldn't find what they needed. Adding a document that explains that Karapace is already included with a Kafka service, covers how to turn it on, and signposts the main project documentation (which itself is a work in progress, but we'll keep most Karapace docs there rather than here).
