### PR TITLE
Improve the tools page copy

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -9,6 +9,6 @@ The ``avn`` :doc:`command-line tool </docs/tools/cli>` brings Aiven features to 
 
 For programmatic integrations, the :doc:`Aiven API </docs/tools/api>` provides an interface you can use. This public-facing API also powers our own web interface so everything you need is supported.
 
-The :doc:`terraform </docs/tools/terraform>` gives orchestration features for infrastructure-as-code projects.
+:doc:`Aiven Terraform provider </docs/tools/terraform>` gives orchestration features for infrastructure-as-code projects.
 
-The :doc:`kubernetes </docs/tools/kubernetes>` adds orchestration of your Aiven services to your existing Kubernetes® cluster.
+:doc:`Aiven Operator for Kubernetes </docs/tools/kubernetes>` adds orchestration of your Aiven services to your existing Kubernetes® cluster.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -11,4 +11,4 @@ For programmatic integrations, the :doc:`Aiven API </docs/tools/api>` provides a
 
 :doc:`Aiven Terraform provider </docs/tools/terraform>` gives orchestration features for infrastructure-as-code projects.
 
-:doc:`Aiven Operator for Kubernetes </docs/tools/kubernetes>` adds orchestration of your Aiven services to your existing Kubernetes® cluster.
+:doc:`Aiven Operator for Kubernetes® </docs/tools/kubernetes>` adds orchestration of your Aiven services to your existing Kubernetes® cluster.


### PR DESCRIPTION
# What changed, and why it matters
Fixes https://github.com/aiven/devportal/issues/1172

* Removed superfluous "The"s on the tools index page and changed to match thetext for these two items as at the bottom of https://developer.aiven.io/index.html

