### PR TITLE
Fixed pool name documentation

### DIFF
--- a/docs/products/postgresql/howto/manage-pool.rst
+++ b/docs/products/postgresql/howto/manage-pool.rst
@@ -24,7 +24,7 @@ To manage the connection pools, follow the steps below:
 
    The settings available are:
 
-   * **Pool name:** Enter a name for your connection pool here. This also becomes the ``database`` or ``dbname`` connection parameter for your pooled client connections.
+   * **Pool name:** Enter a name for your connection pool here. This also becomes the ``database`` or ``dbname`` connection parameter for your pooled client connections. This parameter must be equal to the ``Database`` parameter. 
    * **Database**: Choose the database that you want to connect to. Each pool can only connect to a single database.
    * **Username:** Select the database username that you want to use when connecting to the backend database.
    * **Pool Mode:** Select the pooling mode as described in more detail above.


### PR DESCRIPTION
As it is written right now in the doc, it is not clear to the customer that the pool name must be equal to the database name or pgbouncer is not capable to connect to the database server.
![image](https://user-images.githubusercontent.com/34677902/176898003-a126ef42-56db-43f6-906e-b23f6ce19966.png)
![image](https://user-images.githubusercontent.com/34677902/176898279-b26570a9-e45f-469c-835e-87694013b96f.png)



