### PR TITLE
Migrate Datadog custom metrics for Kafka

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -201,6 +201,7 @@ entries:
             entries:
               - file: docs/products/kafka/howto/integrate-service-logs-into-kafka-topic
               - file: docs/products/kafka/howto/kafka-streams-with-aiven-for-kafka
+              - file: docs/products/kafka/howto/datadog-customised-metrics
           - file: docs/products/kafka/howto/list-topic-schema
             title: Topic/schema management
             entries:

--- a/docs/integrations/datadog/datadog-metrics.rst
+++ b/docs/integrations/datadog/datadog-metrics.rst
@@ -37,6 +37,10 @@ Repeat these steps for each service whose metrics should be sent to Datadog.
 
 6. From the list, choose which Datadog integration to use, then select **Enable**.
 
+.. Tip::
+
+    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`
+
 7. Return to your Datadog dashboard and after a few minutes, you should see the data start to arrive from your Aiven service(s).
 
 .. seealso:: Learn more about :doc:`/docs/integrations/datadog/index`.

--- a/docs/integrations/datadog/datadog-metrics.rst
+++ b/docs/integrations/datadog/datadog-metrics.rst
@@ -39,7 +39,7 @@ Repeat these steps for each service whose metrics should be sent to Datadog.
 
 .. Tip::
 
-    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`
+    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`.
 
 7. Return to your Datadog dashboard and after a few minutes, you should see the data start to arrive from your Aiven service(s).
 

--- a/docs/integrations/datadog/index.rst
+++ b/docs/integrations/datadog/index.rst
@@ -10,6 +10,10 @@ You can send the metrics from any or all of your Aiven services to Datadog. The 
 
 Find out :doc:`how to send your Aiven service metrics to Datadog </docs/integrations/datadog/datadog-metrics>`.
 
+.. Tip::
+
+    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`
+
 Datadog for logs
 ----------------
 

--- a/docs/integrations/datadog/index.rst
+++ b/docs/integrations/datadog/index.rst
@@ -12,7 +12,7 @@ Find out :doc:`how to send your Aiven service metrics to Datadog </docs/integrat
 
 .. Tip::
 
-    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`
+    If you're using Aiven for Apache Kafka® you can also :doc:`customise the metrics sent to Datadog </docs/product/kafka/howto/datadog-customised-metrics>`.
 
 Datadog for logs
 ----------------

--- a/docs/products/kafka/howto/datadog-customised-metrics.rst
+++ b/docs/products/kafka/howto/datadog-customised-metrics.rst
@@ -44,7 +44,7 @@ To customise the metrics sent to Datadog, you can use the ``service integration-
 
 .. Tip:: 
 
-    By default all topics are included
+    By default, all topics are included.
 
 * ``exclude_topics``: defining the comma separated list of topics to exclude
 * ``include_consumer_groups``: defining the comma separated list of consumer groups to include
@@ -60,3 +60,4 @@ As example to sent the ``kafka.log.log_size`` and ``kafka.log.log_end_offset`` m
 
 Once the update is successful and metrics have been collected and pushed, you should see them in your Datadog explorer.
 
+.. seealso:: Learn more about :doc:`/docs/integrations/datadog/index`.

--- a/docs/products/kafka/howto/datadog-customised-metrics.rst
+++ b/docs/products/kafka/howto/datadog-customised-metrics.rst
@@ -1,0 +1,62 @@
+Configure Apache Kafka® metrics sent to Datadog
+-----------------------------------------------
+
+When creating a :doc:`Datadog service integration </docs/integrations/datadog/datadog-metrics>`, you can customise which metrics are sent to the Datadog endpoint using the :doc:`Aiven CLI </docs/tools/cli>`.
+
+For each Apache Kafka® topic and partition, the following metrics are currently supported:
+
+* ``kafka.log.log_size``
+* ``kafka.log.log_start_offset``
+* ``kafka.log.log_end_offset``
+
+.. Tip::
+
+    All the above metrics are tagged with ``topic`` and ``partition`` allowing you to monitor each topic and partition independently.
+
+Variables
+---------
+
+These are the placeholders you will need to replace in the code samples. 
+
+==================     ============================================================================
+Variable               Description
+==================     ============================================================================
+``SERVICE_NAME``       Aiven for Apache Kafka® service name
+------------------     ----------------------------------------------------------------------------
+``INTEGRATION_ID``     ID of the integration between the Aiven for Apache Kafka service and Datadog
+==================     ============================================================================
+
+.. Tip::
+    
+    The ``INTEGRATION_ID`` parameter can be found by issuing::
+        
+        avn service integration-list SERVICE_NAME
+
+Customise Apache Kafka® metrics sent to Datadog
+-----------------------------------------------
+
+Before customising the metrics, make sure that you have a Datadog endpoint configured and enabled in your Aiven for Apache Kafka service. For details on how to set up the Datadog integration, check the :doc:`dedicated article </docs/integrations/datadog/datadog-metrics>`.
+
+To customise the metrics sent to Datadog, you can use the ``service integration-update`` passing the following customised parameters:
+
+* ``kafka_custom_metrics``: defining the comma separated list of custom metrics to include (within ``kafka.log.log_size``, ``kafka.log.log_start_offset`` and ``kafka.log.log_end_offset``)
+* ``include_topics``: defining the comma separated list of topics to include
+
+.. Tip:: 
+
+    By default all topics are included
+
+* ``exclude_topics``: defining the comma separated list of topics to exclude
+* ``include_consumer_groups``: defining the comma separated list of consumer groups to include
+* ``exclude_consumer_groups``: defining the comma separated list of consumer groups to include
+
+
+As example to sent the ``kafka.log.log_size`` and ``kafka.log.log_end_offset`` metrics for ``topic1`` and ``topic2`` execute the following code::
+
+    avn service integration-update                                          \
+        -c kafka_custom_metrics=kafka.log.log_size,kafka.log.log_end_offset \
+        -c include_topics=topic1,topic2                                     \
+        INTEGRATION_ID
+
+Once the update is successful and metrics have been collected and pushed, you should see them in your Datadog explorer.
+

--- a/docs/products/kafka/howto/datadog-customised-metrics.rst
+++ b/docs/products/kafka/howto/datadog-customised-metrics.rst
@@ -1,5 +1,5 @@
 Configure Apache Kafka® metrics sent to Datadog
------------------------------------------------
+===============================================
 
 When creating a :doc:`Datadog service integration </docs/integrations/datadog/datadog-metrics>`, you can customise which metrics are sent to the Datadog endpoint using the :doc:`Aiven CLI </docs/tools/cli>`.
 


### PR DESCRIPTION
# What changed, and why it matters

Source: https://help.aiven.io/en/articles/3359501-configuring-datadog-metrics-with-aiven-for-apache-kafka

Fixes #1024

