### PR TITLE
Add first set of Snowplow data collection

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -25,6 +25,45 @@
 </script>
 <!-- End Google Analytics -->
 
+<!-- Snowplow Analytics -->
+<script type="text/javascript" async=1>
+
+;(function(p,l,o,w,i,n,g){
+  if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
+  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
+  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
+  n.src=w;g.parentNode.insertBefore(n,g)}
+}(
+  window,
+  document,
+  "script",
+  "https://storage.googleapis.com/aiven-dw-prod-snowplow-tracker/3.4.0/gh7rnaha.js",
+  "snowplow")
+);
+
+
+snowplow("newTracker", "at", "dc.aiven.io", {
+  appId: "devportal",
+  platform: "web",
+  forceSecureTracker: true,
+  discoverRootDomain: true,
+  cookieSameSite: 'Lax',
+  anonymousTracking: { withServerAnonymisation: true },
+  stateStorageStrategy: 'none',
+  eventMethod: 'post',
+  contexts: {
+    webPage: true
+  }
+});
+
+// enable fully anonymous tracking
+snowplow('clearUserData');
+
+snowplow("trackPageView");
+
+</script>
+<!-- End Snowplow Analytics -->
+
 <!-- OneTrust Cookies Consent Notice start for aiven.io -->
 <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="0623fbc6-a463-4822-a7a4-fdb5afcc3afb" ></script>
 <script type="text/javascript">


### PR DESCRIPTION
# What changed, and why it matters

Adds anonymous tracking for page views only. As part of our wider data strategy, this should replace GA eventually.

