### PR TITLE
Get started page for Cassandra

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -633,6 +633,8 @@ entries:
   - file: docs/products/cassandra
     title: Apache Cassandra
     entries:
+      - file: docs/products/cassandra/get-started
+        title: Get started
       - file: docs/products/cassandra/concepts
         title: Concepts
         entries:

--- a/docs/products/cassandra.rst
+++ b/docs/products/cassandra.rst
@@ -20,7 +20,7 @@ It is a truly distributed database where the individual nodes can communicate wi
 Get started with Aiven for Apache Cassandra
 -------------------------------------------
 
-Find more information about Apache Cassandra in the following sections:
+Take your first steps with Aiven for Apache Cassandra® by following our :doc:`/docs/products/cassandra/get-started` article, or browse through our full list of articles:
 
 .. panels::
 

--- a/docs/products/cassandra/get-started.rst
+++ b/docs/products/cassandra/get-started.rst
@@ -1,0 +1,30 @@
+Get started with Aiven for Apache Cassandra®
+============================================
+
+The first step in using Aiven for Apache Cassandra® is to create a service. You can do so either using the `Aiven Web Console <https://console.aiven.io/>`_ or the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
+
+Create an Aiven for Apache Cassandra® service using the Aiven web console
+----------------------------------------------------
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_.
+
+2. Follow :doc:`these instructions </docs/platform/howto/create_new_service>` to create a new Cassandra® service.
+
+   Once the service is ready, the status changes to *Running*. This typically takes a couple of minutes, depending on your selected cloud provider and region.
+
+Create an Aiven for Apache Cassandra® service using the Aiven CLI
+--------------------------------------------
+
+If you prefer launching a new service from the CLI, `Aiven CLI <https://github.com/aiven/aiven-client>`_ includes a command for doing so. 
+
+In order to launch a service, decide on the service plan, cloud provider, and region you want to run your service on. Then run the following command to create a **Cassandra®** service named ``demo-cassandra``: 
+
+::
+
+      avn service create demo-cassandra       \
+         --service-type cassandra             \
+         --cloud CLOUD_AND_REGION             \
+         --plan PLAN                          \
+         --project PROJECT_NAME 
+
+.. note::
+   See the full list of default flags with the following command: ``avn service create -h``. Additionally, there are some type specific options, which you can see executing the following command: ``avn service types -v``


### PR DESCRIPTION
# What changed, and why it matters
This pull request adds a get started page to Aiven for Apache Cassandra, which is currently missing. 

I based the page on the get started page of Redis. Please let me know about any possible improvements.

This fixes [#89](https://github.com/aiven/devportal/issues/89) 

