### PR TITLE
fix/opensearch: broken link

### DIFF
--- a/docs/products/opensearch/reference/plugins.rst
+++ b/docs/products/opensearch/reference/plugins.rst
@@ -3,12 +3,6 @@ Plugins available with Aiven for OpenSearch®
 
 Aiven for OpenSearch® includes a standard set of plugins. In addition to the plugins that were previously available in Aiven for Elasticsearch, Aiven for OpenSearch also includes plugins that are designed and developed specifically for OpenSearch.
 
-.. tip::
-
-    If you 
-    are upgrading from Aiven for Elasticsearch, all the existing `supported 
-    plugins <https://help.aiven.io/en/articles/511872-elasticsearch-plugins>`__
-    are included. 
 
 Included plugins
 ----------------


### PR DESCRIPTION
Elasticsearch is no longer our product
and we no longer need this link to the plugins
The link is redirecting to the same page
and therefore removing it.

Fixes #1023 


