### PR TITLE
Tiny link fixes for platform page

### DIFF
--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -35,7 +35,7 @@ Learn about some of the key concepts for working with Aiven platform:
 
   Securing connections to Aiven services with certificates.
 
-* :doc: `Dynamic Disk Sizing (DDS) </docs/platform/concepts/dynamic-disk-sizing>`.
+* :doc:`Dynamic Disk Sizing (DDS) </docs/platform/concepts/dynamic-disk-sizing>`.
 
   Add (and remove) storage on the fly without upgrading your plan.
 

--- a/docs/platform/concepts/logs-metrics-alerts.rst
+++ b/docs/platform/concepts/logs-metrics-alerts.rst
@@ -21,5 +21,5 @@ You can create custom OpenSearch® or Grafana® dashboards to monitor the servic
 Alerts
 ------
 
-The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <http://help.aiven.io/en/articles/5234705-technical-emails>`_.
+The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <https://help.aiven.io/en/articles/5234705-technical-emails>`_.
 


### PR DESCRIPTION
# What changed, and why it matters

We had a bug report of a non-SSL link to a help article - and I also spotted a misformatted link on the main page.

