### PR TITLE
Adding a warning on token revocation.

### DIFF
--- a/docs/platform/howto/user-2fa.rst
+++ b/docs/platform/howto/user-2fa.rst
@@ -34,6 +34,10 @@ If you need to disable two-factor authentication settings from your account, you
 
 With those steps, you can disable your user two-factor authentication. Disabling two-factor authentication means that you no longer need to provide both the password and a time-based authentication code generated to login into your account. 
 
+.. warning::
+    
+    Disabling two-factor authentication will automatically revoke the user's existing tokens. 
+
 Reset user two-factor authentication
 ------------------------------------
 


### PR DESCRIPTION
# What changed, and why it matters

I came to know that disabling 2FA would actually revoke all of your existing tokens. I think our docs need to show a warning to the reader for this.
