### PR TITLE
Replace `Redis™*` with `Redis®*`

### DIFF
--- a/.github/vale/styles/Aiven/first_Redis_is_registered.yml
+++ b/.github/vale/styles/Aiven/first_Redis_is_registered.yml
@@ -1,0 +1,8 @@
+extends: conditional
+message: "At least one '%s' must be marked as ®*"
+level: error
+scope: text
+ignorecase: false
+
+first: '\b(Redis)(?!®\*)'
+second: '(Redis)(?:®\*)'

--- a/.github/vale/styles/Aiven/first_Redis_is_trademarked.yml
+++ b/.github/vale/styles/Aiven/first_Redis_is_trademarked.yml
@@ -1,8 +1,0 @@
-extends: conditional
-message: "At least one '%s' must be marked as ™*"
-level: error
-scope: text
-ignorecase: false
-
-first: '\b(Redis)(?!™\*\W)'
-second: '\b(Redis)(?:™\*)'

--- a/.github/vale/tests/first_ref_bad.rst
+++ b/.github/vale/tests/first_ref_bad.rst
@@ -14,8 +14,10 @@ A word at the end of a line is OK: Kubernetes
 This is a Redis title
 ---------------------
 
-And Redis is trademarked and needs an asterisk. But the second Redis does not.
+And Redis is registered and needs an asterisk. But the second Redis does not.
 
-There's something wrong about Redis*™, Redis™ and Redis*.
+Redis™* doesn't count - the trademark should now be registered.
 
-Flink®wahooness and Redis™*blibble are just odd.
+There's something wrong about Redis*®, Redis® and Redis*.
+
+Flink®wahooness and Redis®*blibble are just odd.

--- a/.github/vale/tests/first_ref_good.rst
+++ b/.github/vale/tests/first_ref_good.rst
@@ -11,7 +11,7 @@ Other registered names: Cassandra®, OpenSearch®, PostgreSQL®, InfluxDB®, Gra
 
 A word at the end of a line is OK: Kubernetes®
 
-This is a Redis™* title
+This is a Redis®* title
 -----------------------
 
-And Redis™* is trademarked and needs an asterisk. But the second Redis does not.
+And Redis®* is registered and needs an asterisk. But the second Redis does not.

--- a/.github/vale/tests/sentence_case_title_good.rst
+++ b/.github/vale/tests/sentence_case_title_good.rst
@@ -26,7 +26,7 @@ Aiven and Flink®
 
 3 words, ``Aiven`` is +1 because it's title-case and first, ``and`` is +1 because it's lower case, ``Flink`` is +1 because it's an exception. So score is 3/3 which is more than 80%, so this title is good.
 
-Aiven and Redis™*
+Aiven and Redis®*
 -----------------
 
 3 words, ``Aiven`` is +1 because it's title-case and first, ``and`` is +1 because it's lower case, ``Redis`` is +1 because it's an exception. So score is 3/3 which is more than 80%, so this title is good.

--- a/.github/vale/tests/shelltest.test
+++ b/.github/vale/tests/shelltest.test
@@ -66,7 +66,7 @@ $ vale --output=line --sort .github/vale/tests/first_ref_good.rst
 >
 >=0
 
-# In line 15, we detect that `Redis™*blibble` and `Flink@wahooness` are problems, but
+# In line 15, we detect that `Redis®*blibble` and `Flink@wahooness` are problems, but
 # I'm not quite sure if the errors given are quite what I want.
 
 $ vale --output=line --sort .github/vale/tests/first_ref_bad.rst
@@ -82,14 +82,15 @@ $ vale --output=line --sort .github/vale/tests/first_ref_bad.rst
 .github/vale/tests/first_ref_bad.rst:10:60:Aiven.first_InfluxDB_is_registered:At least one 'InfluxDB' must be marked as ®
 .github/vale/tests/first_ref_bad.rst:10:70:Aiven.first_Grafana_is_registered:At least one 'Grafana' must be marked as ®
 .github/vale/tests/first_ref_bad.rst:12:36:Aiven.first_Kubernetes_is_registered:At least one 'Kubernetes' must be marked as ®
-.github/vale/tests/first_ref_bad.rst:14:11:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:17:5:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:17:64:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:19:31:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:19:40:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:19:51:Aiven.first_Redis_is_trademarked:At least one 'Redis' must be marked as ™*
-.github/vale/tests/first_ref_bad.rst:21:7:Aiven.aiven_spelling:'wahooness' does not seem to be a recognised word
-.github/vale/tests/first_ref_bad.rst:21:28:Aiven.aiven_spelling:'blibble' does not seem to be a recognised word
+.github/vale/tests/first_ref_bad.rst:14:11:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:17:5:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:17:63:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:19:1:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:21:31:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:21:40:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:21:51:Aiven.first_Redis_is_registered:At least one 'Redis' must be marked as ®*
+.github/vale/tests/first_ref_bad.rst:23:7:Aiven.aiven_spelling:'wahooness' does not seem to be a recognised word
+.github/vale/tests/first_ref_bad.rst:23:28:Aiven.aiven_spelling:'blibble' does not seem to be a recognised word
 >=1
 
 # ---------------------------------------------------------------

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -60,7 +60,7 @@
         {% include "feedback-form.html" %}
         <div class="disclaimer"><p>Apache, Apache Kafka, Kafka, Apache Flink, Flink, Apache Cassandra, and Cassandra are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
           M3, M3 Aggregator, M3 Coordinator, OpenSearch, PostgreSQL, MySQL, InfluxDB, Grafana, Terraform, and Kubernetes are trademarks and property of their respective owners.
-         *Redis is a trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven. All product and service names used in this website are for identification purposes only and do not imply endorsement.</p></div>
+         *Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Aiven is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Aiven. All product and service names used in this website are for identification purposes only and do not imply endorsement.</p></div>
         {% block footer %}
 
         <div class="related-information">

--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -17,7 +17,7 @@ You can fork the following Aiven services:
 
 - PostgreSQL®
 - MySQL
-- Redis™*
+- Redis®*
 - Apache Cassandra® (Limitation: you cannot fork to a lower amount of nodes)
 - Elasticsearch
 - OpenSearch®

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -22,7 +22,7 @@ Depending on the service plan, each service provides different backups with diff
 +---------------------------------------+------------------------------------------+---------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
 | Aiven for Apache Cassandra®           | Plan not available                       | Single day backup                                       | Single day backup                                      | Single day backup                                      |
 +---------------------------------------+------------------------------------------+---------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
-| Aiven for Redis™*                     | Single backup only for disaster recovery | Backup every 12 hours up to 1 day                       | Backup every 12 hours up to 3 days                     | Backup every 12 hours up to 13 days                    |
+| Aiven for Redis®*                     | Single backup only for disaster recovery | Backup every 12 hours up to 1 day                       | Backup every 12 hours up to 3 days                     | Backup every 12 hours up to 13 days                    |
 +---------------------------------------+------------------------------------------+---------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
 | Aiven for InfluxDB®                   | Plan not available                       | Backup every 12 hours up to 2.5 days                    | Plan not available                                     | Plan not available                                     |
 +---------------------------------------+------------------------------------------+---------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
@@ -93,7 +93,7 @@ Aiven for Apache Cassandra®
 We currently support backups taken every 24 hours. The PITR feature is currently not available. Please contact support if you would to be notified once the PITR feature is available for Cassandra.
 
 
-Aiven for Redis™*
+Aiven for Redis®*
 ''''''''''''''''''''''''
 We offer backups that are taken every 12 hours, and for persistence we support **RBD** (Redis Database Backup). The persistence feature can be controlled by ``redis_persistence`` under **Advanced Configuration**. AOF persistence is currently not supported by the Aiven for Redis service.
 

--- a/docs/platform/howto/migrate-services.rst
+++ b/docs/platform/howto/migrate-services.rst
@@ -2,7 +2,7 @@ Migrate services
 ================
 
 When migrating a service, the migration happens in the background and does not affect your service until the service has been rebuilt at the new region. The migration includes the **DNS update** for the  named service to point to the new region. 
-Most of the services have usually no service interruption expected. However, for services like PostgreSQL®, MySQL and Redis™*, it may cause a short interruption (5 to 10 seconds) in service while the DNS changes are propagated.
+Most of the services have usually no service interruption expected. However, for services like PostgreSQL®, MySQL and Redis®*, it may cause a short interruption (5 to 10 seconds) in service while the DNS changes are propagated.
 
 The short interruption mentioned above does not include the potential delays caused by client side library implementation.
 

--- a/docs/platform/index.rst
+++ b/docs/platform/index.rst
@@ -11,7 +11,7 @@ Apache Kafka®,
 Apache Cassandra®,
 PostgreSQL®,
 MySQL,
-Redis™*,
+Redis®*,
 InfluxDB®,
 Grafana®,
 and M3 - all available in more than 80 regions around the world on AWS, GCP, Microsoft Azure, DigitalOcean, and UpCloud cloud platforms.

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -76,7 +76,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Stream Reactor MQTT <https://docs.lenses.io/connectors/sink/mqtt.html>`__
 
-* `Stream Reactor Redis™* <https://docs.lenses.io/connectors/sink/redis.html>`__
+* `Stream Reactor Redis®* <https://docs.lenses.io/connectors/sink/redis.html>`__
 
 
 Preview connectors

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.rst
@@ -1,7 +1,7 @@
-Create a Redis™* stream reactor sink connector by Lenses.io
+Create a Redis®* stream reactor sink connector by Lenses.io
 ===========================================================
 
-**The Redis stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Redis™* database**. The Lenses.io implementation enables you to write `KCQL transformations <https://docs.lenses.io/connectors/sink/redis.html>`_ on the topic data before sending it to the Redis database.
+**The Redis stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Redis®* database**. The Lenses.io implementation enables you to write `KCQL transformations <https://docs.lenses.io/connectors/sink/redis.html>`_ on the topic data before sending it to the Redis database.
 
 
 .. _connect_redis_lenses_sink_prereq:

--- a/docs/products/opensearch/howto/opensearch-log-integration.rst
+++ b/docs/products/opensearch/howto/opensearch-log-integration.rst
@@ -1,7 +1,7 @@
 Manage OpenSearch® log integration
 ==================================
 
-Aiven provides a service integration that allows you to send your logs from several services, such as Aiven for Apache Kafka®, PostgreSQL®, Apache Cassandra®, OpenSearch®, Redis™*, InfluxDB®, and Grafana®, to Aiven for OpenSearch®. Making it possible for you to use OpenSearch to gain more insight and control over your logs.
+Aiven provides a service integration that allows you to send your logs from several services, such as Aiven for Apache Kafka®, PostgreSQL®, Apache Cassandra®, OpenSearch®, Redis®*, InfluxDB®, and Grafana®, to Aiven for OpenSearch®. Making it possible for you to use OpenSearch to gain more insight and control over your logs.
 
 In this article, you will understand how to enable, edit and disable the logs integration feature on Aiven for OpenSearch.
 

--- a/docs/products/redis/concepts.rst
+++ b/docs/products/redis/concepts.rst
@@ -1,6 +1,6 @@
 Concepts
 ========
 
-Learn more about some of the key concepts for working with Aiven for Redis™*:
+Learn more about some of the key concepts for working with Aiven for Redis®*:
 
 .. tableofcontents::

--- a/docs/products/redis/concepts/high-availability-redis.rst
+++ b/docs/products/redis/concepts/high-availability-redis.rst
@@ -1,7 +1,7 @@
-High availability in Aiven for Redis™*
+High availability in Aiven for Redis®*
 ======================================
 
-Aiven for Redis™* is available on a variety of plans, offering different levels of high availability. The selected plan defines the features available, and a summary is provided in the table below:
+Aiven for Redis®* is available on a variety of plans, offering different levels of high availability. The selected plan defines the features available, and a summary is provided in the table below:
 
 .. list-table::
     :header-rows: 1

--- a/docs/products/redis/concepts/lua-scripts-redis.rst
+++ b/docs/products/redis/concepts/lua-scripts-redis.rst
@@ -1,7 +1,7 @@
-Lua scripts with Aiven for Redis™*
+Lua scripts with Aiven for Redis®*
 ==================================
 
-Redis™* has inbuilt support for running Lua scripts to perform various actions directly on the Redis server. Scripting is typically controlled using the ``EVAL`` , ``EVALSHA`` and ``SCRIPT LOAD`` commands.
+Redis®* has inbuilt support for running Lua scripts to perform various actions directly on the Redis server. Scripting is typically controlled using the ``EVAL`` , ``EVALSHA`` and ``SCRIPT LOAD`` commands.
 
 For all newly-created Redis instances, ``EVAL``, ``EVALSHA`` and ``SCRIPT LOAD`` commands are enabled by default. 
 

--- a/docs/products/redis/concepts/memory-usage.rst
+++ b/docs/products/redis/concepts/memory-usage.rst
@@ -1,9 +1,9 @@
-Memory usage, on-disk persistence and replication in Aiven for Redis™*
+Memory usage, on-disk persistence and replication in Aiven for Redis®*
 ======================================================================
 
-Here we show you how Aiven for Redis™* solves the challenges related to high memory usage and high change rate.
+Here we show you how Aiven for Redis®* solves the challenges related to high memory usage and high change rate.
 
-One of the main ways Redis™* is used is as a database cache. Data is written to Redis whenever it is fetched from a database, and the following queries with the same parameters first try to look data up in Redis, skipping the database query if the data is found. This results in high memory usage, and can result in a high change rate.
+One of the main ways Redis®* is used is as a database cache. Data is written to Redis whenever it is fetched from a database, and the following queries with the same parameters first try to look data up in Redis, skipping the database query if the data is found. This results in high memory usage, and can result in a high change rate.
 
 
 Data eviction policy in Aiven for Redis

--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -1,9 +1,9 @@
-Get started with Aiven for Redis™*
+Get started with Aiven for Redis®*
 ==================================
 
-The first step in using Aiven for Redis™* is to create a service. You can do so either using the `Aiven Web Console <https://console.aiven.io/>`_ or the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
+The first step in using Aiven for Redis®* is to create a service. You can do so either using the `Aiven Web Console <https://console.aiven.io/>`_ or the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
 
-Create a Redis™* service using the Aiven web console
+Create a Redis®* service using the Aiven web console
 ----------------------------------------------------
 1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
 
@@ -11,12 +11,12 @@ Create a Redis™* service using the Aiven web console
 
    Once the service is ready, the status changes to *Running*. This typically takes a couple of minutes, depending on your selected cloud provider and region.
 
-Create a Redis™* service using the Aiven CLI
+Create a Redis®* service using the Aiven CLI
 --------------------------------------------
 
 If you prefer launching a new service from the CLI, `Aiven CLI <https://github.com/aiven/aiven-client>`_ includes a command for doing so. 
 
-In order to launch a service, decide on the service plan, cloud provider, and region you want to run your service on. Then run the following command to create a **Redis™\*** service named ``demo-redis``: 
+In order to launch a service, decide on the service plan, cloud provider, and region you want to run your service on. Then run the following command to create a **Redis®\*** service named ``demo-redis``: 
 
 ::
 

--- a/docs/products/redis/howto.rst
+++ b/docs/products/redis/howto.rst
@@ -1,7 +1,7 @@
 HowTo
 =====
 
-Check out the common tasks for working with Aiven for Redis™*.
+Check out the common tasks for working with Aiven for Redis®*.
 
 .. tableofcontents::
 

--- a/docs/products/redis/howto/configure-acl-permissions.rst
+++ b/docs/products/redis/howto/configure-acl-permissions.rst
@@ -1,9 +1,9 @@
-Configure ACL permissions in Aiven for Redis™*
+Configure ACL permissions in Aiven for Redis®*
 ==============================================
 
 Use the Aiven console or the Aiven client to create custom Access Control Lists (ACLs). 
 
-Redis™* uses `ACLs <https://redis.io/docs/manual/security/acl/>`_ to restrict the usage of commands and keys available for connecting for a specific username and password. Aiven for Redis™*, however, does not allow use of the  `ACL * <https://redis.io/commands/acl-list>`_ commands directly in order to guarantee the reliability of replication, configuration management, or backups for disaster recovery for the default user. You can use the console or the client to create custom ACLs instead.
+Redis®* uses `ACLs <https://redis.io/docs/manual/security/acl/>`_ to restrict the usage of commands and keys available for connecting for a specific username and password. Aiven for Redis®*, however, does not allow use of the  `ACL * <https://redis.io/commands/acl-list>`_ commands directly in order to guarantee the reliability of replication, configuration management, or backups for disaster recovery for the default user. You can use the console or the client to create custom ACLs instead.
 
 
 Create an ACL using the Aiven console

--- a/docs/products/redis/howto/connect-go.rst
+++ b/docs/products/redis/howto/connect-go.rst
@@ -1,7 +1,7 @@
 Connect with Go
 ---------------
 
-This example connects to Redis™* service from Go, making use of the ``go-redis/redis`` library.
+This example connects to Redis®* service from Go, making use of the ``go-redis/redis`` library.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/connect-java.rst
+++ b/docs/products/redis/howto/connect-java.rst
@@ -1,7 +1,7 @@
 Connect with Java
 -------------------
 
-This example connects to Redis™* service from Java, making use of the ``jredis``.
+This example connects to Redis®* service from Java, making use of the ``jredis``.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/connect-node.rst
+++ b/docs/products/redis/howto/connect-node.rst
@@ -1,7 +1,7 @@
 Connect with NodeJS
 -------------------
 
-This example connects to Redis™* service from NodeJS, making use of the ``ioredis`` library.
+This example connects to Redis®* service from NodeJS, making use of the ``ioredis`` library.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/connect-php.rst
+++ b/docs/products/redis/howto/connect-php.rst
@@ -1,7 +1,7 @@
 Connect with PHP
 ----------------
 
-This example connects to Redis™* service from PHP, making use of the ``predis`` library.
+This example connects to Redis®* service from PHP, making use of the ``predis`` library.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/connect-python.rst
+++ b/docs/products/redis/howto/connect-python.rst
@@ -1,7 +1,7 @@
 Connect with Python
 -------------------
 
-This example connects to Redis™* service from Python, making use of the ``redis-py`` library.
+This example connects to Redis®* service from Python, making use of the ``redis-py`` library.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/connect-redis-cli.rst
+++ b/docs/products/redis/howto/connect-redis-cli.rst
@@ -1,7 +1,7 @@
 Connect with ``redis-cli``
 --------------------------
 
-This example connects to a Redis™* service from ``redis-cli``.
+This example connects to a Redis®* service from ``redis-cli``.
 
 Variables
 '''''''''

--- a/docs/products/redis/howto/estimate-max-number-of-connections.rst
+++ b/docs/products/redis/howto/estimate-max-number-of-connections.rst
@@ -1,7 +1,7 @@
 Estimate maximum number of connection
 =====================================
 
-The number of simultaneous connections in Aiven for Redis™* depends on the total available memory on the server.
+The number of simultaneous connections in Aiven for Redis®* depends on the total available memory on the server.
 
 You can use the following to estimate:
 

--- a/docs/products/redis/howto/manage-ssl-connectivity.rst
+++ b/docs/products/redis/howto/manage-ssl-connectivity.rst
@@ -6,7 +6,7 @@ Client support for SSL-encrypted connections
 
 Default support
 ~~~~~~~~~~~~~~~
-Aiven for Redis™* uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI`` on the `Aiven Console <https://console.aiven.io/>`_.
+Aiven for Redis®* uses SSL encrypted connections by default. This is shown by the use of ``rediss://`` (with double s) prefix in the ``Service URI`` on the `Aiven Console <https://console.aiven.io/>`_.
 
 .. Tip::
 

--- a/docs/products/redis/howto/migrate-aiven-redis.rst
+++ b/docs/products/redis/howto/migrate-aiven-redis.rst
@@ -1,7 +1,7 @@
-Migrate from Redis™* to Aiven for Redis™*
+Migrate from Redis®* to Aiven for Redis®*
 =========================================
 
-Move your data from a source, standalone Redis™* data store to an Aiven-managed Redis service. The migration first attempts to use the ``replication`` method, and if it fails, it uses ``scan``.
+Move your data from a source, standalone Redis®* data store to an Aiven-managed Redis service. The migration first attempts to use the ``replication`` method, and if it fails, it uses ``scan``.
 
 In the following steps, we show you how to create a new Aiven for Redis service, and migrate data from AWS ElastiCache Redis. The Aiven project name is ``test``, and the service name for the target Aiven for Redis is ``redis``.
 

--- a/docs/products/redis/howto/warning-overcommit_memory.rst
+++ b/docs/products/redis/howto/warning-overcommit_memory.rst
@@ -1,8 +1,8 @@
 Handle warning ``overcommit_memory``
 ====================================
 
-When starting a Redis™* service on `Aiven console <https://console.aiven.io/>`_, you may notice on **Logs** the following **warning** ``overcommit_memory``::
+When starting a Redis®* service on `Aiven console <https://console.aiven.io/>`_, you may notice on **Logs** the following **warning** ``overcommit_memory``::
 
     # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
 
-This warning can be safely ignored as Aiven for Redis™* ensures that the available memory will never drop low enough to hit this particular failure case.
+This warning can be safely ignored as Aiven for Redis®* ensures that the available memory will never drop low enough to hit this particular failure case.

--- a/docs/products/redis/index.rst
+++ b/docs/products/redis/index.rst
@@ -1,10 +1,10 @@
-Aiven for Redis™*
+Aiven for Redis®*
 =================
 
-What is Aiven for Redis™*?
+What is Aiven for Redis®*?
 --------------------------
 
-Aiven for Redis™* is a fully managed **in-memory NoSQL database**, deployable in the cloud of your choice which can help you store and access data quickly and efficiently.
+Aiven for Redis®* is a fully managed **in-memory NoSQL database**, deployable in the cloud of your choice which can help you store and access data quickly and efficiently.
 
 
 Why Redis?

--- a/docs/products/redis/reference.rst
+++ b/docs/products/redis/reference.rst
@@ -1,6 +1,6 @@
 Reference
 =========
 
-Additional reference information for Aiven for Redis™*:
+Additional reference information for Aiven for Redis®*:
 
 .. tableofcontents::

--- a/docs/products/redis/reference/advanced-params.rst
+++ b/docs/products/redis/reference/advanced-params.rst
@@ -1,6 +1,6 @@
-Advanced parameters for Aiven for Redis™*
+Advanced parameters for Aiven for Redis®*
 =========================================
 
-Below you can find a summary of every configuration option available for Aiven for Redis™* service:
+Below you can find a summary of every configuration option available for Aiven for Redis®* service:
 
 .. include:: /includes/config-redis.rst

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -44,7 +44,7 @@ Retrieves the project CA that the selected service belongs to.
 ``avn service cli``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Opens the appropriate interactive shell, such as ``psql`` or ``redis-cli``, to the given service. Supported only for Aiven for PostgreSQL®, Aiven for Redis™*, and Aiven for InfluxDB® services.
+Opens the appropriate interactive shell, such as ``psql`` or ``redis-cli``, to the given service. Supported only for Aiven for PostgreSQL®, Aiven for Redis®*, and Aiven for InfluxDB® services.
 
 .. list-table::
   :header-rows: 1
@@ -149,7 +149,7 @@ Resets the service credentials. More information on user password change is prov
 ``avn service current-queries``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-List current service connections/queries for an Aiven for PostgreSQL®, Aiven for MySQL or Aiven for Redis™* service.
+List current service connections/queries for an Aiven for PostgreSQL®, Aiven for MySQL or Aiven for Redis®* service.
 
 .. list-table::
   :header-rows: 1

--- a/docs/tools/cli/service/user.rst
+++ b/docs/tools/cli/service/user.rst
@@ -27,13 +27,13 @@ Creates a new user for the selected service.
   * - ``--m3-group``
     - The name of the group the user belongs to (for Aiven for M3 services only)
   * - ``--redis-acl-keys``
-    - The ACL rules for keys (Aiven for Redis™* services only)
+    - The ACL rules for keys (Aiven for Redis®* services only)
   * - ``--redis-acl-commands``
-    - The ACL rules for commands (Aiven for Redis™* services only)
+    - The ACL rules for commands (Aiven for Redis®* services only)
   * - ``--redis-acl-categories``
-    - The ACL rules for categories (Aiven for Redis™* services only)
+    - The ACL rules for categories (Aiven for Redis®* services only)
   * - ``--redis-acl-channels``
-    - The ACL rules for channels (Aiven for Redis™* services only)
+    - The ACL rules for channels (Aiven for Redis®* services only)
 
 **Example:** Create a new user named ``janedoe`` for a service named ``pg-demo``.
 
@@ -233,4 +233,4 @@ Resets or changes the service user password.
 ``avn service user-set-access-control``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Set Redis™* service user access control
+Set Redis®* service user access control

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,7 +1,7 @@
 Set up your first Aiven Terraform project
 =========================================
 
-This example shows the setup for a Terraform project containing a single Redis™* service, and shows off some useful commands to stand up (and destroy) your Aiven data infrastructure.
+This example shows the setup for a Terraform project containing a single Redis®* service, and shows off some useful commands to stand up (and destroy) your Aiven data infrastructure.
 
 Prepare the dependencies 
 ''''''''''''''''''''''''

--- a/index.rst
+++ b/index.rst
@@ -8,7 +8,7 @@ Apache Kafka®,
 Apache Flink®,
 OpenSearch®,
 Apache Cassandra®,
-Redis™*,
+Redis®*,
 MySQL,
 InfluxDB® and Grafana®.
 
@@ -104,7 +104,7 @@ Learn about the Aiven platform
 
     ---
 
-    |icon-redis| **Redis™\*** In-memory data store for all your high-peformance short-term storage and caching needs.
+    |icon-redis| **Redis®\*** In-memory data store for all your high-peformance short-term storage and caching needs.
 
     +++
 


### PR DESCRIPTION
* Change the vale rule that checks for `Redis™*` to check for `Redis®*`
* Update the tests for that rule
* Replace all the occurrences of `Redis™*` with `Redis®*`
* Update the Redis acknowledgement text to include the word "registered"

The change to the vale rule was simpler than I expected - it's now very similar to the other "needs an `®`" rules.

Fixes https://github.com/aiven/devportal/issues/938

