### PR TITLE
Change Flink documentation links to target Flink 1.15

### DIFF
--- a/docs/products/flink.rst
+++ b/docs/products/flink.rst
@@ -76,4 +76,4 @@ If you are new to Flink, try these resources to get you started with the platfor
 
 * Our :doc:`/docs/products/flink/getting-started` guide is a good way to get hands on with your first project..
 
-* Read more about `Flink SQL capabilities <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/overview/>`_.
+* Read more about `Flink SQL capabilities <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/table/sql/overview/>`_.

--- a/docs/products/flink/concepts/checkpoints.rst
+++ b/docs/products/flink/concepts/checkpoints.rst
@@ -16,6 +16,6 @@ Essentially, a checkpoint creates a snapshot of the data stream and stores it. T
         id3-->id6[(State backend)];
 
 
-For more information, see the `Apache Flink® documentation on checkpoints <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/ops/state/checkpoints/>`_.
+For more information, see the `Apache Flink® documentation on checkpoints <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/ops/state/checkpoints/>`_.
 
 

--- a/docs/products/flink/concepts/event-processing-time.rst
+++ b/docs/products/flink/concepts/event-processing-time.rst
@@ -5,6 +5,6 @@ Event time refers to when events actually happen, while processing time refers t
 
 In Apache Flink®, the streamed data does not always arrive in the same order as the events occurred. This means that using processing time in your applications can cause issues in system behavior. For this reason, we recommend that you use event time to process data, as it allows your applications to maintain the correct event sequence throughout the data streaming pipeline. In addition, using event time to process your data allows you to reprocess the data later on with consistent results.
 
-For more information, see the `Apache Flink® documentation on event time and processing time <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/time/>`_.
+For more information, see the `Apache Flink® documentation on event time and processing time <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/concepts/time/>`_.
 
 

--- a/docs/products/flink/concepts/flink-for-analysts.rst
+++ b/docs/products/flink/concepts/flink-for-analysts.rst
@@ -20,7 +20,7 @@ In order to run a stable and reliable service, you will see some differences bet
 * User-defined functions are not supported.
 * The Apache Flink® CLI tool cannot be used with this service as it requires access to the JobManager in production, which is currently not exposed to customers.
 * Job-level settings are not yet supported. Each job inherits the cluster-level settings.
-* Flame graphs, marked as an experimental feature in Apache Flink® 1.13, are not currently enabled in the Flink web UI.
+* Flame graphs, marked as an experimental feature in Apache Flink® 1.15, are not currently enabled in the Flink web UI.
 
 Troubleshooting
 ---------------

--- a/docs/products/flink/concepts/flink-for-operators.rst
+++ b/docs/products/flink/concepts/flink-for-operators.rst
@@ -12,9 +12,9 @@ Our product page provides you detailed information about the available plans and
 Cluster deployment
 ------------------
 
-Aiven for Apache Flink® is configured to use the `HashMap state backend <https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.html>`_. This means that `state <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/concepts/stateful-stream-processing/#what-is-state>`_ is stored in memory, which can impact the performance of jobs that require keeping a very large state. We recommend you provision your platform accordingly.
+Aiven for Apache Flink® is configured to use the `HashMap state backend <https://ci.apache.org/projects/flink/flink-docs-stable/api/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.html>`_. This means that `state <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/concepts/stateful-stream-processing/#what-is-state>`_ is stored in memory, which can impact the performance of jobs that require keeping a very large state. We recommend you provision your platform accordingly.
 
-The Flink cluster executes applications in `session mode <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/deployment/overview/#session-mode>`_, so you can deploy multiple Flink jobs on the same cluster to use the available resources effectively.
+The Flink cluster executes applications in `session mode <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/deployment/overview/#session-mode>`_, so you can deploy multiple Flink jobs on the same cluster to use the available resources effectively.
 
 Scaling a Flink cluster
 '''''''''''''''''''''''

--- a/docs/products/flink/concepts/kafka-connector-requirements.rst
+++ b/docs/products/flink/concepts/kafka-connector-requirements.rst
@@ -5,7 +5,7 @@ This article outlines the required settings for standard and upsert Kafka connec
 
 .. note::
 
-   Aiven for Apache Flink® supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink® documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/table/formats/overview/>`_.
+   Aiven for Apache Flink® supports the following data formats: JSON (default), Apache Avro, Confluent Avro, Debezium CDC. For more information on these, see the `Apache Flink® documentation on formats <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/connectors/table/formats/overview/>`_.
 
 .. list-table::
   :header-rows: 1

--- a/docs/products/flink/concepts/watermarks.rst
+++ b/docs/products/flink/concepts/watermarks.rst
@@ -7,6 +7,6 @@ This allows Flink to set points in the stream when all events up to a certain ti
 
 Flink uses *watermark strategies* and *watermark generators* to define how the watermark logic is implemented. For example, you can set Flink to generate watermarks either periodically at specific intervals or when triggered by an event or element with a specific marker.
 
-For more information on watermarks, see the `Apache Flink® documentation on generating watermarks <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/event-time/generating_watermarks/>`_.
+For more information on watermarks, see the `Apache Flink® documentation on generating watermarks <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/datastream/event-time/generating_watermarks/>`_.
 
 

--- a/docs/products/flink/concepts/windows.rst
+++ b/docs/products/flink/concepts/windows.rst
@@ -9,6 +9,6 @@ For example, you can set 15:00 as the start time for a time-based window, with t
 
 Events may still arrive after the allowed lateness for the window, so your application should include a means of handling those events, for example by logging them separately and then discarding them.
 
-For more information, see the `Apache Flink® documentation on windows <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/operators/windows/>`_.
+For more information, see the `Apache Flink® documentation on windows <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/datastream/operators/windows/>`_.
 
 

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -1,7 +1,7 @@
 Create an Apache Kafka®-based Apache Flink® table
 ==================================================
 
-To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
 
 A Flink table can be defined over an existing or new Aiven for Apache Kafka® topic to be able to source or sink streaming data. To define a table over an Apache Kafka® topic, the topic name, columns data format and connector type need to be defined, together with the Flink table name to use as reference when building data pipelines.
 
@@ -82,7 +82,7 @@ We can define a ``metrics_in`` Flink table with:
 
     The SQL schema includes:
 
-    * the message fields ``cpu``, ``hostname``, ``usage``, ``occurred_at`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/dev/table/types/#list-of-data-types>`_. The order of fields in the SQL definition doesn't need to follow the order presented in the payload.
+    * the message fields ``cpu``, ``hostname``, ``usage``, ``occurred_at`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/types/#list-of-data-types>`_. The order of fields in the SQL definition doesn't need to follow the order presented in the payload.
     * the definition of the field ``time_ltz`` as transformation to ``TIMESTAMP(3)`` from the ``occurred_at`` timestamp in Linux format.
     * the ``WATERMARK`` definition
 
@@ -110,7 +110,7 @@ We can define a ``metrics-out`` Flink table with:
 
 .. Note::
 
-    The SQL schema includes the output message fields ``cpu``, ``hostname``, ``usage`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/dev/table/types/#list-of-data-types>`_. 
+    The SQL schema includes the output message fields ``cpu``, ``hostname``, ``usage`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/types/#list-of-data-types>`_.
 
 
 Example: Define a Flink table using the upsert connector over topic in Avro format   
@@ -144,5 +144,5 @@ We can define a ``metrics-out`` Flink table with:
 
     The SQL schema includes:
     
-    * the output message fields ``cpu``, ``hostname``, ``max_usage`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/dev/table/types/#list-of-data-types>`_. 
+    * the output message fields ``cpu``, ``hostname``, ``max_usage`` and the related `data type <https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/types/#list-of-data-types>`_.
     * the ``PRIMARY KEY`` definition, driving the key part of the Apache Kafka message

--- a/docs/products/flink/howto/connect-opensearch.rst
+++ b/docs/products/flink/howto/connect-opensearch.rst
@@ -1,7 +1,7 @@
 Create an OpenSearch®-based Apache Flink® table
 ===============================================
 
-To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
 
 A Flink table can be defined over an existing or new Aiven for OpenSearch® index, to sink streaming data. To define a table over an OpenSearch® index, the index name and column data formats need to be defined, together with the Flink table name to use as reference when building data pipelines.
 

--- a/docs/products/flink/howto/connect-pg.rst
+++ b/docs/products/flink/howto/connect-pg.rst
@@ -1,7 +1,7 @@
 Create a PostgreSQL®-based Apache Flink® table
 ==============================================
 
-To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
 
 A Flink table can be defined over an existing or new Aiven for PostgreSQL® table to be able to source or sink streaming data. To define a table over an PostgreSQL® table, the table name and columns data format need to be defined, together with the Flink table name to use as reference when building data pipelines.
 


### PR DESCRIPTION
Flink version supported in Aiven is changed from 1.13.X to 1.15.1. Modify the links in devportal to point to Flink 1.15-series documentation. This PR needs to be merged _after_ the version of Flink has been changed in prod.

Note some links point to `nightlies.apache.org`, some point to `ci.apache.org`. If you go to https://flink.apache.org/ and from there to the docs, you'll go to https://nightlies.apache.org/flink/flink-docs-release-1.15/. We should probably change all our links to point to that host.