### PR TITLE
fix/terraform: warnings for title

### DIFF
--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -1,5 +1,5 @@
 Debezium source connector - PostgreSQL® to Apache Kafka® across clouds
-==========================================================
+======================================================================
 
 The `Aiven Terraform Provider <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ is a great choice for provisioning an Aiven for Apache Kafka® cluster with Kafka Connect enabled and the `Debezium source connector for PostgreSQL® <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.html>`_ configured.
 


### PR DESCRIPTION
devportal/docs/tools/terraform/
reference/cookbook/
kafka-debezium-postgres-source.rst:2:
WARNING: Title underline too short.




