### PR TITLE
Documented `avn service connection-info` and `avn service backup-list`

### DIFF
--- a/docs/products/kafka/howto/kcat.rst
+++ b/docs/products/kafka/howto/kcat.rst
@@ -67,6 +67,10 @@ If :doc:`SASL authentication <kafka-sasl-auth>` is enabled, then the ``kcat`` co
    sasl.username=avnadmin
    sasl.password=yourpassword
 
+.. Tip::
+
+   If you're using Aiven for Apache Kafka®, you can retrieve the ``kcat`` command parameters using the dedicated :ref:`Aiven CLI command <_avn_cli_service_connection_info_kcat>`.
+
 Produce data to an Apache Kafka® topic
 --------------------------------------
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -20,7 +20,7 @@ More information on ``acl-add``, ``acl-delete`` and ``acl-list`` can be found in
 ``avn service backup-list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the information about the list of backups for a certain service.
+Retrieves the list of backups for a certain service.
 
 
 .. list-table::

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -17,6 +17,35 @@ Manages the Aiven for Apache Kafka® ACL entries.
 
 More information on ``acl-add``, ``acl-delete`` and ``acl-list`` can be found in :doc:`the dedicated page <service/acl>`.
 
+``avn service backup-list``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the information about the list of backups for a certain service.
+
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+
+**Example:** Retrieve the list of backups for the service ``grafana-25c408a5``.
+
+::
+  
+  avn service backup-list grafana-25c408a5
+
+An example of ``service backup-list`` output:
+
+.. code:: text
+
+  BACKUP_NAME                     BACKUP_TIME           DATA_SIZE  STORAGE_LOCATION
+  ==============================  ====================  =========  ===================
+  grafana-20220614T140308137245Z  2022-06-14T14:03:08Z  774144     google-europe-west3
+
 ``avn service ca get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -60,6 +89,13 @@ Opens the appropriate interactive shell, such as ``psql`` or ``redis-cli``, to t
 ::
 
   avn service cli pg-doc
+
+``avn service connection-info``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the connection information for Aiven for Apache Kafka®, Aiven for PostgreSQL® and Aiven for Redis® in a variety of formats.
+
+More information on ``connection-info`` can be found in :doc:`the dedicated page <service/connection-info>`.
 
 ``avn service connection-pool``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -258,7 +294,7 @@ Lists services within an Aiven project.
 
     avn service list
 
-An example of ``account service list`` output:
+An example of ``service list`` output:
 
 .. code:: text
 
@@ -686,7 +722,7 @@ For each service, lists the versions available together with:
 
   avn service versions
 
-An example of ``account service versions`` output:
+An example of ``service versions`` output:
 
 .. code:: text
 

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -93,7 +93,7 @@ Opens the appropriate interactive shell, such as ``psql`` or ``redis-cli``, to t
 ``avn service connection-info``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the connection information for Aiven for Apache Kafka®, Aiven for PostgreSQL® and Aiven for Redis® in a variety of formats.
+Retrieves the connection information for Aiven for Apache Kafka®, Aiven for PostgreSQL® and Aiven for Redis®* in a variety of formats.
 
 More information on ``connection-info`` can be found in :doc:`the dedicated page <service/connection-info>`.
 

--- a/docs/tools/cli/service/connection-info.rst
+++ b/docs/tools/cli/service/connection-info.rst
@@ -1,0 +1,250 @@
+``avn service connection-info``
+==================================================
+
+Here you’ll find the full list of commands for ``avn service connection-info``.
+
+
+Retrieve connection information
+--------------------------------------------------------
+
+``avn service connection-info kafkacat``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the :doc:`kcat </docs/products/kafka/howto/kcat>` command necessary to connect to a certain Aiven for Apache Kafka® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--kafka-authentication-method``
+    - The Aiven for Apache Kafka® authentication method. Possible values are ``certificate`` and ``sasl``
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--ca``
+    - The path to the CA certificate file
+  * - ``--client-cert``
+    - The path to the client certificate file
+  * - ``--client-key``
+    - The path to the client key file
+  * - ``--write``
+    - Save the certificate and key files if not existing
+  * - ``--overwrite``
+    - Save (or overwrite if already existing) the certificate and key files
+
+**Example:** Retrieve the kcat command to connect to an Aiven for Apache Kafka service named ``demo-kafka`` with SSL authentication (``certificate``), download the certificates necessary for the connection:
+
+::
+
+  avn service connection-info kafkacat demo-kafka --write
+
+An example of ``service connection-info kafkacat`` output:
+
+.. code:: text
+
+  kafkacat -b demo-kafka-dev-advocates.aivencloud.com:13041 -X security.protocol=SSL -X ssl.ca.location=ca.pem -X ssl.key.location=service.key -X ssl.certificate.location=service.crt
+
+.. Warning::
+
+  The command output uses the old ``kafkacat`` naming. To be able to execute ``kcat`` commands, replace ``kafkacat with ``kcat``.
+
+``avn service connection-info pg string``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the connection parameters for a certain Aiven for PostgreSQL® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--usage``
+    - The database connection usage. Possible values are ``primary`` and ``replica`` 
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--dbname``
+    - The database name to use to connect
+  * - ``--sslmode``
+    - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
+
+
+**Example:** Retrieve the connection parameters for an Aiven for PostgreSQL® service named ``demo-pg``:
+
+::
+
+  avn service connection-info pg string demo-pg
+
+An example of ``avn service connection-info pg string`` output:
+
+.. code:: text
+
+  host='demo-pg-dev-project.aivencloud.com' port='13039' user=avnadmin dbname='defaultdb'
+
+
+``avn service connection-info pg string``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the connection parameters for a certain Aiven for PostgreSQL® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--usage``
+    - The database connection usage. Possible values are ``primary`` and ``replica`` 
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--dbname``
+    - The database name to use to connect
+  * - ``--sslmode``
+    - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
+
+
+**Example:** Retrieve the connection parameters for an Aiven for PostgreSQL® service named ``demo-pg``:
+
+::
+
+  avn service connection-info pg string demo-pg
+
+An example of ``avn service connection-info pg string`` output:
+
+.. code:: text
+
+  host='demo-pg-dev-project.aivencloud.com' port='13039' user=avnadmin dbname='defaultdb'
+
+``avn service connection-info pg uri``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the jdbc connection string for a certain Aiven for PostgreSQL® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--usage``
+    - The database connection usage. Possible values are ``primary`` and ``replica`` 
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--dbname``
+    - The database name to use to connect
+  * - ``--sslmode``
+    - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
+
+
+**Example:** Retrieve the jdbc connection string for an Aiven for PostgreSQL® service named ``demo-pg``:
+
+::
+
+  avn service connection-info pg uri demo-pg
+
+An example of ``avn service connection-info pg uri`` output:
+
+.. code:: text
+
+  postgres://avnadmin:XXXXXXXXXX@demo-pg-dev-project.aivencloud.com:13039/defaultdb?sslmode=require
+
+``avn service connection-info psql``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the ``psql`` command needed to connect to a certain Aiven for PostgreSQL® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--usage``
+    - The database connection usage. Possible values are ``primary`` and ``replica`` 
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--dbname``
+    - The database name to use to connect
+  * - ``--sslmode``
+    - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
+
+
+**Example:** Retrieve the ``psql`` command needed to connect to an Aiven for PostgreSQL® service named ``demo-pg``:
+
+::
+
+  avn service connection-info psql demo-pg
+
+An example of ``avn service connection-info psql`` output:
+
+.. code:: text
+
+  psql postgres://avnadmin:AVNS_YlkRllMsFCkXnGfin6H@demo-pg-dev-advocates.aivencloud.com:13039/defaultdb?sslmode=require
+
+
+``avn service connection-info redis uri``
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Retrieves the connection uri needed to connect to a certain Aiven for Redis® service.
+
+.. list-table::
+  :header-rows: 1
+  :align: left
+
+  * - Parameter
+    - Information
+  * - ``service_name``
+    - The name of the service
+  * - ``--route``
+    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
+  * - ``--usage``
+    - The database connection usage. Possible values are ``primary`` and ``replica`` 
+  * - ``--privatelink-connection-id``
+    - The Id of the privatelink to use
+  * - ``--username``
+    - The username used to connect if using ``sasl`` authentication method
+  * - ``--db``
+    - The database name to use to connect
+
+**Example:** Retrieve the connection uri needed to connect to an Aiven for Regis® service named ``demo-redis``:
+
+::
+
+  avn service connection-info redis uri demo-redis
+
+An example of ``avn service connection-info redis uri`` output:
+
+.. code:: text
+
+  rediss://default:XXXXXXXXXX@demo-redis-dev-project.aivencloud.com:13040

--- a/docs/tools/cli/service/connection-info.rst
+++ b/docs/tools/cli/service/connection-info.rst
@@ -95,45 +95,6 @@ An example of ``avn service connection-info pg string`` output:
   host='demo-pg-dev-project.aivencloud.com' port='13039' user=avnadmin dbname='defaultdb'
 
 
-``avn service connection-info pg string``
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Retrieves the connection parameters for a certain Aiven for PostgreSQL® service.
-
-.. list-table::
-  :header-rows: 1
-  :align: left
-
-  * - Parameter
-    - Information
-  * - ``service_name``
-    - The name of the service
-  * - ``--route``
-    - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
-  * - ``--usage``
-    - The database connection usage. Possible values are ``primary`` and ``replica`` 
-  * - ``--privatelink-connection-id``
-    - The Id of the privatelink to use
-  * - ``--username``
-    - The username used to connect if using ``sasl`` authentication method
-  * - ``--dbname``
-    - The database name to use to connect
-  * - ``--sslmode``
-    - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
-
-
-**Example:** Retrieve the connection parameters for an Aiven for PostgreSQL® service named ``demo-pg``:
-
-::
-
-  avn service connection-info pg string demo-pg
-
-An example of ``avn service connection-info pg string`` output:
-
-.. code:: text
-
-  host='demo-pg-dev-project.aivencloud.com' port='13039' user=avnadmin dbname='defaultdb'
-
 ``avn service connection-info pg uri``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -210,7 +171,7 @@ An example of ``avn service connection-info psql`` output:
 
 .. code:: text
 
-  psql postgres://avnadmin:AVNS_YlkRllMsFCkXnGfin6H@demo-pg-dev-advocates.aivencloud.com:13039/defaultdb?sslmode=require
+  psql postgres://avnadmin:XXXXXXXXXXXX@demo-pg-dev-advocates.aivencloud.com:13039/defaultdb?sslmode=require
 
 
 ``avn service connection-info redis uri``

--- a/docs/tools/cli/service/connection-info.rst
+++ b/docs/tools/cli/service/connection-info.rst
@@ -10,7 +10,7 @@ Retrieve connection information
 ``avn service connection-info kafkacat``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the :doc:`kcat </docs/products/kafka/howto/kcat>` command necessary to connect to a certain Aiven for Apache Kafka® service.
+Retrieves the ``kcat`` :doc:`command </docs/products/kafka/howto/kcat>` necessary to connect to a certain Aiven for Apache Kafka® service.
 
 .. list-table::
   :header-rows: 1
@@ -39,7 +39,7 @@ Retrieves the :doc:`kcat </docs/products/kafka/howto/kcat>` command necessary to
   * - ``--overwrite``
     - Save (or overwrite if already existing) the certificate and key files
 
-**Example:** Retrieve the kcat command to connect to an Aiven for Apache Kafka service named ``demo-kafka`` with SSL authentication (``certificate``), download the certificates necessary for the connection:
+**Example:** Retrieve the ``kcat`` command to connect to an Aiven for Apache Kafka service named ``demo-kafka`` with SSL authentication (``certificate``), download the certificates necessary for the connection:
 
 ::
 
@@ -137,7 +137,7 @@ An example of ``avn service connection-info pg string`` output:
 ``avn service connection-info pg uri``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the jdbc connection string for a certain Aiven for PostgreSQL® service.
+Retrieves the connection URI for a certain Aiven for PostgreSQL® service.
 
 .. list-table::
   :header-rows: 1
@@ -161,7 +161,7 @@ Retrieves the jdbc connection string for a certain Aiven for PostgreSQL® servic
     - The ``sslmode`` to use. Possible values are ``require``, ``verify-ca``, ``verify-full``, ``disable``, ``allow``, ``prefer``
 
 
-**Example:** Retrieve the jdbc connection string for an Aiven for PostgreSQL® service named ``demo-pg``:
+**Example:** Retrieve the connection URI for an Aiven for PostgreSQL® service named ``demo-pg``:
 
 ::
 
@@ -216,7 +216,7 @@ An example of ``avn service connection-info psql`` output:
 ``avn service connection-info redis uri``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the connection uri needed to connect to a certain Aiven for Redis® service.
+Retrieves the connection URI needed to connect to a certain Aiven for Redis®* service.
 
 .. list-table::
   :header-rows: 1
@@ -237,7 +237,7 @@ Retrieves the connection uri needed to connect to a certain Aiven for Redis® se
   * - ``--db``
     - The database name to use to connect
 
-**Example:** Retrieve the connection uri needed to connect to an Aiven for Regis® service named ``demo-redis``:
+**Example:** Retrieve the connection URI needed to connect to an Aiven for Regis® service named ``demo-redis``:
 
 ::
 

--- a/docs/tools/cli/service/connection-info.rst
+++ b/docs/tools/cli/service/connection-info.rst
@@ -198,7 +198,7 @@ Retrieves the connection URI needed to connect to a certain Aiven for Redis®* s
   * - ``--db``
     - The database name to use to connect
 
-**Example:** Retrieve the connection URI needed to connect to an Aiven for Regis® service named ``demo-redis``:
+**Example:** Retrieve the connection URI needed to connect to an Aiven for Redis® service named ``demo-redis``:
 
 ::
 

--- a/docs/tools/cli/service/connection-info.rst
+++ b/docs/tools/cli/service/connection-info.rst
@@ -3,6 +3,7 @@
 
 Here you’ll find the full list of commands for ``avn service connection-info``.
 
+.. _avn_cli_service_connection_info_kcat:
 
 Retrieve connection information
 --------------------------------------------------------
@@ -10,7 +11,7 @@ Retrieve connection information
 ``avn service connection-info kafkacat``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the ``kcat`` :doc:`command </docs/products/kafka/howto/kcat>` necessary to connect to a certain Aiven for Apache Kafka® service.
+Retrieves the ``kcat`` command necessary to connect to an Aiven for Apache Kafka® service and produce/consume messages to topics, check out more in the :doc:`dedicated article </docs/products/kafka/howto/kcat>`.
 
 .. list-table::
   :header-rows: 1
@@ -23,7 +24,7 @@ Retrieves the ``kcat`` :doc:`command </docs/products/kafka/howto/kcat>` necessar
   * - ``--route``
     - The type of route to use to connect to the service. Possible values are ``dynamic``, ``privatelink`` and ``public``
   * - ``--privatelink-connection-id``
-    - The Id of the privatelink to use
+    - The ID of the privatelink to use
   * - ``--kafka-authentication-method``
     - The Aiven for Apache Kafka® authentication method. Possible values are ``certificate`` and ``sasl``
   * - ``--username``
@@ -53,7 +54,7 @@ An example of ``service connection-info kafkacat`` output:
 
 .. Warning::
 
-  The command output uses the old ``kafkacat`` naming. To be able to execute ``kcat`` commands, replace ``kafkacat with ``kcat``.
+  The command output uses the old ``kafkacat`` naming. To be able to execute ``kcat`` commands, replace ``kafkacat`` with ``kcat``.
 
 ``avn service connection-info pg string``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -73,7 +74,7 @@ Retrieves the connection parameters for a certain Aiven for PostgreSQL® service
   * - ``--usage``
     - The database connection usage. Possible values are ``primary`` and ``replica`` 
   * - ``--privatelink-connection-id``
-    - The Id of the privatelink to use
+    - The ID of the privatelink to use
   * - ``--username``
     - The username used to connect if using ``sasl`` authentication method
   * - ``--dbname``
@@ -98,7 +99,7 @@ An example of ``avn service connection-info pg string`` output:
 ``avn service connection-info pg uri``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the connection URI for a certain Aiven for PostgreSQL® service.
+Retrieves the connection URI for an Aiven for PostgreSQL® service.
 
 .. list-table::
   :header-rows: 1
@@ -113,7 +114,7 @@ Retrieves the connection URI for a certain Aiven for PostgreSQL® service.
   * - ``--usage``
     - The database connection usage. Possible values are ``primary`` and ``replica`` 
   * - ``--privatelink-connection-id``
-    - The Id of the privatelink to use
+    - The ID of the privatelink to use
   * - ``--username``
     - The username used to connect if using ``sasl`` authentication method
   * - ``--dbname``
@@ -137,7 +138,7 @@ An example of ``avn service connection-info pg uri`` output:
 ``avn service connection-info psql``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the ``psql`` command needed to connect to a certain Aiven for PostgreSQL® service.
+Retrieves the ``psql`` command needed to connect to an Aiven for PostgreSQL® service.
 
 .. list-table::
   :header-rows: 1
@@ -177,7 +178,7 @@ An example of ``avn service connection-info psql`` output:
 ``avn service connection-info redis uri``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the connection URI needed to connect to a certain Aiven for Redis®* service.
+Retrieves the connection URI needed to connect to an Aiven for Redis®* service.
 
 .. list-table::
   :header-rows: 1
@@ -192,7 +193,7 @@ Retrieves the connection URI needed to connect to a certain Aiven for Redis®* s
   * - ``--usage``
     - The database connection usage. Possible values are ``primary`` and ``replica`` 
   * - ``--privatelink-connection-id``
-    - The Id of the privatelink to use
+    - The ID of the privatelink to use
   * - ``--username``
     - The username used to connect if using ``sasl`` authentication method
   * - ``--db``


### PR DESCRIPTION
# What changed, and why it matters

Added documentation for

* `avn service connection-info`
* `anv service backup-list`

