### PR TITLE
add one trust cookies consent script to base template

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -24,4 +24,11 @@
     ga('send', 'pageview');
 </script>
 <!-- End Google Analytics -->
+
+<!-- OneTrust Cookies Consent Notice start for aiven.io -->
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="0623fbc6-a463-4822-a7a4-fdb5afcc3afb" ></script>
+<script type="text/javascript">
+function OptanonWrapper() { }
+</script>
+<!-- OneTrust Cookies Consent Notice end for aiven.io -->
 {% endblock %}


### PR DESCRIPTION
# What changed, and why it matters
Add missing cookies consent to enable tracking across aiven.io domain
Preview: https://deploy-preview-1043--developer-aiven-io-preview.netlify.app/
In production, once cookies are accepted or rejected it will not pop-up again.

<img width="2324" alt="Screenshot 2022-06-27 at 18 16 13" src="https://user-images.githubusercontent.com/3796599/175974815-17cd2019-a3f5-4d29-8691-ef8fbddfd06b.png">


