### PR TITLE
Add "Connect with Go" page to Cassandra documentation

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -691,6 +691,7 @@ entries:
           - file: docs/products/cassandra/howto/list-code-samples
             entries:
               - file: docs/products/cassandra/howto/connect-python
+              - file: docs/products/cassandra/howto/connect-go
       - file: docs/products/cassandra/reference
         title: Reference
         entries:

--- a/code/products/cassandra/connect.go
+++ b/code/products/cassandra/connect.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/gocql/gocql"
+)
+
+func main() {
+	var args = parseArgs()
+	cassandraExample(args)
+}
+
+type Args struct {
+	Host        string
+	Port        int
+	Username    string
+	Password    string
+	SSLCertfile string
+}
+
+func parseArgs() Args {
+	var args Args
+	flag.StringVar(&args.Host, "host", "", "Cassandra host")
+	flag.IntVar(&args.Port, "port", -1, "Cassandra port")
+	flag.StringVar(&args.Username, "username", "avnadmin", "Cassandra username")
+	flag.StringVar(&args.Password, "password", "", "Cassandra password")
+	flag.StringVar(&args.SSLCertfile, "ssl-certfile", "./ca.pem", "Path to project CA certificate")
+	flag.Parse()
+
+	if args.Host == "" {
+		fail("-host is required")
+	} else if args.Port == -1 {
+		fail("-port is required")
+	} else if args.Password == "" {
+		fail("-password is required")
+	}
+	return args
+}
+
+func fail(message string) {
+	flag.Usage()
+	log.Fatal(message)
+}
+
+func cassandraExample(args Args) {
+	var session = createSession(args)
+	defer session.Close()
+	createSchema(session)
+	writeData(session)
+	readData(session)
+}
+
+func createSession(args Args) gocql.Session {
+	cluster := gocql.NewCluster(args.Host)
+	cluster.ConnectTimeout = 10 * time.Second
+	cluster.Port = args.Port
+	cluster.ProtoVersion = 4
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: args.Username,
+		Password: args.Password,
+	}
+	cluster.SslOpts = &gocql.SslOptions{
+		SSLCertfile: args.SSLCertfile,
+	}
+	cluster.Consistency = gocql.Quorum
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return *session
+}
+
+func createSchema(session gocql.Session) {
+	if err := session.Query(
+		"CREATE KEYSPACE IF NOT EXISTS example_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'aiven': 3}",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+	if err := session.Query(
+		"CREATE TABLE IF NOT EXISTS example_keyspace.example_go (id int PRIMARY KEY, message text)",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func writeData(session gocql.Session) {
+	if err := session.Query(
+		"INSERT INTO example_keyspace.example_go (id, message) VALUES (?, ?)", 1, "hello world",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func readData(session gocql.Session) {
+	iter := session.Query("SELECT id, message FROM example_keyspace.example_go").Iter()
+	var id int
+	var message string
+	for iter.Scan(&id, &message) {
+		fmt.Printf("Row: id = %d, message = %s\n", id, message)
+	}
+	if err := iter.Close(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/code/products/cassandra/connect.go
+++ b/code/products/cassandra/connect.go
@@ -26,7 +26,7 @@ func parseArgs() Args {
 	var args Args
 	flag.StringVar(&args.Host, "host", "", "Cassandra host")
 	flag.IntVar(&args.Port, "port", -1, "Cassandra port")
-	flag.StringVar(&args.Username, "username", "avnadmin", "Cassandra username")
+	flag.StringVar(&args.Username, "user", "avnadmin", "Cassandra username")
 	flag.StringVar(&args.Password, "password", "", "Cassandra password")
 	flag.StringVar(&args.SSLCertfile, "ssl-certfile", "./ca.pem", "Path to project CA certificate")
 	flag.Parse()
@@ -64,7 +64,7 @@ func createSession(args Args) gocql.Session {
 		Password: args.Password,
 	}
 	cluster.SslOpts = &gocql.SslOptions{
-		SSLCertfile: args.SSLCertfile,
+		CaPath: args.SSLCertfile,
 	}
 	cluster.Consistency = gocql.Quorum
 

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -1,0 +1,44 @@
+Connect with Go
+---------------
+
+This example connects to an Aiven for Apache Cassandra® service from Go as the ``avnadmin`` user by making use of the ``gocql`` library. 
+
+Variables
+'''''''''
+
+These are the placeholders you will need to replace in the code sample:
+
+==================      =============================================================
+Variable                Description
+==================      =============================================================
+``HOST``                Host name of your Cassandra service 
+``PORT``                Port number to use for connection to your Cassandra service 
+``PASSWORD``            Password of the ``avnadmin`` user
+``SSL-CERTFILE``        Path to the `CA Certificate` file of your Cassandra service
+==================      =============================================================
+
+Pre-requisites
+''''''''''''''
+
+Get the ``gocql`` library::
+
+    go get github.com/gocql/gocql
+
+Code
+''''
+1. Create a new file named ``main.go`` and add the following content:
+
+.. literalinclude:: /code/products/cassandra/connect.go
+   :language: go
+
+This code first creates a keyspace named ``example_keyspace`` and a table named ``example_go`` that contains an ``id`` and a ``message``. Then, it writes a new 
+entry into the table with the values ``1`` and ``hello world``. Finally, it reads the entry from the table and prints it.
+
+2. Execute the following from a terminal window to build an executable:: 
+
+    go build main.go
+
+3. Run the program with the required flags to pass the necessary connection details:: 
+
+    ./main --HOST <HOST> --PORT <PORT> --USER avnadmin --PASSWORD <PASSWORD> --SSL-CERTFILE <PATH TO CERTFILE>
+

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -27,6 +27,7 @@ Get the ``gocql`` library::
 
 Code
 ''''
+
 1. Create a new file named ``main.go`` and add the following content:
 
 .. literalinclude:: /code/products/cassandra/connect.go

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -41,5 +41,5 @@ entry into the table with the values ``1`` and ``hello world``. Finally, it read
 
 3. Run the program with the required flags to pass the necessary connection details:: 
 
-    ./main --HOST <HOST> --PORT <PORT> --USER avnadmin --PASSWORD <PASSWORD> --SSL-CERTFILE <PATH TO CERTFILE>
+    ./main --host <HOST> --port <PORT> --user avnadmin --password <PASSWORD> --ssl-certfile <PATH TO CERTFILE>
 

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -8,14 +8,15 @@ Variables
 
 These are the placeholders you will need to replace in the code sample:
 
-==================      =============================================================
+==================      ================================================================================
 Variable                Description
-==================      =============================================================
+==================      ================================================================================
 ``HOST``                Host name of your Cassandra service 
-``PORT``                Port number to use for connection to your Cassandra service 
+``PORT``                Port number used for connecting to your Cassandra service 
+``USER``                Username used for connecting to your Cassandra service. Defaults to ``avnadmin`` 
 ``PASSWORD``            Password of the ``avnadmin`` user
 ``SSL-CERTFILE``        Path to the `CA Certificate` file of your Cassandra service
-==================      =============================================================
+==================      ================================================================================
 
 Pre-requisites
 ''''''''''''''


### PR DESCRIPTION
# What changed, and why it matters
I have moved the example code which could previously only be found on our GitHub: https://github.com/aiven/aiven-examples/tree/master/cassandra/go and was mentioned in our old help article: https://help.aiven.io/en/articles/1803299-getting-started-with-aiven-for-cassandra to a separate page, as is the approach in our documentation for the other services as well. 

While doing so, I also moved the old GitHub example into one code file as this improves the clarity of the example and also contains the code in only one file, as is our approach for our other services as well. I also made some surface changes to the code itself in order to improve the readability. 

Let me know what you think of this approach. 

This partly fixes #98 
