### PR TITLE
Adding missing instructions. For issue-1227

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
@@ -21,6 +21,8 @@ Furthermore you need to follow the steps :doc:`to prepare the GCP account and GC
 
     The ``GCS_CREDENTIALS`` parameter should be in the format ``{\"type\": \"service_account\",\"project_id\": \"XXXXXX\", ...}``
 
+    Additionally, any ``\n`` symbols contained in the ``private_key`` field need to be escaped (by substituting with ``\\n``)
+
 
 Setup an GCS sink connector with Aiven Console
 ----------------------------------------------


### PR DESCRIPTION
Adding instructions for escaping the new line for the GCS credentials.

# What changed, and why it matters

In the prerequisites warning section the instructions for the GCS_CREDENTIALS attribute format do not include how to escape the new line for the private_key value. I spent a while working out the error I was getting for the credentials until I found out the newlines had to be escaped. 

https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/gcs-sink.html


