### PR TITLE
Fixing broken datadog link.

### DIFF
--- a/docs/integrations/rsyslog.rst
+++ b/docs/integrations/rsyslog.rst
@@ -142,7 +142,7 @@ See the Coralogix `Rsyslog <https://coralogix.com/docs/rsyslog/>`_ documentation
 Datadog
 ~~~~~~~
 
-For `Datadog <https://www.datadoghq.com/>`_ integration, please see the `Aiven and Datadog <./datadog.html>`_ page.
+For `Datadog <https://www.datadoghq.com/>`_ integration, please see the `Aiven and Datadog <https://developer.aiven.io/docs/integrations/datadog.html>`_ page.
 
 Loggly®
 ~~~~~~~

--- a/docs/integrations/rsyslog.rst
+++ b/docs/integrations/rsyslog.rst
@@ -142,7 +142,7 @@ See the Coralogix `Rsyslog <https://coralogix.com/docs/rsyslog/>`_ documentation
 Datadog
 ~~~~~~~
 
-For `Datadog <https://www.datadoghq.com/>`_ integration, please see the `Aiven and Datadog <https://developer.aiven.io/docs/integrations/datadog.html>`_ page.
+For `Datadog <https://www.datadoghq.com/>`_ integration, please see the :doc:`Aiven and Datadog </docs/integrations/datadog>` page.
 
 Loggly®
 ~~~~~~~


### PR DESCRIPTION
# What changed, and why it matters

Fixes the following Sphinx/Prose fail issue:

(docs/integrations/rsyslog: line  145) broken    ./datadog.html
