### PR TITLE
Added details about service account permission

### DIFF
--- a/docs/platform/concepts/projects_accounts_access.rst
+++ b/docs/platform/concepts/projects_accounts_access.rst
@@ -90,7 +90,8 @@ The roles and corresponding permissions that Aiven supports are:
      - 
      - 
      - 
-
+.. Note::
+    Read-Only role cannot view or copy service account passwords.  Administrator, Operator and Developer can fully manage service accounts.
 
 Teams
 -----


### PR DESCRIPTION
Current role matrix does not explain which role can or cannot view service account password or manage service accounts.
Added details about service account permission.