### PR TITLE
Fix url link elasticsearch-dump

### DIFF
--- a/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-using-elasticsearch-dump.rst
@@ -8,11 +8,11 @@ In this article, you can find out how to dump your OpenSearch data to an:
 * :ref:`Aiven for OpenSearch® <copy-data-from-os-to-os>`
 * :ref:`AWS S3 bucket <copy-data-from-os-to-s3>`
 
-To copy the index data, we will be using ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on how to install it. From this library, we will use ``elasticdump`` command to copy the input index data to an specific output. 
+To copy the index data, we will be using ``elasticsearch-dump`` `tool <https://github.com/elasticsearch-dump/elasticsearch-dump>`__. You can read the `instructions on GitHub <https://github.com/elasticsearch-dump/elasticsearch-dump/blob/master/README.md>`_ on how to install it. From this library, we will use ``elasticdump`` command to copy the input index data to an specific output. 
 
 .. note::
 
-    Make sure to have ``elasticsearch-dump`` `tool <elashttps://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed for the next steps.
+    Make sure to have ``elasticsearch-dump`` `tool <https://github.com/elasticsearch-dump/elasticsearch-dump>`__ installed for the next steps.
 
 .. _copy-data-from-os-to-os:
 


### PR DESCRIPTION
# What changed, and why it matters

Typo in url to provide elasticsearch-dump github repository.

