### PR TITLE
Fixed Cloudwatch, ssl and sentence case warnings

### DIFF
--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -6,6 +6,7 @@ scope: heading
 match: $sentence
 exceptions:
   - ACLs
+  - Amazon
   - Amazon Aurora
   - APIs
   - Aiven
@@ -15,6 +16,7 @@ exceptions:
   - BYOA
   - Cassandra
   - ClickHouse
+  - CloudWatch
   - Connect
   - Dashboards
   - Datadog

--- a/docs/platform/concepts/tls-ssl-certificates.rst
+++ b/docs/platform/concepts/tls-ssl-certificates.rst
@@ -17,7 +17,7 @@ Certificate requirements
 
 Most of our services use a browser-recognized CA certificate, but there are exceptions:
 
-- **Aiven for PostgreSQL®** requires the Aiven project CA certificate to connect when using `verify-ca` or `verify-full` as sslmode. The first mode requires the client to verify that the server certificate is actually emitted by the Aiven CA, while the second provides maximum security by performing HTTPS-like validation on the hostname as well. The default sslmode, `require`, ensures TLS is used when connecting to the database, but does not verify the server certificate. For more information, see the `PostgreSQL documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_
+- **Aiven for PostgreSQL®** requires the Aiven project CA certificate to connect when using `verify-ca` or `verify-full` as ``sslmode``. The first mode requires the client to verify that the server certificate is actually emitted by the Aiven CA, while the second provides maximum security by performing HTTPS-like validation on the hostname as well. The default ``sslmode``, `require`, ensures TLS is used when connecting to the database, but does not verify the server certificate. For more information, see the `PostgreSQL documentation <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_
   
 - **Aiven for Apache Kafka®** requires the Aiven project CA certificate, and also the client key and certificate.
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,4 +1,4 @@
-Receive Technical Notifications
+Receive technical notifications
 ===============================
 
 After creating services on Aiven you will want to make sure you stay


### PR DESCRIPTION
# What changed, and why it matters

We had some warnings in the build regarding
* CloudWatch capitalization
* sslmode word
* Receive Technical Notifications in title case

This fixes them all 
Fixes #1152


