### PR TITLE
Missing kafka.producer and kafka.consumer metrics

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -237,6 +237,7 @@ entries:
               - file: docs/products/kafka/howto/datadog-customised-metrics
               - file: docs/products/kafka/howto/ksql-docker
                 title: Use ksqlDB with Aiven for Apache Kafka
+              - file: docs/products/kafka/howto/add-missing-producer-consumer-metrics
           - file: docs/products/kafka/howto/list-topic-schema
             title: Topic/schema management
             entries:

--- a/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
+++ b/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
@@ -3,13 +3,6 @@ Add ``kafka.producer.`` and ``kafka.consumer`` Datadog metrics
 
 When you enable the :doc:`Datadog integration </docs/integrations/datadog/datadog-metrics>` in Aiven for Apache Kafka®, the service supports all of the broker-side metrics listed in the `Datadog Kafka integration documentation <https://docs.datadoghq.com/integrations/kafka/?tab=host#data-collected>`_ and allows you to send additional :doc:`custom metrics <datadog-customised-metrics>`.
 
-However, all metrics that have a prefix like ``kafka.producer.*`` or ``kafka.consumer.*`` are client-side metrics and **require a connecting the Datadog agent to the Java producer or consumer processes**.
-
-A setup where the Datadog agent running on the Apache Kafka nodes polls the application code processes is only feasible in environments where Apache Kafka brokers and clients are self hosted and available at specific IP addresses. 
-
-Enabling Datadog to poll external processes would lower the security of a managed service like Aiven for Apache Kafka®. Therefore, Aiven does not support gathering client-side metrics with the Datadog integration. 
-
-Add ``kafka.producer.`` and ``kafka.consumer`` metrics
-------------------------------------------------------
+However, all metrics that have a prefix like ``kafka.producer.*`` or ``kafka.consumer.*`` are client-side metrics that should be collected from the producer or consumer, and sent to Datadog.
 
 The dedicated `Datadog documentation <https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka>`_ (see "Missing producer and consumer metrics" chapter) provides a way to include the missing metrics natively for Java based producers and consumers or via `DogStatsD <https://docs.datadoghq.com/developers/dogstatsd/>`_ for clients in other languages.

--- a/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
+++ b/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
@@ -1,0 +1,15 @@
+Add ``kafka.producer.`` and ``kafka.consumer`` Datadog metrics
+==============================================================
+
+When you enable the :doc:`Datadog integration </docs/integrations/datadog/datadog-metrics>` in Aiven for Apache Kafka®, the service supports all of the broker-side metrics listed in the `Datadog Kafka integration documentation <https://docs.datadoghq.com/integrations/kafka/?tab=host#data-collected>`_ and allows you to send additional :doc:`custom metrics <datadog-customised-metrics>`.
+
+However, all metrics that have a prefix like ``kafka.producer.*`` or ``kafka.consumer.*`` are client-side metrics and **require a connecting the Datadog agent to the Java producer or consumer processes**.
+
+A setup where the Datadog agent running on the Apache Kafka nodes polls the application code processes is only feasible in environments where Apache Kafka brokers and clients are self hosted and available at specific IP addresses. 
+
+Enabling Datadog to poll external processes would lower the security of a managed service like Aiven for Apache Kafka®. Therefore, Aiven does not support gathering client-side metrics with the Datadog integration. 
+
+Add ``kafka.producer.`` and ``kafka.consumer`` metrics
+------------------------------------------------------
+
+The dedicated `Datadog documentation <https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka>`_ (see "Missing producer and consumer metrics" chapter) provides a way to include the missing metrics natively for Java based producers and consumers or via `DogStatsD <https://docs.datadoghq.com/developers/dogstatsd/>`_ for clients in other languages.


### PR DESCRIPTION
# What changed, and why it matters

Migrated https://help.aiven.io/en/articles/5088895-missing-kafka-datadog-metrics

Fixes #1158
