### PR TITLE
Add color flag to linkcheck 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ livehtmlall:
 	sphinx-autobuild -a "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --watch _static
 
 linkcheck-specified-files:
-	sphinx-build -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(files)
-	
+	sphinx-build -b linkcheck --color "$(SOURCEDIR)" "$(BUILDDIR)" $(files)
 
 spell:
 	vale $(SOURCEDIR)/index.rst


### PR DESCRIPTION
In every push, we use linkcheck
to check on changed files. Currently,
there is no color on the logs.

This commit adds the color flag to enable
colors. This useful for the contributors to
easily see error messages, warnings etc in
a visual way.

Colors look like this:
<img width="1525" alt="Screenshot 2022-08-01 at 14 28 22" src="https://user-images.githubusercontent.com/36624597/182148431-77608062-aebc-4104-9480-e5c2d6dce9c3.png">



