### PR TITLE
warn about whitespace in ip_filter

### DIFF
--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -650,12 +650,14 @@ Updates the settings for an Aiven service.
     avn service update big-service        \
       --plan business-4     
 
-**Example:** Update the service named ``secure-database`` to only accept connections from the range ``10.0.1.0/24`` and the IP ``10.25.10.12``. Note that there is no whitespace between the IP addresses in the command below.
+**Example:** Update the service named ``secure-database`` to only accept connections from the range ``10.0.1.0/24`` and the IP ``10.25.10.12``.
 
 ::
 
     avn service update secure-database \
       -c ip_filter=10.0.1.0/24,10.25.10.1/32
+
+.. note:: There is no whitespace between the IP addresses and comma in the command.
 
 
 ``avn service user``

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -650,7 +650,7 @@ Updates the settings for an Aiven service.
     avn service update big-service        \
       --plan business-4     
 
-**Example:** Update the service named ``secure-database`` to only accept connections from the range ``10.0.1.0/24`` and the IP ``10.25.10.12``.
+**Example:** Update the service named ``secure-database`` to only accept connections from the range ``10.0.1.0/24`` and the IP ``10.25.10.12``. Note that there is no whitespace between the IP addresses in the command below.
 
 ::
 


### PR DESCRIPTION
# What changed, and why it matters

If whitespace is added between values in the ip_filter it can lead to a confusing error. Calling it out here will make it clear to omit any whitespace between values
