### PR TITLE
add/requirements: pygments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary==2.9.1
 sphinxext-opengraph==0.4.2
 sphinx-sitemap==2.2.0
 sphinx-notfound-page==0.8
+pygments==2.12.0


### PR DESCRIPTION
Add an updated version of pygments.
This helps to not depend on the sphinix
version or other package to be updated to
use pygments on v2.12.0

Previous versions have issues supporting
terraform highlight.

This avoid this error:

```
WARNING: Could not lex literal_block as "terraform". Highlighting skipped.
```

You can check out more info:
https://github.com/pygments/pygments/issues/2162


