### PR TITLE
platform: add reference tab

### DIFF
--- a/docs/platform/index.rst
+++ b/docs/platform/index.rst
@@ -22,9 +22,12 @@ Learn more about the Aiven platform
 
 .. panels::
 
-    📙 :doc:`concepts`
+    📚 :doc:`Concepts <concepts>`
 
     ---
 
-    💻 :doc:`howto`
+    💻 :doc:`HowTo <howto>`
 
+    ---
+
+    📖 :doc:`Reference <reference>`


### PR DESCRIPTION
platform: add missing reference tab

this way the user can navigate to reference section from the main page

fixes: https://github.com/aiven/devportal/issues/840