### PR TITLE
Fixed typo in "Connect with redis-cli"

### DIFF
--- a/docs/products/redis/howto/connect-redis-cli.rst
+++ b/docs/products/redis/howto/connect-redis-cli.rst
@@ -25,7 +25,7 @@ For this example you will need:
 Code
 ''''
 
-Execute the following to from a terminal window:
+Execute the following from a terminal window:
 
 ::
 


### PR DESCRIPTION
# What changed, and why it matters
I fixed a little typo that I came across while working on another page. The original sentence said: 
```Execute the following to from a terminal window:```

I removed `to` in order to correct the sentence.   