### PR TITLE
Reference blog post on finishing support of Aiven for Elasticsearch

### DIFF
--- a/docs/products/grafana/howto/replace-expression-string.rst
+++ b/docs/products/grafana/howto/replace-expression-string.rst
@@ -6,6 +6,12 @@ This page describes how to do that using the ``aiven-string-replacer-for-grafana
 
 The approach described will work with your own Grafana® cluster or with an Aiven for Grafana® cluster
 
+.. note:: This command is mentioned in the 2022-08-09 Aiven blog post
+   `Aiven finishes the transition away from Elasticsearch: technical details
+   <https://aiven.io/blog/finish-move-away-from-elasticsearch>`_
+   See `Example: changing elasticsearch to opensearch`_ later in this page for
+   specific help.
+
 Prerequisites
 -------------
 

--- a/docs/products/grafana/howto/replace-expression-string.rst
+++ b/docs/products/grafana/howto/replace-expression-string.rst
@@ -9,8 +9,9 @@ The approach described will work with your own Grafana® cluster or with an Aive
 .. note:: This command is mentioned in the 2022-08-09 Aiven blog post
    `Aiven finishes the transition away from Elasticsearch: technical details
    <https://aiven.io/blog/finish-move-away-from-elasticsearch>`_
-   See `Example: changing elasticsearch to opensearch`_ later in this page for
-   specific help.
+
+   See `the example`_ of changing ``elasticsearch_`` to ``opensearch_`` later
+   in this page for.
 
 Prerequisites
 -------------
@@ -80,6 +81,8 @@ Use a command like the following to perform the replacement, changing the placeh
       -from OLD_STRING \
       -to NEW_STRING \
       -uid GRAFANA_DASHBOARD_UID
+
+.. _`the example`:
 
 Example: changing ``elasticsearch_`` to ``opensearch_``
 -------------------------------------------------------


### PR DESCRIPTION
The `aiven-string-replacer-for-grafana` is referenced in an Aiven blog post, 
https://aiven.io/blog/finish-move-away-from-elasticsearch

More precisely, the blog post refers to this page.

It seems sensible to add a link back to the blog post.
