### PR TITLE
Migrate Kafka console tool examples

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -2,6 +2,7 @@
 ACL
 ACLs
 Aiven
+Aiven's
 Amazon
 Apache
 API

--- a/_toc.yml
+++ b/_toc.yml
@@ -188,6 +188,8 @@ entries:
                 title: Connect with Java
               - file: docs/products/kafka/howto/connect-with-go
                 title: Connect with Go
+              - file: docs/products/kafka/howto/connect-with-command-line
+                title: Connect with command line
           - file: docs/products/kafka/howto/list-tools
             title: Tools
             entries:

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -61,7 +61,7 @@ With ``kafka-avro-console-producer`` you can include the schema by connecting to
 
    1. The ``schema.registry.url`` value must be a full URL, typically starting with ``https://``
    2. Aiven's `Karapace <https://karapace.io/>`_ is an acceptable schema registry for this purpose.
-      See `Use Karapace with Aiven for Apache Kafka® <enable-karapace.html>`_ for how to enable it for your Aiven for Kafka service. The ``SCHEMA_REGISTRY_`` values for the command line can be found on the service Overview page, on the **Schema registry** tab.
+      See `Use Karapace with Aiven for Apache Kafka® <https://developer.aiven.io/docs/products/kafka/howto/enable-karapace.html>`_ for how to enable it for your Aiven for Kafka service. The ``SCHEMA_REGISTRY_`` values for the command line can be found on the service Overview page, on the **Schema registry** tab.
 
 .. code::
 

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -6,24 +6,24 @@ These examples show how to send messages to and receive messages from an Aiven f
 Pre-requisites
 --------------
 
-``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow
-`the guide to set up properties to use Apache Kafka toolbox <kafka-tools-config-file.html>`_
+``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with the `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow
+`the guide to set up properties to use the Apache Kafka toolbox <kafka-tools-config-file.html>`_
 For ``kafka-avro-console-producer`` follow the installation instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
 
 Variables
 ---------
 
-========================     ========================================================================================================================
+========================     ===========================================================================================
 Variable                     Description
-========================     ========================================================================================================================
+========================     ===========================================================================================
 ``HOST``                     Host name for the connection
 ``PORT``                     Port number to use for the Kafka service
 ``CONFIGURATION_PATH``       Path to your configuration file `for Apache Kafka toolbox <kafka-tools-config-file.html>`_.
-``SCHEMA_REGISTRY_HOST``      Host name for your schema registry
-``SCHEMA_REGISTRY_PORT``      Port number for your schema registry
-``SCHEMA_REGISTRY_USER``      User name for your schema registry
-``SCHEMA_REGISTRY_PWD``       Password for your schema registry
-========================     ========================================================================================================================
+``SCHEMA_REGISTRY_HOST``     Host name for your schema registry
+``SCHEMA_REGISTRY_PORT``     Port number for your schema registry
+``SCHEMA_REGISTRY_USER``     User name for your schema registry
+``SCHEMA_REGISTRY_PWD``      Password for your schema registry
+========================     ===========================================================================================
 
 Produce messages
 -----------------
@@ -33,8 +33,8 @@ With ``kafka-console-producer`` you can send multiple messages into your topic.
 .. code::
 
     kafka-console-producer --broker-list {HOST}:{PORT} \
-    --topic target-topic \
-    --producer.config {CONFIGURATION_PATH}
+      --topic target-topic \
+      --producer.config {CONFIGURATION_PATH}
 
 Produce messages with schema
 ----------------------------
@@ -44,12 +44,12 @@ With ``kafka-avro-console-producer`` you can include the schema by connecting to
 .. code::
 
     kafka-avro-console-producer --broker-list {HOST}:{PORT} \
-    --producer.config {CONFIGURATION_PATH} \
-    --topic target-topic \
-    --property value.schema='{"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}' \
-    --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PASSWORD} \
-    --property basic.auth.credentials.source=USER_INFO \
-    --property basic.auth.user.info={SCHEMA_REGISTRY_USER}:{SCHEMA_REGISTRY_PASSWORD}
+      --producer.config {CONFIGURATION_PATH} \
+      --topic target-topic \
+      --property value.schema='{"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}' \
+      --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PASSWORD} \
+      --property basic.auth.credentials.source=USER_INFO \
+      --property basic.auth.user.info={SCHEMA_REGISTRY_USER}:{SCHEMA_REGISTRY_PASSWORD}
 
 Consume messages
 -----------------
@@ -59,6 +59,6 @@ With ``kafka-console-consumer`` you can read messages from your topic. For examp
 .. code::
 
     kafka-console-consumer --bootstrap-server {HOST}:{PORT} \
-    --topic target-topic  \
-    --consumer.config {CONFIGURATION_PATH} \
-    --from-beginning
+      --topic target-topic  \
+      --consumer.config {CONFIGURATION_PATH} \
+      --from-beginning

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -36,6 +36,13 @@ With ``kafka-console-producer`` you can send multiple messages into your topic.
       --topic target-topic \
       --producer.config {CONFIGURATION_PATH}
 
+Once the connection is successfully established you can send messages one after another by typing them in the terminal. For example:
+
+.. code::
+
+    message1
+    message2
+
 Produce messages with schema
 ----------------------------
 
@@ -50,6 +57,16 @@ With ``kafka-avro-console-producer`` you can include the schema by connecting to
       --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PASSWORD} \
       --property basic.auth.credentials.source=USER_INFO \
       --property basic.auth.user.info={SCHEMA_REGISTRY_USER}:{SCHEMA_REGISTRY_PASSWORD}
+
+After the connection is established you can send messages according to selected schema. For example:
+
+.. code::
+
+    {"id": "1"}
+
+.. note::
+
+    For more details how to use ``kafka-avro-console-producer`` check `Confluent developer documentation <https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/kafka-commands.html#consume-avro-records>`_.
 
 Consume messages
 -----------------

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -1,12 +1,13 @@
 Connect to Aiven for Apache Kafka® with command line tools
 ==========================================================
 
-These examples show how to send messages to and receive messages from an Aiven for Apache Kafka service using command line tools.
+These examples show how to send messages to and receive messages from an Aiven for Apache Kafka® service using command line tools.
 
 Pre-requisites
 --------------
 
-``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow :doc:`the guide to set up properties to use Apache Kafka toolbox <kafka-tools-config-file>`.
+``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow
+`the guide to set up properties to use Apache Kafka toolbox <kafka-tools-config-file.html>`_
 For ``kafka-avro-console-producer`` follow the installation instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
 
 Variables
@@ -17,7 +18,7 @@ Variable                     Description
 ========================     ========================================================================================================================
 ``HOST``                     Host name for the connection
 ``PORT``                     Port number to use for the Kafka service
-``CONFIGURATION_PATH``       Path to your configuration file :doc:`for Apache Kafka toolbox <kafka-tools-config-file>`.
+``CONFIGURATION_PATH``       Path to your configuration file `for Apache Kafka toolbox <kafka-tools-config-file.html>`_.
 ``SCHEMA_REGISTRY_HOST``      Host name for your schema registry
 ``SCHEMA_REGISTRY_PORT``      Port number for your schema registry
 ``SCHEMA_REGISTRY_USER``      User name for your schema registry

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -6,7 +6,7 @@ These examples show how to connect to an Aiven for Apache Kafka® command line c
 Pre-requisites
 --------------
 
-Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up `kafka-console-producer` and `kafka-console-consumer`. For `kafka-avro-console-producer` follow the instructions in `its github repository <https://github.com/confluentinc/schema-registry>`_.
+Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up ``kafka-console-producer`` and ``kafka-console-consumer``. For ``kafka-avro-console-producer`` follow the instructions in `its github repository <https://github.com/confluentinc/schema-registry>`_.
 
 Create the keystore ``client.keystore.p12`` and truststore ``client.truststore.jks`` by following  :doc:`our article on configuring Java SSL to access Kafka <../howto/keystore-truststore>`.
 
@@ -54,7 +54,7 @@ Both producer and consumer will need to securely connect to the Apache Kafka ser
 Produce messages
 -----------------
 
-With `kafka-console-producer` you can send multiple messages into your topic.
+With ``kafka-console-producer`` you can send multiple messages into your topic.
 
 .. code::
 
@@ -65,7 +65,7 @@ With `kafka-console-producer` you can send multiple messages into your topic.
 Produce messages with schema
 ----------------------------
 
-With `kafka-avro-console-producer` you can include the schema by connecting to your schema registry
+With ``kafka-avro-console-producer`` you can include the schema by connecting to your schema registry
 
 .. code::
 
@@ -80,7 +80,7 @@ With `kafka-avro-console-producer` you can include the schema by connecting to y
 Consume messages
 -----------------
 
-With `kafka-console-consumer` you can read messages from your topic. For example, run the command below to start reading from the beginning of the topic.
+With ``kafka-console-consumer`` you can read messages from your topic. For example, run the command below to start reading from the beginning of the topic.
 
 .. code::
 

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -6,7 +6,7 @@ These examples show how to connect to an Aiven for Apache Kafka® command line c
 Pre-requisites
 --------------
 
-Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up ``kafka-console-producer`` and ``kafka-console-consumer``. For ``kafka-avro-console-producer`` follow the instructions in `its github repository <https://github.com/confluentinc/schema-registry>`_.
+Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up ``kafka-console-producer`` and ``kafka-console-consumer``. For ``kafka-avro-console-producer`` follow the instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
 
 Create the keystore ``client.keystore.p12`` and truststore ``client.truststore.jks`` by following  :doc:`our article on configuring Java SSL to access Kafka <../howto/keystore-truststore>`.
 

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -6,9 +6,15 @@ These examples show how to send messages to and receive messages from an Aiven f
 Pre-requisites
 --------------
 
-``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with the `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow
+``kafka-console-producer.sh`` and ``kafka-console-consumer.sh`` are part of the Apache Kafka® toolbox included with the `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. They may be found in the ``bin`` directory of the unpacked archive.
+
+For ``kafka-avro-console-producer`` follow the installation instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_, or
+get the Confluent platform using the **Tar archive** option at `Quick Start for Confluent Platform <https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html>`_. The ``kafka-avro-console-producer`` tool is in the ``bin`` directory of the unpacked Confluent archive.
+
+.. note:: You do not need to install the Confluent platform to use the ``kafka-avro-console-producer`` tool with an Aiven for Apache Kafka service that is using Karapace.
+
+To setup the configuration file needed by all three tools, follow
 `the guide to set up properties to use the Apache Kafka toolbox <kafka-tools-config-file.html>`_
-For ``kafka-avro-console-producer`` follow the installation instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
 
 Variables
 ---------
@@ -23,7 +29,10 @@ Variable                     Description
 ``SCHEMA_REGISTRY_PORT``     Port number for your schema registry
 ``SCHEMA_REGISTRY_USER``     User name for your schema registry
 ``SCHEMA_REGISTRY_PWD``      Password for your schema registry
+``TARGET_TOPIC``             The name of the Kafka topic to be written to/read from
 ========================     ===========================================================================================
+
+In the command lines below, values in ``{`` and ``}`` are to be replaced - so ``{PORT}`` would be replaced by the appropriate port number, for instance ``12345``.
 
 Produce messages
 -----------------
@@ -32,8 +41,8 @@ With ``kafka-console-producer`` you can send multiple messages into your topic.
 
 .. code::
 
-    kafka-console-producer --broker-list {HOST}:{PORT} \
-      --topic target-topic \
+    kafka-console-producer.sh --broker-list {HOST}:{PORT} \
+      --topic {TARGET_TOPIC} \
       --producer.config {CONFIGURATION_PATH}
 
 Once the connection is successfully established you can send messages one after another by typing them in the terminal. For example:
@@ -48,13 +57,19 @@ Produce messages with schema
 
 With ``kafka-avro-console-producer`` you can include the schema by connecting to your schema registry
 
+.. note::
+
+   1. The ``schema.registry.url`` value must be a full URL, typically starting with ``https://``
+   2. Aiven's `Karapace <https://karapace.io/>`_ is an acceptable schema registry for this purpose.
+      See `Use Karapace with Aiven for Apache Kafka® <enable-karapace.html>`_ for how to enable it for your Aiven for Kafka service. The ``SCHEMA_REGISTRY_`` values for the command line can be found on the service Overview page, on the **Schema registry** tab.
+
 .. code::
 
     kafka-avro-console-producer --broker-list {HOST}:{PORT} \
       --producer.config {CONFIGURATION_PATH} \
-      --topic target-topic \
+      --topic {TARGET_TOPIC} \
       --property value.schema='{"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}' \
-      --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PASSWORD} \
+      --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PORT} \
       --property basic.auth.credentials.source=USER_INFO \
       --property basic.auth.user.info={SCHEMA_REGISTRY_USER}:{SCHEMA_REGISTRY_PASSWORD}
 
@@ -66,7 +81,7 @@ After the connection is established you can send messages according to selected 
 
 .. note::
 
-    For more details how to use ``kafka-avro-console-producer`` check `Confluent developer documentation <https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/kafka-commands.html#consume-avro-records>`_.
+    For more information on how to use ``kafka-avro-console-producer`` see the `Confluent developer documentation <https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/kafka-commands.html#consume-avro-records>`_.
 
 Consume messages
 -----------------
@@ -75,7 +90,7 @@ With ``kafka-console-consumer`` you can read messages from your topic. For examp
 
 .. code::
 
-    kafka-console-consumer --bootstrap-server {HOST}:{PORT} \
-      --topic target-topic  \
+    kafka-console-consumer.sh --bootstrap-server {HOST}:{PORT} \
+      --topic {TARGET_TOPIC}  \
       --consumer.config {CONFIGURATION_PATH} \
       --from-beginning

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -27,10 +27,10 @@ Variable                     Description
 ``TRUSTSTORE_LOCATION``      Location of your truststore (named by default as client.truststore.jks)
 ``TRUSTSTORE_PASSWORD``      Password you used when creating a truststore
 ``CONFIGURATION_PATH``       Path to your configuration file with security protocol details.
-``SCHEMA_REGISRY_HOST``      Host name for your schema registry
-``SCHEMA_REGISRY_PORT``      Port number for your schema registry
-``SCHEMA_REGISRY_USER``      User name for your schema registry
-``SCHEMA_REGISRY_PWD``       Password for your schema registry
+``SCHEMA_REGISTRY_HOST``     Host name for your schema registry
+``SCHEMA_REGISTRY_PORT``     Port number for your schema registry
+``SCHEMA_REGISTRY_USER``     User name for your schema registry
+``SCHEMA_REGISTRY_PWD``      Password for your schema registry
 ========================     =======================================================================================================
 
 Create configuration file
@@ -73,9 +73,9 @@ With ``kafka-avro-console-producer`` you can include the schema by connecting to
     --producer.config {CONFIGURATION_PATH} \
     --topic target-topic \
     --property value.schema='{"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}' \
-    --property schema.registry.url={SCHEMA_REGISRY_HOST}:{SCHEMA_REGISRY_PASSWORD} \
+    --property schema.registry.url={SCHEMA_REGISTRY_HOST}:{SCHEMA_REGISTRY_PASSWORD} \
     --property basic.auth.credentials.source=USER_INFO \
-    --property basic.auth.user.info={SCHEMA_REGISRY_USER}:{SCHEMA_REGISRY_PASSWORD}
+    --property basic.auth.user.info={SCHEMA_REGISTRY_USER}:{SCHEMA_REGISTRY_PASSWORD}
 
 Consume messages
 -----------------

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -1,56 +1,28 @@
 Connect to Aiven for Apache Kafka® with command line tools
 ==========================================================
 
-These examples show how to connect to an Aiven for Apache Kafka® command line clients.
+These examples show how to send messages to and receive messages from an Aiven for Apache Kafka service using command line tools.
 
 Pre-requisites
 --------------
 
-Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up ``kafka-console-producer`` and ``kafka-console-consumer``. For ``kafka-avro-console-producer`` follow the instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
-
-Create the keystore ``client.keystore.p12`` and truststore ``client.truststore.jks`` by following  :doc:`our article on configuring Java SSL to access Kafka <../howto/keystore-truststore>`.
-
-.. Warning::
-
-  In the below examples, we just pass the name of the certificate files, but in actual use, the full path should be used.
+``kafka-console-producer`` and ``kafka-console-consumer`` are part of the Apache Kafka® toolbox included with `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_. Follow :doc:`the guide to set up properties to use Apache Kafka toolbox <kafka-tools-config-file>`.
+For ``kafka-avro-console-producer`` follow the installation instructions in `its GitHub repository <https://github.com/confluentinc/schema-registry>`_.
 
 Variables
 ---------
 
-========================     =======================================================================================================
+========================     ========================================================================================================================
 Variable                     Description
-========================     =======================================================================================================
-``HOST``                     Host name for the Kafka service
+========================     ========================================================================================================================
+``HOST``                     Host name for the connection
 ``PORT``                     Port number to use for the Kafka service
-``KEYSTORE_LOCATION``        Location of you keystore (named by default as client.keystore.p12)
-``KEYSTORE_PASSWORD``        Password you used when creating a keystore
-``KEY_PASSWORD``             Password for the key in the keystore, if you chose a different password than the one for keystore
-``TRUSTSTORE_LOCATION``      Location of your truststore (named by default as client.truststore.jks)
-``TRUSTSTORE_PASSWORD``      Password you used when creating a truststore
-``CONFIGURATION_PATH``       Path to your configuration file with security protocol details.
-``SCHEMA_REGISTRY_HOST``     Host name for your schema registry
-``SCHEMA_REGISTRY_PORT``     Port number for your schema registry
-``SCHEMA_REGISTRY_USER``     User name for your schema registry
-``SCHEMA_REGISTRY_PWD``      Password for your schema registry
-========================     =======================================================================================================
-
-Create configuration file
--------------------------
-
-Both producer and consumer will need to securely connect to the Apache Kafka service. Put your connection properties into a configuration file:
-
-.. code::
-
-   security.protocol=SSL
-   ssl.protocol=TLS
-   ssl.key.password={KEY_PASSWORD}
-   ssl.keystore.location={KEYSTORE_LOCATION}
-   ssl.keystore.password={KEYSTORE_PASSWORD}
-   ssl.keystore.type=PKCS12
-   ssl.truststore.location={TRUSTSTORE_LOCATION}
-   ssl.truststore.password={TRUSTSTORE_PASSWORD}
-   ssl.truststore.type=JKS
-
+``CONFIGURATION_PATH``       Path to your configuration file :doc:`for Apache Kafka toolbox <kafka-tools-config-file>`.
+``SCHEMA_REGISTRY_HOST``      Host name for your schema registry
+``SCHEMA_REGISTRY_PORT``      Port number for your schema registry
+``SCHEMA_REGISTRY_USER``      User name for your schema registry
+``SCHEMA_REGISTRY_PWD``       Password for your schema registry
+========================     ========================================================================================================================
 
 Produce messages
 -----------------

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -14,7 +14,7 @@ get the Confluent platform using the **Tar archive** option at `Quick Start for 
 .. note:: You do not need to install the Confluent platform to use the ``kafka-avro-console-producer`` tool with an Aiven for Apache Kafka service that is using Karapace.
 
 To setup the configuration file needed by all three tools, follow
-`the guide to set up properties to use the Apache Kafka toolbox <kafka-tools-config-file.html>`_
+`the guide to set up properties to use the Apache Kafka toolbox`_.
 
 Variables
 ---------
@@ -24,13 +24,17 @@ Variable                     Description
 ========================     ===========================================================================================
 ``HOST``                     Host name for the connection
 ``PORT``                     Port number to use for the Kafka service
-``CONFIGURATION_PATH``       Path to your configuration file `for Apache Kafka toolbox <kafka-tools-config-file.html>`_.
+``CONFIGURATION_PATH``       Path to your configuration file `for Apache Kafka toolbox`_
 ``SCHEMA_REGISTRY_HOST``     Host name for your schema registry
 ``SCHEMA_REGISTRY_PORT``     Port number for your schema registry
 ``SCHEMA_REGISTRY_USER``     User name for your schema registry
 ``SCHEMA_REGISTRY_PWD``      Password for your schema registry
 ``TARGET_TOPIC``             The name of the Kafka topic to be written to/read from
 ========================     ===========================================================================================
+
+.. _`the guide to set up properties to use the Apache Kafka toolbox`: toolbox_
+.. _`for Apache Kafka toolbox`: toolbox_
+.. _toolbox: https://developer.aiven.io/docs/products/kafka/howto/kafka-tools-config-file.html
 
 In the command lines below, values in ``{`` and ``}`` are to be replaced - so ``{PORT}`` would be replaced by the appropriate port number, for instance ``12345``.
 

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -1,0 +1,90 @@
+Connect to Aiven for Apache Kafka® with command line tools
+==========================================================
+
+These examples show how to connect to an Aiven for Apache Kafka® command line clients.
+
+Pre-requisites
+--------------
+
+Follow `Apache Kafka documentation <https://kafka.apache.org/downloads>`_ to set up `kafka-console-producer` and `kafka-console-consumer`. For `kafka-avro-console-producer` follow the instructions in `its github repository <https://github.com/confluentinc/schema-registry>`_.
+
+Create the keystore ``client.keystore.p12`` and truststore ``client.truststore.jks`` by following  :doc:`our article on configuring Java SSL to access Kafka <../howto/keystore-truststore>`.
+
+.. Warning::
+
+  In the below examples, we just pass the name of the certificate files, but in actual use, the full path should be used.
+
+Variables
+---------
+
+========================     =======================================================================================================
+Variable                     Description
+========================     =======================================================================================================
+``HOST``                     Host name for the connection
+``KEYSTORE_LOCATION``        Location of you keystore (named by default as client.keystore.p12)
+``KEYSTORE_PASSWORD``        Password you used when creating a keystore
+``KEY_PASSWORD``             Password for the key in the keystore, if you chose a different password than the one for keystore
+``TRUSTSTORE_LOCATION``      Location of your truststore (named by default as client.truststore.jks)
+``TRUSTSTORE_PASSWORD``      Password you used when creating a truststore
+``CONFIGURATION_PATH``       Path to your configuration file with security protocol details.
+``SCHEMA_REGISRY_HOST``      Host name for your schema registry
+``SCHEMA_REGISRY_PORT``      Port number for your schema registry
+``SCHEMA_REGISRY_USER``      User name for your schema registry
+``SCHEMA_REGISRY_PWD``       Password for your schema registry
+========================     =======================================================================================================
+
+Create configuration file
+-------------------------
+
+Both producer and consumer will need to securely connect to the Apache Kafka service. Put your connection properties into a configuration file:
+
+.. code::
+
+   security.protocol=SSL
+   ssl.protocol=TLS
+   ssl.key.password={KEY_PASSWORD}
+   ssl.keystore.location={KEYSTORE_LOCATION}
+   ssl.keystore.password={KEYSTORE_PASSWORD}
+   ssl.keystore.type=PKCS12
+   ssl.truststore.location={TRUSTSTORE_LOCATION}
+   ssl.truststore.password={TRUSTSTORE_PASSWORD}
+   ssl.truststore.type=JKS
+
+
+Produce messages
+-----------------
+
+With `kafka-console-producer` you can send multiple messages into your topic.
+
+.. code::
+
+    kafka-console-producer --broker-list {HOST}:{PORT} \
+    --topic target-topic \
+    --producer.config {CONFIGURATION_PATH}
+
+Produce messages with schema
+----------------------------
+
+With `kafka-avro-console-producer` you can include the schema by connecting to your schema registry
+
+.. code::
+
+    kafka-avro-console-producer --broker-list {HOST}:{PORT} \
+    --producer.config {CONFIGURATION_PATH} \
+    --topic target-topic \
+    --property value.schema='{"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}' \
+    --property schema.registry.url={SCHEMA_REGISRY_HOST}:{SCHEMA_REGISRY_PASSWORD} \
+    --property basic.auth.credentials.source=USER_INFO \
+    --property basic.auth.user.info={SCHEMA_REGISRY_USER}:{SCHEMA_REGISRY_PASSWORD}
+
+Consume messages
+-----------------
+
+With `kafka-console-consumer` you can read messages from your topic. For example, run the command below to start reading from the beginning of the topic.
+
+.. code::
+
+    kafka-console-consumer --bootstrap-server {HOST}:{PORT} \
+    --topic target-topic  \
+    --consumer.config {CONFIGURATION_PATH} \
+    --from-beginning

--- a/docs/products/kafka/howto/connect-with-command-line.rst
+++ b/docs/products/kafka/howto/connect-with-command-line.rst
@@ -20,7 +20,8 @@ Variables
 ========================     =======================================================================================================
 Variable                     Description
 ========================     =======================================================================================================
-``HOST``                     Host name for the connection
+``HOST``                     Host name for the Kafka service
+``PORT``                     Port number to use for the Kafka service
 ``KEYSTORE_LOCATION``        Location of you keystore (named by default as client.keystore.p12)
 ``KEYSTORE_PASSWORD``        Password you used when creating a keystore
 ``KEY_PASSWORD``             Password for the key in the keystore, if you chose a different password than the one for keystore

--- a/docs/products/kafka/howto/kafka-tools-config-file.rst
+++ b/docs/products/kafka/howto/kafka-tools-config-file.rst
@@ -1,20 +1,25 @@
-Configure consumer properties for Apache Kafka® toolbox
+Configure properties for Apache Kafka® toolbox
 ==========================================================
 
 The `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_ includes a series of tools under the ``bin`` directory that can be useful to manage and interact with Aiven for Apache Kafka®.
-Before using the tools, you need to configure a ``consumer.properties`` file pointing to a Java keystore and truststore which contain the required certificates for authentication.
+Before using the tools, you need to configure a file pointing to a Java keystore and truststore which contain the required certificates for authentication.
+
+.. note::
+
+    There is no restrictions on the file name, but make sure to use correct file name when performing cli operations. In the examples below we'll name the file `configuration.properties`.
 
 Define the configuration file
 -----------------------------
 
 #. Create the Java keystore and truststore for your Aiven for Apache Kafka® service using the :ref:`dedicated Aiven CLI command <avn_service_user_kafka_java_creds>`.
 
-#. Create a ``consumer.properties`` file pointing to the keystore and truststore with the following entries:
+#. Create a ``configuration.properties`` file pointing to the keystore and truststore with the following entries:
 
 * ``security.protocol``: security protocol, SSL for the default TLS security settings
 * ``ssl.keystore.type``: keystore type, ``PKCS12`` for the keystore generated with the :ref:`dedicated Aiven CLI command <avn_service_user_kafka_java_creds>`
 * ``ssl.keystore.location``: keystore location on the file system
 * ``ssl.keystore.password``: keystore password
+* ``ssl.truststore.type``: truststore type
 * ``ssl.truststore.location``: truststore location on the file system
 * ``ssl.truststore.password``: truststore password
 * ``ssl.key.password``: keystore password
@@ -23,12 +28,14 @@ Define the configuration file
 
     The ``avn service user-kafka-java-creds`` :ref:`Aiven CLI command <avn_service_user_kafka_java_creds>` accepts a ``--password`` parameter setting the same password for the truststore, keystore and key
    
-An example of the ``consumer.properties`` content is the following::
+An example of the ``configuration.properties`` content is the following::
 
     security.protocol=SSL
+    ssl.protocol=TLS
     ssl.keystore.type=PKCS12
     ssl.keystore.location=client.keystore.p12
     ssl.keystore.password=changeit
     ssl.key.password=changeit
     ssl.truststore.location=client.truststore.jks
     ssl.truststore.password=changeit
+    ssl.truststore.type=JKS

--- a/docs/products/kafka/howto/kafka-tools-config-file.rst
+++ b/docs/products/kafka/howto/kafka-tools-config-file.rst
@@ -6,7 +6,7 @@ Before using the tools, you need to configure a file pointing to a Java keystore
 
 .. note::
 
-    There are no restrictions on the file name, but make sure to use the correct name when performing CLI operations. In the examples below we'll name the file ``configuration.properties```.
+    There are no restrictions on the file name, but make sure to use the correct name when performing CLI operations. In the examples below we'll name the file ``configuration.properties``.
 
 Define the configuration file
 -----------------------------

--- a/docs/products/kafka/howto/kafka-tools-config-file.rst
+++ b/docs/products/kafka/howto/kafka-tools-config-file.rst
@@ -1,12 +1,12 @@
 Configure properties for Apache Kafka® toolbox
 ==========================================================
 
-The `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_ includes a series of tools under the ``bin`` directory that can be useful to manage and interact with Aiven for Apache Kafka®.
+The `open source Apache Kafka® code <https://kafka.apache.org/downloads>`_ includes a series of tools under the ``bin`` directory that can be useful to manage and interact with an Aiven for Apache Kafka® service.
 Before using the tools, you need to configure a file pointing to a Java keystore and truststore which contain the required certificates for authentication.
 
 .. note::
 
-    There is no restrictions on the file name, but make sure to use correct file name when performing cli operations. In the examples below we'll name the file `configuration.properties`.
+    There are no restrictions on the file name, but make sure to use the correct name when performing CLI operations. In the examples below we'll name the file ``configuration.properties```.
 
 Define the configuration file
 -----------------------------


### PR DESCRIPTION
# What changed, and why it matters

Migrated https://help.aiven.io/en/articles/5344081-kafka-console-tool-examples-for-testing-aiven-for-apache-kafka
