### PR TITLE
Add redis-cli article to list of howto connect articles on get started page

### DIFF
--- a/docs/products/redis/get-started.rst
+++ b/docs/products/redis/get-started.rst
@@ -32,7 +32,8 @@ In order to launch a service, decide on the service plan, cloud provider, and re
 Next steps
 ----------
 
-* Learn how to connect to Aiven for Redis by using different programming languages:
+* Learn how to connect to Aiven for Redis by either using ``redis-cli`` or different programming languages:
+   - :doc:`redis-cli<howto/connect-redis-cli>`
    - :doc:`Go <howto/connect-go>`
    - :doc:`Node <howto/connect-node>`
    - :doc:`PHP <howto/connect-php>`


### PR DESCRIPTION
# What changed, and why it matters
While looking at our get started page for Redis, I noticed that the article on how to connect to our service by using `redis-cli` was missing from the list of connect articles. 

This pull request adds the article to the list. 

