### PR TITLE
Update Kafka Connect warning text.

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/enable-connect.rst
+++ b/docs/products/kafka/kafka-connect/howto/enable-connect.rst
@@ -5,9 +5,7 @@ To enable Apache Kafka® Connect on Aiven for Apache Kafka® services, those sho
 
 .. Warning::
 
-    Creating a :ref:`dedicated Aiven for Apache Kafka Connect service <apache_kafka_connect_dedicated_cluster>` is Aiven's suggested option. Having Kafka Connect running on the same nodes as Apache Kafka increases the load on the nodes possibly making the cluster more unstable. 
-    
-    For a better separation of concerns, a dedicated Aiven for Apache Kafka Connect cluster is therefore suggested.
+    Aiven provides the option to run Kafka Connect on the same nodes as your Kafka cluster, sharing the resources. This is a low-cost way to get started with Kafka Connect. A standalone Aiven for Apache Kafka® Connect allows you to scale independently, offers more CPU time and memory for the Kafka Connect service and reduces load on nodes, making the cluster more stable.
 
 To enable Kafka Connect on Aiven for Apache Kafka nodes
 

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -24,9 +24,7 @@ Here is the Terraform recipe that will spin up an Aiven for Apache Kafka service
 
 .. Warning::
 
-    Creating a `dedicated Aiven for Apache Kafka Connect service <https://developer.aiven.io/docs/products/kafka/kafka-connect/getting-started.html#apache-kafka-connect-dedicated-cluster>`_ is Aiven's suggested option. Having Kafka Connect running on the same nodes as Apache Kafka increases the load on the nodes possibly making the cluster more unstable. 
-    
-    For a better separation of concerns, a dedicated Aiven for Apache Kafka Connect cluster is therefore suggested.
+    Aiven provides the option to run Kafka Connect on the same nodes as your Kafka cluster, sharing the resources. This is a low-cost way to get started with Kafka Connect. A standalone Aiven for Apache Kafka® Connect allows you to scale independently, offers more CPU time and memory for the Kafka Connect service and reduces load on nodes, making the cluster more stable.
 
 Before you begin, you will require a MongoDB database and the related database connection information. You'll also need to make sure that the database is reachable from the public internet (unless it's part of a paired VPC).
 


### PR DESCRIPTION
# What changed, and why it matters

This PR updates some of the DevPortal pages with warning texts that talk about the choice of using a dedicated Apache Kafka Connect over running Apache Kafka Connect on the same node as the Apache Kafka service. 

For further details, please check the following issue.

Resolves https://github.com/aiven/devportal/issues/1155
