### PR TITLE
add dynamic disk sizing platform concept article

### DIFF
--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -22,6 +22,7 @@ exceptions:
   - Dev
   - Disaster Recovery
   - Docker
+  - Dynamic Disk Sizing
   - Elasticsearch
   - European Union
   - Flink

--- a/_toc.yml
+++ b/_toc.yml
@@ -24,6 +24,7 @@ entries:
       - file: docs/platform/concepts/static-ips
       - file: docs/platform/concepts/tls-ssl-certificates
       - file: docs/platform/concepts/byoa
+      - file: docs/platform/concepts/dynamic-disk-sizing
       - file: docs/platform/concepts/enhanced-compliance-env
       - file: docs/platform/concepts/disaster-recovery-test-scenarios
     - file: docs/platform/howto

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -35,6 +35,10 @@ Learn about some of the key concepts for working with Aiven platform:
 
   Securing connections to Aiven services with certificates.
 
+* :doc: `Dynamic Disk Sizing (DDS) </docs/platform/concepts/dynamic-disk-sizing>`.
+
+  Add (and remove) storage on the fly without upgrading your plan.
+
 * :doc:`Bring your own account (BYOA) </docs/platform/concepts/byoa>`.
 
   BYOA is an optional setup feature that allows you to purchase your Aiven services through your existing Cloud Provider.

--- a/docs/platform/concepts/dynamic-disk-sizing.rst
+++ b/docs/platform/concepts/dynamic-disk-sizing.rst
@@ -1,21 +1,23 @@
 Dynamic Disk Sizing
 ====================
 
-When running a service, you may soon fill up the storage available and notice that the other resources are not limited. Upgrading your plan is an option but then you are paying for additional compute resources (or RAM) that your current usage does not require.
+When running a service, you may soon fill up the storage available and notice that the other resources are not limited. Upgrading your plan is an option but then you are paying for additional compute resources (or RAM) that your current usage does not require. If your need is to exclusively increase the storage, with Dynamic Disk Sizing (DDS) you can achieve it for the following services: 
 
-Dynamic Disk Sizing (DDS) is a feature available for: 
-- Aiven for Apache Kafka
-- Aiven for PostgreSQL
-- Aiven for MySQL
-- Aiven for OpenSearch
-- Aiven for Apache Cassandra
-- Aiven for M3DB
+- Aiven for Apache Kafka®
+- Aiven for PostgreSQL®
+- Aiven for MySQL®
+- Aiven for OpenSearch®
+- Aiven for Apache Cassandra®
+- Aiven for M3DB®
 
-You can add up to 2x the original storage amount to any plan, allowing you 3x the initial storage amount. For example, if you are deploying a business-4 PostgreSQL service, the default storage is 80GB, and you can add up to 160GB of additional storage, to give a total of 240GB.
+With Dynamic Disk Sizing, you can add up to 2x the original storage amount to any plan, allowing you 3x the initial storage amount. 
+
+For example, if you are deploying a ``business-4`` Aiven for PostgreSQL service, the default storage is 80GB, and you can add up to 160GB of additional storage, to give a total of 240GB.
 
 The price you see is the cost of the storage, as well as any backups associated with it.
 
 .. note::
+
     Dynamic Disk Sizing is not supported on custom plans
 
 How does Dynamic Disk Sizing work?
@@ -23,8 +25,9 @@ How does Dynamic Disk Sizing work?
 
 When increasing storage, the Aiven platform provisions additional network attached storage and dynamically adds it to your running instances. Your services are not affected or interrupted and you can continue to use your service as normal. 
 
-You can add storage at the time you create a new service. Once created, you can add (and remove) DDS storage by selecting `Edit` or `Add Storage` under the `Service Plan` section of your `Service Overview`` page.
+You can add DDS storage at the time you create a new service. Once created, you can add (and remove) DDS storage by selecting `Edit` or `Add Storage` under the `Service Plan` section of your `Service Overview` page.
 
 .. note:: 
+
     It is unlikely that any performance degradation from using network attached storage would be noticeable in your clients but it is a possibility. 
 

--- a/docs/platform/concepts/dynamic-disk-sizing.rst
+++ b/docs/platform/concepts/dynamic-disk-sizing.rst
@@ -1,0 +1,30 @@
+Dynamic Disk Sizing
+====================
+
+When running a service, you may soon fill up the storage available and notice that the other resources are not limited. Upgrading your plan is an option but then you are paying for additional compute resources (or RAM) that your current usage does not require.
+
+Dynamic Disk Sizing (DDS) is a feature available for: 
+- Aiven for Apache Kafka
+- Aiven for PostgreSQL
+- Aiven for MySQL
+- Aiven for OpenSearch
+- Aiven for Apache Cassandra
+- Aiven for M3DB
+
+You can add up to 2x the original storage amount to any plan, allowing you 3x the initial storage amount. For example, if you are deploying a business-4 PostgreSQL service, the default storage is 80GB, and you can add up to 160GB of additional storage, to give a total of 240GB.
+
+The price you see is the cost of the storage, as well as any backups associated with it.
+
+.. note::
+    Dynamic Disk Sizing is not supported on custom plans
+
+How does Dynamic Disk Sizing work?
+----------------------------------
+
+When increasing storage, the Aiven platform provisions additional network attached storage and dynamically adds it to your running instances. Your services are not affected or interrupted and you can continue to use your service as normal. 
+
+You can add storage at the time you create a new service. Once created, you can add (and remove) DDS storage by selecting `Edit` or `Add Storage` under the `Service Plan` section of your `Service Overview`` page.
+
+.. note:: 
+    It is unlikely that any performance degradation from using network attached storage would be noticeable in your clients but it is a possibility. 
+


### PR DESCRIPTION
# What changed, and why it matters

Added dynamic disk sizing article to explain how it works, what disks it uses and confirmation that services are not impacted.

Internal docs (and [blogs](https://aiven.io/blog/announcing-dynamic-disk-sizing)) show DDS in title case so added exceptions for this as well.


