### PR TITLE
concepts: added service memory limits

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -22,6 +22,7 @@ entries:
       - file: docs/platform/concepts/projects_accounts_access
       - file: docs/platform/concepts/service-forking
       - file: docs/platform/concepts/service_backups
+      - file: docs/platform/concepts/service-memory-limits
       - file: docs/platform/concepts/static-ips
       - file: docs/platform/concepts/tls-ssl-certificates
       - file: docs/platform/concepts/byoa

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -27,6 +27,10 @@ Learn about some of the key concepts for working with Aiven platform:
 
   Quickly and safely make a copy of your database or other service for testing, dry run upgrades, or anything else, without affecting your existing service.
 
+* :doc:`Service memory limits </docs/platform/concepts/service-memory-limits>`.
+
+  Understanding memory overhead and limits applied to services.
+
 * :doc:`Projects and access management </docs/platform/concepts/projects_accounts_access>`.
 
   Understand how to set up users, accounts and access management for your Aiven projects.

--- a/docs/platform/concepts/service-memory-limits.rst
+++ b/docs/platform/concepts/service-memory-limits.rst
@@ -7,7 +7,7 @@ Service memory limits
 - Aiven's cloud data platform also requires memory to monitor availability, provide metrics, logging and manage backups.
 - Some services utilize optional integrations, connection pooling, or plug-ins components that also consume system resources.
 
-In most instances, the combined overhead is negligible; however, it is *critically important to maintain availability*.
+In most instances, the combined overhead is negligible; however, it is **critically important to maintain availability**.
 
 If a service consumes too much memory, the operating system or management components, including backups and availability monitoring, may fail status checks or timed operations due to limited system resources. In severe instances, the node may fail completely with an ``Out of Memory`` condition. 
 
@@ -17,7 +17,7 @@ A memory limit is applied to the primary process of the following Aiven services
 - MySQL
 - PostgreSQL®
 
-With all new instances, a limit of ``80%`` of available memory (``RAM - 350MB``) is assigned to the primary process, with the remainder reserved for operating overhead and mitigation of potential ``Out of Memory`` conditions.
+With all new instances, a limit of 80% of available memory (RAM - 350MB) is assigned to the primary process, with the remainder reserved for operating overhead and mitigation of potential ``Out of Memory`` conditions.
 
 .. note:: Reserved memory for non-service use is capped to a maximum of 4GB.
 

--- a/docs/platform/concepts/service-memory-limits.rst
+++ b/docs/platform/concepts/service-memory-limits.rst
@@ -1,0 +1,25 @@
+Service memory limits
+=====================
+
+**All services are subject to operating overhead:**
+
+- A small amount of memory is required by the operating system kernel to manage system resources, including networking functions and disk buffers.
+- Aiven's cloud data platform also requires memory to monitor availability, provide metrics, logging and manage backups.
+- Some services utilize optional integrations, connection pooling, or plug-ins components that also consume system resources.
+
+In most instances, the combined overhead is negligible; however, it is *critically important to maintain availability*.
+
+If a service consumes too much memory, the operating system or management components, including backups and availability monitoring, may fail status checks or timed operations due to limited system resources. In severe instances, the node may fail completely with an ``Out of Memory`` condition. 
+
+A memory limit is applied to the primary process of the following Aiven services:
+
+- InfluxDB®
+- MySQL
+- PostgreSQL®
+
+With all new instances, a limit of ``80%`` of available memory (``RAM - 350MB``) is assigned to the primary process, with the remainder reserved for operating overhead and mitigation of potential ``Out of Memory`` conditions.
+
+.. note:: Reserved memory for non-service use is capped to a maximum of 4GB.
+
+.. note:: For MySQL, a minimum of 600MB is always guaranteed.
+


### PR DESCRIPTION
# What changed, and why it matters
This document overviews expected system overhead and additional memory limits
that have been applied to several databases: InfluxDB, MySQL and PostgreSQL.

This can provide some context to other `Out of Memory` references and future articles.

