### PR TITLE
Fix http output in the page

### DIFF
--- a/docs/tools/api/examples.rst
+++ b/docs/tools/api/examples.rst
@@ -8,7 +8,7 @@ List of cloud regions
 
 .. code::
 
-  curl -H "Authorization: Bearer TOKEN" https://api.aiven.io/v1/clouds
+  curl -H "Authorization: Bearer {TOKEN}" https://api.aiven.io/v1/clouds
 
 The response looks something like this
 

--- a/docs/tools/api/examples.rst
+++ b/docs/tools/api/examples.rst
@@ -1,15 +1,14 @@
 API examples
 ============
 
-Here are a few examples (using curl) to get you started with the Aiven API. Replace all the ``<variables>`` with your own values.
+Here are a few examples (using curl) to get you started with the Aiven API. Replace all ``TOKEN`` with your own value.
 
 List of cloud regions
 ---------------------
 
-::
+.. code::
 
-  curl -H "Authorization: Bearer <token>" \
-    https://api.aiven.io/v1/clouds
+  curl -H "Authorization: Bearer TOKEN" https://api.aiven.io/v1/clouds
 
 The response looks something like this
 

--- a/docs/tools/api/examples.rst
+++ b/docs/tools/api/examples.rst
@@ -1,7 +1,7 @@
 API examples
 ============
 
-Here are a few examples (using curl) to get you started with the Aiven API. Replace all ``TOKEN`` with your own value.
+Here is an example to get you started with the Aiven API using curl. Replace ``{TOKEN}`` with your own value of the authentication token.
 
 List of cloud regions
 ---------------------


### PR DESCRIPTION
page:
https://developer.aiven.io/docs/tools/api/examples.html

Having <token> close to https shows up the url entry
in the page.

So replacing to TOKEN.

Fixes https://github.com/aiven/devportal/issues/888


