### PR TITLE
Clarify SSL certificate verification in PostgreSQL

### DIFF
--- a/docs/platform/concepts/tls-ssl-certificates.rst
+++ b/docs/platform/concepts/tls-ssl-certificates.rst
@@ -17,9 +17,9 @@ Certificate requirements
 
 Most of our services use a browser-recognized CA certificate, but there are exceptions:
 
-- **Aiven for PostgreSQL®** requires the CA certificate to connect.
-
-- **Aiven for Apache Kafka®** requires the CA certificate, and also the client key and certificate.
+- **Aiven for PostgreSQL®** requires the Aiven project CA certificate to connect when using `verify-ca` or `verify-full` as sslmode. The first mode requires the client to verify that the server certificate is actually emitted by the Aiven CA, while the second provides maximum security by performing HTTPS-like validation on the hostname as well. The default sslmode, `require`, ensures TLS is used when connecting to the database, but does not verify the server certificate. For more information, see the `PostgreSQL documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_
+  
+- **Aiven for Apache Kafka®** requires the Aiven project CA certificate, and also the client key and certificate.
 
 For these services you can :doc:`../howto/download-ca-cert` from the service overview page.
 


### PR DESCRIPTION
It isn't actually true that we require users to download a cert to connect to postgresql, since our default suggested sslmode is `require`,
which enables TLS without verifying the server's certificate.

# What changed, and why it matters

Documentation wasn't 100% correct, and could confuse some customers.


