### PR TITLE
Fix links that got broken after the changes in OpenSearch documentation

### DIFF
--- a/docs/products/opensearch/howto/opensearch-search-and-python.rst
+++ b/docs/products/opensearch/howto/opensearch-search-and-python.rst
@@ -296,11 +296,6 @@ Suppose you are looking for citrus recipes 🍋. For example, recipes with ingre
 
   python search.py multi-match title ingredients lemon
 
-
-.. seealso::
-
-  Check out more about `multi match query <https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match>`_ on the OpenSearch documentation.
-
 .. _match-phrase-query:
 
 Match with phrases
@@ -379,7 +374,7 @@ So with ``slop`` parameter adjusted, you're may be able to find results even wit
 
 .. seealso::
 
-  Read more about ``slop`` parameter on the `OpenSearch project specifications <https://opensearch.org/docs/latest/opensearch/query-dsl/full-text#options>`_.
+  Read more about ``slop`` parameter on the `OpenSearch project specifications <https://opensearch.org/docs/latest/opensearch/query-dsl/full-text#other-optional-query-fields>`_.
 
 
 Use a ``term`` query


### PR DESCRIPTION
# What changed, and why it matters

For several last days the link check fails for two OpenSearch links. I replaced one of the link and removed another one.


