### PR TITLE
Update search indexing for new templates

### DIFF
--- a/scripts/index_developer_portal_pages.py
+++ b/scripts/index_developer_portal_pages.py
@@ -49,7 +49,7 @@ def parse_pages(html_build_dir):
             content = elements.text
             pages.append({
                 'title': title,
-                'content': content,
+                'content': content.strip(),
                 'url': relative_path,
                 'source': 'devportal',
                 'sort_priority': 1

--- a/scripts/index_developer_portal_pages.py
+++ b/scripts/index_developer_portal_pages.py
@@ -29,11 +29,27 @@ def parse_pages(html_build_dir):
             doc = BeautifulSoup(file.read(), 'html.parser')
 
             title = doc.title.text
-            content = doc.select('main .content')[0].text
+            elements = doc.select('div.article-container')[0]
 
+            # remove tables of contents
+            for toc in elements.select('div.toctree-wrapper'):
+                toc.decompose()
+
+            # remove header links
+            for headerlink in elements.select('a.headerlink'):
+                headerlink.decompose()
+
+            # remove preamble links etc
+            for backtotop in elements.select('a.back-to-top'):
+                backtotop.decompose()
+
+            for icons in elements.select('div.content-icon-container'):
+                icons.decompose()
+
+            content = elements.text
             pages.append({
                 'title': title,
-                'content': content.replace("¶", ""),
+                'content': content,
                 'url': relative_path,
                 'source': 'devportal',
                 'sort_priority': 1


### PR DESCRIPTION
# What changed, and why it matters

After updating to the new Furo theme, the change in page structure caused our search indexing to fail. This fixes that and the issues relating to it:
 - takes account of the new headerlink (it's a # rather than a paragraph symbol so we need to pick out the tag rather than parsing a symbol out of the text)
 - ignores the "back to top" link and the light/dark and menu item icons
 - does not index tables of contents (for example the lists on the "concept" pages)

Use the SEARCH instructions to create an opensearch and test what gets indexed.