### PR TITLE
cassandra: add help article on tombstones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 *.ipr
 env/
 venv/
+.venv/

--- a/_toc.yml
+++ b/_toc.yml
@@ -630,6 +630,10 @@ entries:
   - file: docs/products/cassandra
     title: Apache Cassandra
     entries:
+      - file: docs/products/cassandra/concepts
+        title: Concepts
+        entries:
+          - glob: docs/products/cassandra/concepts/*
       - file: docs/products/cassandra/reference
         title: Reference
         entries:

--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,7 @@ templates_path = ['_templates']
 exclude_patterns = [
     '_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils',
     'CONTRIBUTING.rst', 'REVIEWING.rst', 'includes',
-    '.github/vale'
+    '.github/vale', '.venv',
 ]
 
 # gitstamp config

--- a/docs/products/cassandra.rst
+++ b/docs/products/cassandra.rst
@@ -23,4 +23,9 @@ Get started with Aiven for Apache Cassandra
 Find more information about Apache Cassandra in the following sections:
 
 .. panels::
+
+    📚 :doc:`Concepts </docs/products/cassandra/concepts>`
+
+    ---
+
     📖 :doc:`/docs/products/cassandra/reference`

--- a/docs/products/cassandra/concepts.rst
+++ b/docs/products/cassandra/concepts.rst
@@ -1,0 +1,6 @@
+Guides for Apache Cassandra®
+============================
+
+In this section you can find guides for working with Aiven for Apache Cassandra®.
+
+.. tableofcontents::

--- a/docs/products/cassandra/concepts/tombstones.rst
+++ b/docs/products/cassandra/concepts/tombstones.rst
@@ -1,0 +1,66 @@
+Tombstones in Apache Cassandra®
+===============================
+
+Apache Cassandra manages deletion of data via a mechanism called *tombstones*. Because Cassandra is a distributed system,
+it cannot delete data immediately in the same way as a traditional relational database. On a high-level, when a row is
+deleted, instead of immediately deleting it, Cassandra will mark it as a tombstone row. Then, as part of regularly scheduled
+maintenance, the row will actually get deleted. This maintenance is called *compaction* and the threshold is controlled by
+the table-level setting ``gc_grace_seconds``. Any tombstone older than this setting will be removed completely during
+compaction (with some caveats - more details in the Cassandra `documentation <compaction-tombstones_>`_ on compaction). The
+default value for this setting is 864000 seconds (10 days).
+
+Problems caused by tombstones
+-----------------------------
+
+Excessive amounts of tombstone rows can lead to various problems since the data is still there on disk, it's just got a
+tombstone marker attached to it. If your workload includes a lot of data deletion, you are more likely to face problems.
+Tombstones also result in a lot of garbage collection, which can affect cluster stability. The two main things affected are
+read performance and disk usage.
+
+**Read performance**: if read queries have to scan large numbers of tombstones, the query performance can be significantly
+degraded. In particularly bad cases, the query can even time out. There are a couple of types of queries that are more likely
+to be affected by this. They all involve scanning all or a large part of a table.
+
+* Full table scans like ``SELECT * from inventory.items``
+* Any query that requires adding ``ALLOW FILTERING``
+* Range queries, i.e. queries with ``WHERE item_cost > threshold`` or similar
+
+**Disk usage**: if you are rapidly filling up your cluster with data at the same time as you are doing a lot of
+deletions, you will reach size limits sooner. This is because the tombstone data is not actually deleted and still taking up
+space on disk.
+
+
+If you suspect problems caused by tombstones for your cluster, you can check the logs. By default, if a query encounters over
+1000 tombstones (configured by `tombstone_warn_threshold <cassandra-tombstone-warn_>`_) it will generate a log entry. The
+entry will be in the format ``Read <X> live rows and <Y> tombstone cells for query <query> [...] (see tombstone_warn_threshold)``.
+
+If it encounters over 100 000 tombstones (configured by ``tombstone_failure_threshold)``, the query will be aborted with a
+``TombstoneOverwhelmingException`` (or just time out). To investigate a query that is encountering tombstones, the easiest
+way is to connect with a ``cqlsh`` session and run ``TRACING ON`` followed by the query of interest. You can view values of
+Cassandra settings with ``SELECT * FROM system_views.settings WHERE name = '<setting name>';``.
+
+Preventing tombstone problems
+-----------------------------
+
+Often there is no "quick fix" solution for tombstone-related performance problems. Instead, you might want to rethink your
+data model or your query strategy. Implementing something like table-level `time-to-live <cassandra-ttl_>`_ (TTL) or using
+`TimeWindowCompactionStrategy <cassandra-twcs_>`_ (TWCS) as the compaction strategy might help mitigate these issues. In
+short, some of the solutions available are:
+
+* Review your data model and compaction strategy and consider implementing table TTL and TWCS.
+* Avoid queries that end up running on all partitions in a table (queries with no ``WHERE`` clause, queries that need
+  ``ALLOW FILTERING``).
+* Update your queries so that they don't have to scan over tombstone rows in the same manner. For range queries, this might
+  mean investigating if you can use a narrower range, or use a different approach to the query.
+* If you are planning to delete all the data in a table, you can truncate the table to avoid creating tombstones.
+
+Removing existing tombstones
+----------------------------
+
+The best is to wait for it to happen automatically as part of regular operations. Once more time than ``gc_grace_seconds``
+has elapsed and a compaction happens, the tombstoned data will be removed from disk.
+
+.. _compaction-tombstones: https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/index.html#the-gc_grace_seconds-parameter-and-tombstone-removal
+.. _cassandra-tombstone-warn: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#tombstone_warn_threshold
+.. _cassandra-twcs: https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/twcs.html
+.. _cassandra-ttl: https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/#ttl

--- a/docs/products/cassandra/concepts/tombstones.rst
+++ b/docs/products/cassandra/concepts/tombstones.rst
@@ -6,18 +6,23 @@ it cannot delete data immediately in the same way as a traditional relational da
 deleted, instead of immediately deleting it, Cassandra will mark it as a tombstone row. Then, as part of regularly scheduled
 maintenance, the row will actually get deleted. This maintenance is called *compaction* and the threshold is controlled by
 the table-level setting ``gc_grace_seconds``. Any tombstone older than this setting will be removed completely during
-compaction (with some caveats - more details in the Cassandra `documentation <compaction-tombstones_>`_ on compaction). The
+compaction (with some caveats - more details in the `Cassandra documentation on compaction <compaction-tombstones_>`_). The
 default value for this setting is 864000 seconds (10 days).
 
-Problems caused by tombstones
------------------------------
+Tombstone tradeoffs
+-------------------
 
-Excessive amounts of tombstone rows can lead to various problems since the data is still there on disk, it's just got a
-tombstone marker attached to it. If your workload includes a lot of data deletion, you are more likely to face problems.
-Tombstones also result in a lot of garbage collection, which can affect cluster stability. The two main things affected are
-read performance and disk usage.
+If your system has very large numbers of tombstone rows, this can lead to
+unexpected behaviour since the rows that seem deleted are in fact still there
+on disk, but with a tombstone marker. If your workload includes a lot of data
+deletion, it is useful to be aware of the tradeoffs.  Tombstones are
+periodically processed by garbage collection, which can affect cluster
+stability. The two main things affected are read performance and disk usage.
 
-**Read performance**: if read queries have to scan large numbers of tombstones, the query performance can be significantly
+Tombstones and read performance
+'''''''''''''''''''''''''''''''
+
+If read queries have to scan large numbers of tombstones, the query performance can be significantly
 degraded. In particularly bad cases, the query can even time out. There are a couple of types of queries that are more likely
 to be affected by this. They all involve scanning all or a large part of a table.
 
@@ -25,13 +30,18 @@ to be affected by this. They all involve scanning all or a large part of a table
 * Any query that requires adding ``ALLOW FILTERING``
 * Range queries, i.e. queries with ``WHERE item_cost > threshold`` or similar
 
-**Disk usage**: if you are rapidly filling up your cluster with data at the same time as you are doing a lot of
+Tombstones and disk usage
+'''''''''''''''''''''''''
+
+If you are rapidly filling up your cluster with data at the same time as you are doing a lot of
 deletions, you will reach size limits sooner. This is because the tombstone data is not actually deleted and still taking up
 space on disk.
 
+Identify when tombstones affect a query
+---------------------------------------
 
 If you suspect problems caused by tombstones for your cluster, you can check the logs. By default, if a query encounters over
-1000 tombstones (configured by `tombstone_warn_threshold <cassandra-tombstone-warn_>`_) it will generate a log entry. The
+1000 tombstones (configured by ``tombstone_warn_threshold`` see the `documentation <cassandra-tombstone-warn_>`_) it will generate a log entry. The
 entry will be in the format ``Read <X> live rows and <Y> tombstone cells for query <query> [...] (see tombstone_warn_threshold)``.
 
 If it encounters over 100 000 tombstones (configured by ``tombstone_failure_threshold)``, the query will be aborted with a
@@ -39,26 +49,22 @@ If it encounters over 100 000 tombstones (configured by ``tombstone_failure_thre
 way is to connect with a ``cqlsh`` session and run ``TRACING ON`` followed by the query of interest. You can view values of
 Cassandra settings with ``SELECT * FROM system_views.settings WHERE name = '<setting name>';``.
 
-Preventing tombstone problems
------------------------------
+Tombstone best practice
+-----------------------
 
-Often there is no "quick fix" solution for tombstone-related performance problems. Instead, you might want to rethink your
-data model or your query strategy. Implementing something like table-level `time-to-live <cassandra-ttl_>`_ (TTL) or using
-`TimeWindowCompactionStrategy <cassandra-twcs_>`_ (TWCS) as the compaction strategy might help mitigate these issues. In
-short, some of the solutions available are:
+Designing your data models and query strategies to account for the expected tombstones for your particular application can really help to get the best from Apache Cassandra. We've put together a list of strategies to help mitigate the effects that can sometimes be observed.
 
-* Review your data model and compaction strategy and consider implementing table TTL and TWCS.
-* Avoid queries that end up running on all partitions in a table (queries with no ``WHERE`` clause, queries that need
-  ``ALLOW FILTERING``).
+* Review your data model and compaction strategy and consider implementing
+  table-level `time-to-live <cassandra-ttl_>`_ (TTL) or using
+  `TimeWindowCompactionStrategy <cassandra-twcs_>`_ (TWCS) as the compaction
+  strategy if appropriate for your workload.
+* Avoid queries that end up running on all partitions in a table, such as
+  queries with no ``WHERE`` clause, or queries that need ``ALLOW FILTERING``.
 * Update your queries so that they don't have to scan over tombstone rows in the same manner. For range queries, this might
   mean investigating if you can use a narrower range, or use a different approach to the query.
 * If you are planning to delete all the data in a table, you can truncate the table to avoid creating tombstones.
-
-Removing existing tombstones
-----------------------------
-
-The best is to wait for it to happen automatically as part of regular operations. Once more time than ``gc_grace_seconds``
-has elapsed and a compaction happens, the tombstoned data will be removed from disk.
+* Allow tombstone deletion to happen automatically as part of regular operations rather than forcing the deletes. Once more time than ``gc_grace_seconds``
+  has elapsed and a compaction happens, the data with tombstone marks will be removed from disk.
 
 .. _compaction-tombstones: https://cassandra.apache.org/doc/latest/cassandra/operating/compaction/index.html#the-gc_grace_seconds-parameter-and-tombstone-removal
 .. _cassandra-tombstone-warn: https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html#tombstone_warn_threshold


### PR DESCRIPTION
Add a new help article on Cassandra tombstones, so that we have somewhere to direct users who receive a user alert about encountering too many tombstones during queries. Currently, this article is pretty short; it could definitely go into more detail, but the overarching advice of "change your queries or change your data model" is there, which is the most important bit for someone coming there from a user alert.

Also flesh out the Cassandra section a bit - at the moment there is only a reference document, so add a section for concepts as well. 

This PR also includes a small commit for ignoring the `.venv` folder in the `.gitignore` and when looking for docs to build.