### PR TITLE
Clarify when PG synchronous replication can be used

### DIFF
--- a/docs/products/postgresql/reference/list-of-advanced-params.rst
+++ b/docs/products/postgresql/reference/list-of-advanced-params.rst
@@ -184,7 +184,7 @@ General parameters
     - The static IP addresses: Use static public IP addresses.
   * - ``synchronous_replication``
     - string
-    - Enables synchronous replication type. To use it, make sure your service plan supports synchronous replication.
+    - Enables synchronous replication type.  Only available on premium service plans.
   * - ``timescaledb.max_background_workers``
     - integer
     - The number of background workers for ``timescaledb`` operations. You should configure this setting to the sum of your number of databases, and the total number of the concurrent background workers you want running at any given point in time.


### PR DESCRIPTION
# What changed, and why it matters

Currently, the docs for PG say that `synchronous_replication` can only be used on some plans but doesn't say which ones.  This PR clarifies the plans which can use it.