### PR TITLE
Remove google analytics, it was superseded by snowplow

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -13,18 +13,6 @@
 <meta name="twitter:description" content="{{ body|striptags|replace("\u00B6", '')|truncate(200) }}">
 <meta name="twitter:image" content="https://developer.aiven.io/_static/images/site-preview.png">
 
-<!-- Google Analytics -->
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-68276046-1', 'auto');
-    ga('send', 'pageview');
-</script>
-<!-- End Google Analytics -->
-
 <!-- Snowplow Analytics -->
 <script type="text/javascript" async=1>
 


### PR DESCRIPTION
# What changed, and why it matters

Now that we have snowplow in place, no need to keep google analytics here as well. This PR removes the code snippet.