### PR TITLE
Manage Kafka Connect Logging levels

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -266,6 +266,8 @@ entries:
             - file: docs/products/kafka/kafka-connect/howto/bring-your-own-kafka-connect-cluster
             - file: docs/products/kafka/kafka-connect/howto/enable-connect
             - file: docs/products/kafka/kafka-connect/howto/enable-automatic-restart
+            - file: docs/products/kafka/kafka-connect/howto/manage-logging-level
+              title: Manage Kafka Connect logging level
           - file: docs/products/kafka/kafka-connect/howto/list-source-connectors
             entries:
             - file: docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -3,7 +3,7 @@ Manage Apache Kafka® Connect logging level
 
 During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue, while other times the information provided just isn't enough to work with.
 
-Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__.
+It is possible to get access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__.
 
 .. Warning::
 
@@ -62,7 +62,7 @@ The output should be similar to the following
 
     The previous command shows the standard list of loggers (``org.apache.zookeeper``, ``org.reflections`` and ``root``) and any loggers for which the logging level has been already modified.
     
-    Therefore, if you have not previously set a custom logging level for a connector's logger class, the related logger level information will not be visible in the list, even if that connector is currently running in the Kafka Connect cluster. The next section describes how to change the logging level of a particular logger.
+    This means that if you have not previously set a custom logging level for a connector's logger class, the related logger level information will not be visible in the list, even if that connector is currently running in the Kafka Connect cluster. The next section describes how to change the logging level of a particular logger.
 
 Change the logging level for a particular logger
 ''''''''''''''''''''''''''''''''''''''''''''''''
@@ -108,7 +108,8 @@ Get the connector class name
 
 Loggers are Java objects which trigger log events, and each log message produced by the application is sent to a specific logger. Loggers are arranged in hierarchies, for example the logger ``io.debezium.connector.postgresql.PostgresConnector`` is a child of the logger ``io.debezium.connector.postgresql``. When you define the logging level of a logger using the commands above, the logging level will be set for that logger and all of its children in the logger hierarchy.
 
-By convention, loggers have the same name as the corresponding Java class. Therefore, to get name of the logger of a particular connector, use the connector's class name. The class name is usually the first field of the connector configuration when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its class name ``io.debezium.connector.postgresql``:
+By convention, loggers have the same name as the corresponding Java class.
+To get the name of the logger for a particular connector, use the connector's class name. The class name is usually the first field of the connector configuration when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its class name ``io.debezium.connector.postgresql``:
 
 .. code-block:: json
 

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -60,7 +60,9 @@ The output should be similar to the below
 
 .. Warning::
 
-    If you have not previously set a logging level for a connector's logger class, then the list of loggers retrieved above will not show any logger level information of that connector's logger class, even if that connector is currently running in the Aiven for Apache Kafka Connect cluster. See the next section on how to change the logging level of a particular logger.
+    The previous command shows the standard list of loggers (``org.apache.zookeeper``, ``org.reflections`` and ``root``) and any loggers for which the logging level has been already modified.
+    
+    Therefore, if you have not previously set a custom logging level for a connector's logger class, the related logger level information will not be visible in the list, even if that connector is currently running in the Kafka Connect cluster. The next section describes how to change the logging level of a particular logger.
 
 Change the logging level for a particular logger
 ''''''''''''''''''''''''''''''''''''''''''''''''
@@ -82,29 +84,31 @@ For example, when we set a custom log level for the logger ``io.debezium.connect
 
 .. code-block:: json
 
-    "io.debezium.connector.postgresql.connection.AbstractMessageDecoder": {
-        "level": "TRACE"
-    },
-    "io.debezium.connector.postgresql.connection.PostgresConnection": {
-        "level": "TRACE"
-    },
-    "io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter": {
-        "level": "TRACE"
-    },
-    "io.debezium.connector.postgresql.connection.PostgresReplicationConnection": {
-        "level": "TRACE"
-    },
-    "io.debezium.connector.postgresql.connection.pgproto.PgProtoMessageDecoder": {
-        "level": "TRACE"
+    {
+        "io.debezium.connector.postgresql.connection.AbstractMessageDecoder": {
+            "level": "TRACE"
+        },
+        "io.debezium.connector.postgresql.connection.PostgresConnection": {
+            "level": "TRACE"
+        },
+        "io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter": {
+            "level": "TRACE"
+        },
+        "io.debezium.connector.postgresql.connection.PostgresReplicationConnection": {
+            "level": "TRACE"
+        },
+        "io.debezium.connector.postgresql.connection.pgproto.PgProtoMessageDecoder": {
+            "level": "TRACE"
+        }
     }
 
 
-A note about loggers
-''''''''''''''''''''
+Get the connector class name
+''''''''''''''''''''''''''''
 
 Loggers are Java objects which trigger log events, and each log message produced by the application is sent to a specific logger. Loggers are arranged in hierarchies, for example the logger ``io.debezium.connector.postgresql.PostgresConnector`` is a child of the logger ``io.debezium.connector.postgresql``. When you define the logging level of a logger using the commands above, the logging level will be set for that logger and all of its children in the logger hierarchy.
 
-By convention, loggers have the same name as the corresponding Java class.  Therefore, to get name of the logger of a particular connector, use the connector's classname. The classname is usually the first field of the connector config when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its classname ``io.debezium.connector.postgresql``:
+By convention, loggers have the same name as the corresponding Java class. Therefore, to get name of the logger of a particular connector, use the connector's classname. The classname is usually the first field of the connector config when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its classname ``io.debezium.connector.postgresql``:
 
 .. code-block:: json
 

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -1,0 +1,75 @@
+Manage Apache Kafka® Connect logging level
+==========================================
+
+During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue while other times, the information provided just isn't enough to work with.
+
+Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html#connect_rest>`__. 
+
+.. Warning::
+
+    The REST API only changes the logging level on the node that's accessed, not across an entire distributed Connect cluster. Therefore, for a multi-node cluster, you would have to change the logging level in all of the nodes that run the connector's tasks you wish to debug.
+
+    For a dedicated Aiven for Apache Kafka® Connect cluster using a Startup plan, there is 1 node, while Business and Premium plan have 3 and 6 nodes respectively.
+
+Modify the Kafka Connect logging level
+--------------------------------------
+
+The following procedure allows you to update the logging level in an Aiven for Apache Kafka Connect service.
+
+Get the Kafka Connect nodes connection URI
+''''''''''''''''''''''''''''''''''''''''''
+
+To update the logging level in all the Kafka Connect nodes, you need to get their connection URI using the :ref:`Aiven CLI service get command <avn_service_get>`
+
+::
+
+    avn service get SERVICE_NAME  --format '{connection_info}'
+
+.. Note::
+
+    The above command will show the connection URI for each node in the form ``https://avnadmin:PASSWORD@IP_ADDRESS:PORT``
+
+Retrieve the list of loggers and connectors
+'''''''''''''''''''''''''''''''''''''''''''
+
+You can retrieve the list of loggers, connectors and their current logging level on each worker using the dedicated ``/admin/loggers`` Kafka Connect API
+
+::
+
+    curl https://avnadmin:PASSWORD@IP_ADDRESS:PORT/admin/loggers --insecure
+
+.. Tip::
+
+    The ``--insecure`` parameter avoids ``curl`` non matching certificates error due to using the IP instead of the hostname
+
+The output should be similar to the below
+
+.. code-block:: json
+
+    {
+        "org.apache.zookeeper": {
+            "level": "ERROR"
+        },
+        "org.reflections": {
+            "level": "ERROR"
+        },
+        "root": {
+            "level": "INFO"
+        }
+    }
+
+Change the logging level for a particular logger
+''''''''''''''''''''''''''''''''''''''''''''''''
+
+To change the logging level for a particular logger you can use the same ``admin/loggers`` endpoint appending the logger name (``LOGGER_NAME`` in the below command)
+
+::
+
+    curl -X PUT -H "Content-Type:application/json"          \
+        -d '{"level": "TRACE"}'                             \
+        https://192.168.0.1:443/admin/loggers/LOGGER_NAME   \
+        --insecure
+
+.. Warning::
+
+    When the node is restarted, logging reverts back to using the logging properties defined in the ``log4j`` configuration file. In an Aiven for Apache Kafka® Connect cluster the default logging level is ``INFO``.

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -1,15 +1,15 @@
 Manage Apache Kafka® Connect logging level
 ==========================================
 
-During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue while other times, the information provided just isn't enough to work with.
+During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue, while other times the information provided just isn't enough to work with.
 
-Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__.
+Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__.
 
 .. Warning::
 
     The REST API only changes the logging level on the node that's accessed, not across an entire distributed Connect cluster. Therefore, for a multi-node cluster, you would have to change the logging level in all of the nodes that run the connector's tasks you wish to debug.
 
-    For a dedicated Aiven for Apache Kafka® Connect cluster using a Startup plan, there is 1 node, while Business and Premium plan have 3 and 6 nodes respectively.
+    For a dedicated Aiven for Apache Kafka® Connect cluster using a Startup plan, there is 1 node, while Business and Premium plans have 3 and 6 nodes respectively.
 
 Modify the Kafka Connect logging level
 --------------------------------------
@@ -40,9 +40,9 @@ You can retrieve the list of loggers, connectors and their current logging level
 
 .. Tip::
 
-    The ``--insecure`` parameter avoids ``curl`` non matching certificates error due to using the IP instead of the hostname
+    The ``--insecure`` parameter avoids a ``curl`` non matching certificates error due to using the IP instead of the hostname
 
-The output should be similar to the below
+The output should be similar to the following
 
 .. code-block:: json
 
@@ -67,7 +67,7 @@ The output should be similar to the below
 Change the logging level for a particular logger
 ''''''''''''''''''''''''''''''''''''''''''''''''
 
-To change the logging level for a particular logger you can use the same ``admin/loggers`` endpoint appending the logger name (``LOGGER_NAME`` in the below command)
+To change the logging level for a particular logger you can use the same ``admin/loggers`` endpoint, specifying the logger name (``LOGGER_NAME`` in the following command)
 
 ::
 
@@ -80,7 +80,7 @@ To change the logging level for a particular logger you can use the same ``admin
 
     When the node is restarted, logging reverts back to using the logging properties defined in the ``log4j`` configuration file. In an Aiven for Apache Kafka® Connect cluster the default logging level is ``INFO``.
 
-For example, when we set a custom log level for the logger ``io.debezium.connector.postgresql.connection`` to be ``TRACE``, then this is what you will see upon listing the logger levels:
+For example, if you set the custom log level for the logger ``io.debezium.connector.postgresql.connection`` to be ``TRACE``, then this is what you will see upon listing the logger levels:
 
 .. code-block:: json
 
@@ -108,10 +108,11 @@ Get the connector class name
 
 Loggers are Java objects which trigger log events, and each log message produced by the application is sent to a specific logger. Loggers are arranged in hierarchies, for example the logger ``io.debezium.connector.postgresql.PostgresConnector`` is a child of the logger ``io.debezium.connector.postgresql``. When you define the logging level of a logger using the commands above, the logging level will be set for that logger and all of its children in the logger hierarchy.
 
-By convention, loggers have the same name as the corresponding Java class. Therefore, to get name of the logger of a particular connector, use the connector's classname. The classname is usually the first field of the connector config when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its classname ``io.debezium.connector.postgresql``:
+By convention, loggers have the same name as the corresponding Java class. Therefore, to get name of the logger of a particular connector, use the connector's class name. The class name is usually the first field of the connector configuration when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its class name ``io.debezium.connector.postgresql``:
 
 .. code-block:: json
 
     {
         "connector.class": "io.debezium.connector.postgresql"
     }
+

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -3,7 +3,7 @@ Manage Apache Kafka® Connect logging level
 
 During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue while other times, the information provided just isn't enough to work with.
 
-Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__. 
+Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__.
 
 .. Warning::
 
@@ -58,6 +58,10 @@ The output should be similar to the below
         }
     }
 
+.. Warning::
+
+    If you have not previously set a logging level for a connector's logger class, then the list of loggers retrieved above will not show any logger level information of that connector's logger class, even if that connector is currently running in the Aiven for Apache Kafka Connect cluster. See the next section on how to change the logging level of a particular logger.
+
 Change the logging level for a particular logger
 ''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -73,3 +77,37 @@ To change the logging level for a particular logger you can use the same ``admin
 .. Warning::
 
     When the node is restarted, logging reverts back to using the logging properties defined in the ``log4j`` configuration file. In an Aiven for Apache Kafka® Connect cluster the default logging level is ``INFO``.
+
+For example, when we set a custom log level for the logger ``io.debezium.connector.postgresql.connection`` to be ``TRACE``, then this is what you will see upon listing the logger levels:
+
+.. code-block:: json
+
+    "io.debezium.connector.postgresql.connection.AbstractMessageDecoder": {
+        "level": "TRACE"
+    },
+    "io.debezium.connector.postgresql.connection.PostgresConnection": {
+        "level": "TRACE"
+    },
+    "io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter": {
+        "level": "TRACE"
+    },
+    "io.debezium.connector.postgresql.connection.PostgresReplicationConnection": {
+        "level": "TRACE"
+    },
+    "io.debezium.connector.postgresql.connection.pgproto.PgProtoMessageDecoder": {
+        "level": "TRACE"
+    }
+
+
+A note about loggers
+''''''''''''''''''''
+
+Loggers are Java objects which trigger log events, and each log message produced by the application is sent to a specific logger. Loggers are arranged in hierarchies, for example the logger ``io.debezium.connector.postgresql.PostgresConnector`` is a child of the logger ``io.debezium.connector.postgresql``. When you define the logging level of a logger using the commands above, the logging level will be set for that logger and all of its children in the logger hierarchy.
+
+By convention, loggers have the same name as the corresponding Java class.  Therefore, to get name of the logger of a particular connector, use the connector's classname. The classname is usually the first field of the connector config when you select a connector for creation in the Aiven Console. For example, the logger for the Debezium PostgreSQL® source connector is also its classname ``io.debezium.connector.postgresql``:
+
+.. code-block:: json
+
+    {
+        "connector.class": "io.debezium.connector.postgresql"
+    }

--- a/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
+++ b/docs/products/kafka/kafka-connect/howto/manage-logging-level.rst
@@ -3,7 +3,7 @@ Manage Apache Kafka® Connect logging level
 
 During the operation of an Aiven for Apache Kafka® Connect cluster, you may encounter errors from one or more running connectors. Sometimes the stack trace printed in the logs is useful in determining the root cause of an issue while other times, the information provided just isn't enough to work with.
 
-Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html#connect_rest>`__. 
+Therefore you might need access to more detailed logs to debug an issue. This can be done for a specific logger or connector by setting the logging level of an Apache Kafka® Connect's cluster using the `Kafka Connect REST APIs <https://kafka.apache.org/documentation.html>`__. 
 
 .. Warning::
 


### PR DESCRIPTION
# What changed, and why it matters

Moved https://help.aiven.io/en/articles/4945598-setting-the-logging-level-of-an-aiven-for-apache-kafka-connect-cluster

It's in draft state because I can't see the loggers being created