### PR TITLE
MySQL: disable foreign key checks

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -588,6 +588,7 @@ entries:
           - file: docs/products/mysql/howto/migrate-from-external-mysql
           - file: docs/products/mysql/howto/do-check-service-migration
           - file: docs/products/mysql/howto/prevent-disk-full
+          - file: docs/products/mysql/howto/disable-foreign-key-checks
       - file: docs/products/mysql/reference
         title: Reference
         entries:

--- a/docs/products/mysql/howto/disable-foreign-key-checks.rst
+++ b/docs/products/mysql/howto/disable-foreign-key-checks.rst
@@ -84,6 +84,29 @@ As result, we can see that the foreign key checks are disabled for this session:
     1 row in set (0.04 sec)
 
 
+In addition, you can add the flag when running a set of commands saved in a file which the extension is ``.sql``.
+
+.. list-table::
+  :header-rows: 1
+  :widths: 15 60
+  :align: left
+
+  * - Variable
+    - Description
+  * - ``FILENAME``
+    - File which the extension is ``.sql``, for e.g. filename.sql
+
+You can paste the following command on your ``FILENAME``::
+
+  SHOW VARIABLES LIKE 'foreign_key_checks';
+
+Now you can set the ``init-command`` flag to disable the foreign key checks, and run the commands in this file like:
+
+.. code:: shell
+
+    mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;" < FILENAME
+
+
 More resources
 --------------
 

--- a/docs/products/mysql/howto/disable-foreign-key-checks.rst
+++ b/docs/products/mysql/howto/disable-foreign-key-checks.rst
@@ -1,15 +1,11 @@
 Disable foreign key checks
 ==========================
 
-It can be useful to know how to disable foreign key checks. For example, your migration to Aiven for MySQL may face foreign key violations which can result in an error, similar to::
+All Aiven for MySQL® services have the foreign key checks enabled by default. This helps to keep referential integrity across tables. However, you might want to disable it for a particular session. For example, when migrating to an Aiven for MySQL you may face errors related to foreign key violations similar to::
 
   ERROR 3780 (HY000) at line 11596: Referencing column 'g_id' and referenced column 'g_id' in foreign key constraint 'FK_33b11dcfac6148578da087b07c2f388f' are incompatible.
 
-In this article, we will explain how to temporarily disable Aiven for MySQL foreign key checking for the duration of a session. 
-
-.. note::
-
-    Aiven for MySQL has by default foreign key checks enabled.
+In this article, we will explain how to temporarily disable Aiven for MySQL foreign key checking for the duration of a session.
 
 Prerequisites
 -------------
@@ -30,27 +26,27 @@ You need those variables to run the commands. You can find this information in t
 
   * - Variable
     - Description
-  * - ``USER_HOST``
+  * - ``HOST``
     - Hostname for MySQL connection
-  * - ``USER_PORT``
+  * - ``PORT``
     - Port for MySQL connection
-  * - ``USER_PASSWORD``
+  * - ``PASSWORD``
     - Password of your Aiven for MySQL connection
   * - ``DB_NAME``
     - Database Name of your Aiven for MySQL connection
 
-Disable foreign key checks
---------------------------
+Check the foreign key check flag
+--------------------------------
 
-You can connect to your Aiven for MySQL following this command::
+First, you need connect to your Aiven for MySQL. You can use the following command for that::
     
-    mysql --user avnadmin --password=USER_PASSWORD --host USER_HOST --port USER_PORT DB_NAME
+    mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME
 
 After connecting, you can run the following command to check the default configuration for your foreign key checks.
 
 .. code:: shell
 
-    mysql> SHOW VARIABLES LIKE 'foreign_key_checks';
+    SHOW VARIABLES LIKE 'foreign_key_checks';
 
 As result, you can verify that the foreign keys are enabled by default. This is the output you will see:
 
@@ -63,15 +59,18 @@ As result, you can verify that the foreign keys are enabled by default. This is 
     +--------------------+-------+
     1 row in set (0.05 sec)
 
+Disable foreign key checks
+--------------------------
+
 To disable the foreign key checks for the session, you give an additional parameter when you connect to your Aiven for MySQL using the ``mysqlsh``:
 
-.. code::shell
+.. code:: shell
 
-    mysql --user avnadmin --password=USER_PASSWORD --host USER_HOST --port USER_PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;"
+    mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;"
 
 Once again, we can check the current status of the foreign key checks by running::
 
-  mysql> SHOW VARIABLES LIKE 'foreign_key_checks';
+    SHOW VARIABLES LIKE 'foreign_key_checks';
 
 As result, we can see that the foreign key checks are disabled for this session:
 

--- a/docs/products/mysql/howto/disable-foreign-key-checks.rst
+++ b/docs/products/mysql/howto/disable-foreign-key-checks.rst
@@ -1,0 +1,95 @@
+Disable foreign key checks
+==========================
+
+It can be useful to know how to disable foreign key checks. For example, your migration to Aiven for MySQL may face foreign key violations which can result in an error, similar to::
+
+  ERROR 3780 (HY000) at line 11596: Referencing column 'g_id' and referenced column 'g_id' in foreign key constraint 'FK_33b11dcfac6148578da087b07c2f388f' are incompatible.
+
+In this article, we will explain how to temporarily disable Aiven for MySQL foreign key checking for the duration of a session. 
+
+.. note::
+
+    Aiven for MySQL has by default foreign key checks enabled.
+
+Prerequisites
+-------------
+
+* The ``mysqlsh`` client installed. You can install this by following the MySQL shell installation `documentation <https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install.html>`_.
+
+* An Aiven account with an Aiven for MySQL service running.
+
+Variables
+---------
+
+You need those variables to run the commands. You can find this information in the **Overview** tab of your on your Aiven for MySQL service, under **MySQL** tab.
+
+.. list-table::
+  :header-rows: 1
+  :widths: 15 60
+  :align: left
+
+  * - Variable
+    - Description
+  * - ``USER_HOST``
+    - Hostname for MySQL connection
+  * - ``USER_PORT``
+    - Port for MySQL connection
+  * - ``USER_PASSWORD``
+    - Password of your Aiven for MySQL connection
+  * - ``DB_NAME``
+    - Database Name of your Aiven for MySQL connection
+
+Disable foreign key checks
+--------------------------
+
+You can connect to your Aiven for MySQL following this command::
+    
+    mysql --user avnadmin --password=USER_PASSWORD --host USER_HOST --port USER_PORT DB_NAME
+
+After connecting, you can run the following command to check the default configuration for your foreign key checks.
+
+.. code:: shell
+
+    mysql> SHOW VARIABLES LIKE 'foreign_key_checks';
+
+As result, you can verify that the foreign keys are enabled by default. This is the output you will see:
+
+.. code::
+
+    +--------------------+-------+
+    | Variable_name      | Value |
+    +--------------------+-------+
+    | foreign_key_checks | ON    |
+    +--------------------+-------+
+    1 row in set (0.05 sec)
+
+To disable the foreing key checks for the session, you give an additional parameter when you connect to your Aiven for MySQL using the ``mysqlsh``:
+
+.. code::shell
+
+    mysql --user avnadmin --password=USER_PASSWORD --host USER_HOST --port USER_PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;"
+
+Once again, we can check the current status of the foreign key checks by running::
+
+  mysql> SHOW VARIABLES LIKE 'foreign_key_checks';
+
+As result, we can see that the foreign key checks are disabled for this session:
+
+.. code::
+
+    +--------------------+-------+
+    | Variable_name      | Value |
+    +--------------------+-------+
+    | foreign_key_checks | OFF   |
+    +--------------------+-------+
+    1 row in set (0.04 sec)
+
+
+More resources
+--------------
+
+Read the official documentation to understand possible implications that can happen when disabling foreign key checks in your service.
+
+- `Foreign Key Checks <https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#foreign-key-checks>`_.
+
+- `Server System Variables <https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_foreign_key_checks>`_.

--- a/docs/products/mysql/howto/disable-foreign-key-checks.rst
+++ b/docs/products/mysql/howto/disable-foreign-key-checks.rst
@@ -63,7 +63,7 @@ As result, you can verify that the foreign keys are enabled by default. This is 
     +--------------------+-------+
     1 row in set (0.05 sec)
 
-To disable the foreing key checks for the session, you give an additional parameter when you connect to your Aiven for MySQL using the ``mysqlsh``:
+To disable the foreign key checks for the session, you give an additional parameter when you connect to your Aiven for MySQL using the ``mysqlsh``:
 
 .. code::shell
 

--- a/docs/products/mysql/howto/disable-foreign-key-checks.rst
+++ b/docs/products/mysql/howto/disable-foreign-key-checks.rst
@@ -1,11 +1,11 @@
 Disable foreign key checks
 ==========================
 
-All Aiven for MySQL® services have the foreign key checks enabled by default. This helps to keep referential integrity across tables. However, you might want to disable it for a particular session. For example, when migrating to an Aiven for MySQL you may face errors related to foreign key violations similar to::
+All Aiven for MySQL® services have foreign key checks enabled by default helping in keeping referential integrity across tables. However, you might want to disable it for a particular session. For example, when migrating to an Aiven for MySQL you may face errors related to foreign key violations similar to::
 
   ERROR 3780 (HY000) at line 11596: Referencing column 'g_id' and referenced column 'g_id' in foreign key constraint 'FK_33b11dcfac6148578da087b07c2f388f' are incompatible.
 
-In this article, we will explain how to temporarily disable Aiven for MySQL foreign key checking for the duration of a session.
+The following explains how to temporarily disable Aiven for MySQL foreign key checking for the duration of a session.
 
 Prerequisites
 -------------
@@ -17,7 +17,7 @@ Prerequisites
 Variables
 ---------
 
-You need those variables to run the commands. You can find this information in the **Overview** tab of your on your Aiven for MySQL service, under **MySQL** tab.
+The following variables need to be substituted when running the commands. You can find this information in the **Overview** tab of your on your Aiven for MySQL service, under **MySQL** tab.
 
 .. list-table::
   :header-rows: 1
@@ -38,17 +38,19 @@ You need those variables to run the commands. You can find this information in t
 Check the foreign key check flag
 --------------------------------
 
-First, you need connect to your Aiven for MySQL. You can use the following command for that::
+To check the foreign key check flag you need to:
+
+* connect to your Aiven for MySQL with the following command::
     
     mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME
 
-After connecting, you can run the following command to check the default configuration for your foreign key checks.
+* run the following command to check the default configuration for your foreign key checks.
 
 .. code:: shell
 
     SHOW VARIABLES LIKE 'foreign_key_checks';
 
-As result, you can verify that the foreign keys are enabled by default. This is the output you will see:
+* verify that the foreign keys are enabled by default. This is the output you will see:
 
 .. code::
 
@@ -66,7 +68,12 @@ To disable the foreign key checks for the session, you give an additional parame
 
 .. code:: shell
 
-    mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;"
+    mysql                   \
+      --user avnadmin       \
+      --password=PASSWORD   \
+      --host HOST           \
+      --port PORT DB_NAME   \
+      --init-command="SET @@SESSION.foreign_key_checks = 0;"
 
 Once again, we can check the current status of the foreign key checks by running::
 
@@ -84,7 +91,7 @@ As result, we can see that the foreign key checks are disabled for this session:
     1 row in set (0.04 sec)
 
 
-In addition, you can add the flag when running a set of commands saved in a file which the extension is ``.sql``.
+The same flag works when running a set of commands saved in a file with extension ``.sql``.
 
 .. list-table::
   :header-rows: 1
@@ -104,7 +111,12 @@ Now you can set the ``init-command`` flag to disable the foreign key checks, and
 
 .. code:: shell
 
-    mysql --user avnadmin --password=PASSWORD --host HOST --port PORT DB_NAME --init-command="SET @@SESSION.foreign_key_checks = 0;" < FILENAME
+    mysql                   \
+      --user avnadmin       \
+      --password=PASSWORD   \
+      --host HOST           \
+      --port PORT DB_NAME   \
+      --init-command="SET @@SESSION.foreign_key_checks = 0;" < FILENAME
 
 
 More resources


### PR DESCRIPTION
Article migration:
https://help.aiven.io/en/articles/5580571-can-i-disable-foreign-key-checks

I've tested all the steps. However, the extra command in the end did not work for me. I could not reproduce.

Fixes: https://github.com/aiven/devportal/issues/657

