### PR TITLE
[concepts]: Out of Memory Conditions

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -103,6 +103,8 @@ Okta
 onboarding
 OpenSearch
 operator
+overcommit
+overcommitted
 Pagerduty
 Pagila
 Papertrail
@@ -148,6 +150,8 @@ Stackdriver
 Statusmap
 Stunnel
 subnet
+subprocess
+subprocesses
 subtab
 syslog
 TaskManager

--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -60,6 +60,7 @@ exceptions:
   - NodeJS
   - OpenSearch
   - Operator
+  - Out of Memory Killer
   - Pagila
   - pgAdmin
   - PgBouncer

--- a/_toc.yml
+++ b/_toc.yml
@@ -23,6 +23,7 @@ entries:
       - file: docs/platform/concepts/service-forking
       - file: docs/platform/concepts/service_backups
       - file: docs/platform/concepts/service-memory-limits
+      - file: docs/platform/concepts/out-of-memory-conditions
       - file: docs/platform/concepts/static-ips
       - file: docs/platform/concepts/tls-ssl-certificates
       - file: docs/platform/concepts/byoa

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -59,6 +59,10 @@ Learn about some of the key concepts for working with Aiven platform:
   
   DR testing scenarios are simulations of disaster scenarios run for enterprise support customers by Aiven operators.
 
-* :doc:`Choosing a time series database </docs/platform/concepts/choosing-timeseries-database>`.
+* `Choosing a time series database`_.
   
   Choosing a time series database in Aiven Console.
+
+.. We would like to use a :doc: role for this, but at 2022-08, vale will
+   spell-check the URL if we do so, and complain about 'timeseries'
+.. _`Choosing a time series database`: https://developer.aiven.io/docs/platform/concepts/choosing-timeseries-database

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -31,6 +31,10 @@ Learn about some of the key concepts for working with Aiven platform:
 
   Understanding memory overhead and limits applied to services.
 
+* :doc:`Out of memory conditions </docs/platform/concepts/out-of-memory-conditions>`.
+
+  How Aiven protects your service from the Out Of Memory Killer when memory is overcommitted.
+
 * :doc:`Projects and access management </docs/platform/concepts/projects_accounts_access>`.
 
   Understand how to set up users, accounts and access management for your Aiven projects.

--- a/docs/platform/concepts/out-of-memory-conditions.rst
+++ b/docs/platform/concepts/out-of-memory-conditions.rst
@@ -13,7 +13,7 @@ However, if enough processes start using all their allocated memory simultaneous
 The Out of Memory Killer
 ------------------------
 
-The solution that the linux kernel employs is to invoke the ``Out of Memory Killer`` (or ``OOM Killer``), a Linux kernel process that reviews all running processes and kills one or more of them in order to free up system memory in order keep the system running.
+The solution that the Linux kernel employs is to invoke the ``Out of Memory Killer`` (or ``OOM Killer``), a Linux kernel process that reviews all running processes and kills one or more of them in order to free up system memory in order keep the system running.
 
 
 Which process will be killed?

--- a/docs/platform/concepts/out-of-memory-conditions.rst
+++ b/docs/platform/concepts/out-of-memory-conditions.rst
@@ -1,0 +1,61 @@
+Out of memory conditions
+========================
+
+**Many processes request more memory from the kernel then they will ever use or need.**
+
+Because of this the kernel over allocates memory (heuristic overcommit), which allows it satisfy multiple processes requesting more memory then is available, in the knowledge that either they will never use it, or that they will have freed it by the time any other process actually needs it.
+
+However, if enough processes start using all their allocated memory simultaneously there may not be enough physical memory available and an ``Out Of Memory`` (``OOM``) condition occurs. 
+
+*This situation is critical and must be resolved immediately.*
+
+
+The Out of Memory Killer
+------------------------
+
+The solution that the linux kernel employs is to invoke the ``Out of Memory Killer`` (or ``OOM Killer``), a Linux kernel process that reviews all running processes and kills one or more of them in order to free up system memory in order keep the system running.
+
+
+Which process will be killed?
+-----------------------------
+
+The ``OOM Killer`` selects process to kill based on a ``oom_score``; a calculation that balances the how much memory the process is using with how long the process has been running. 
+
+Processes that have been running for a long time are less likely to be killed. Subprocesses are summed with parent processes in terms of memory usage, so a process which forks a large number of subprocesses, but itself does not use a lot of memory, may still be killed.
+
+*In most instances, the hosted data service, or a child process, will have the highest memory footprint and be a prime candidate for termination when the OOM Killer sweeps the running processes.*
+
+Aiven's cloud data platform leverages kernel namespaces (or containers) to isolate processes from each other. Isolation has several benefits, including: 
+
+- A smaller footprint for security‑related concerns
+- A smaller blast radius for failure
+- Greater control of system resources
+
+Left unchecked, the ``OOM Killer`` may opt to kill the primary service. This is undesirable as unclean termination of the primary service can lead to data loss, inconsistency, or corrupted backups. 
+
+Further, if Aiven's management platform detects that the primary service is unavailable for **60 seconds**, the service will be marked as down and a failover will occur. 
+
+To mitigate this scenario, namespaces are used, :doc:`some with additional memory limits <service-memory-limits>`, in combination with an ``oom_score_adjust`` on the primary process, to coax the ``OOM Killer`` into selection of less critical processes. 
+
+This will still result in a service restart, but in a more controlled process, where the database is shut down, rather than killed; exposure to data loss is limited and recovery is faster when the service restarts, often avoiding failover.
+
+.. warning:: Out of Memory conditions can still lead to unexpected behavior, including data unavailable or data loss conditions. 
+
+
+How to avoid the OOM Killer
+---------------------------
+
+The OOM killer only runs when the system is critically low on memory, so to avoid it running you need to either reduce your memory usage or increase the available memory.
+
+For most databases, the service memory footprint can often be reduced by:
+
+- Reducing concurrency or implementing connection pooling
+- Tuning queries to limit result sets
+- Tuning indexes for query load
+- Dropping unused objects from storage
+
+In cases where the working set no longer fits into memory, consider :doc:`scaling your service <../howto/scale-services>`.
+
+
+
+

--- a/docs/platform/concepts/out-of-memory-conditions.rst
+++ b/docs/platform/concepts/out-of-memory-conditions.rst
@@ -3,7 +3,7 @@ Out of memory conditions
 
 **Many processes request more memory from the kernel then they will ever use or need.**
 
-Because of this the kernel over allocates memory (heuristic overcommit), which allows it satisfy multiple processes requesting more memory then is available, in the knowledge that either they will never use it, or that they will have freed it by the time any other process actually needs it.
+Because of this the kernel over allocates memory (heuristic overcommit), which allows it to satisfy multiple processes requesting more memory then is available, in the knowledge that either they will never use it, or that they will have freed it by the time any other process actually needs it.
 
 However, if enough processes start using all their allocated memory simultaneously there may not be enough physical memory available and an ``Out Of Memory`` (``OOM``) condition occurs. 
 
@@ -19,11 +19,11 @@ The solution that the Linux kernel employs is to invoke the ``Out of Memory Kill
 Which process will be killed?
 -----------------------------
 
-The ``OOM Killer`` selects process to kill based on a ``oom_score``; a calculation that balances the how much memory the process is using with how long the process has been running. 
+The ``OOM Killer`` selects process to kill based on an ``oom_score``; a calculation that balances how much memory the process is using with how long the process has been running.
 
 Processes that have been running for a long time are less likely to be killed. Subprocesses are summed with parent processes in terms of memory usage, so a process which forks a large number of subprocesses, but itself does not use a lot of memory, may still be killed.
 
-*In most instances, the hosted data service, or a child process, will have the highest memory footprint and be a prime candidate for termination when the OOM Killer sweeps the running processes.*
+*In most instances, the hosted data service, or a child process, will have the highest memory footprint and be a prime candidate for termination when the OOM Killer inspects the running processes.*
 
 Aiven's cloud data platform leverages kernel namespaces (or containers) to isolate processes from each other. Isolation has several benefits, including: 
 

--- a/docs/platform/concepts/service-memory-limits.rst
+++ b/docs/platform/concepts/service-memory-limits.rst
@@ -1,25 +1,19 @@
 Service memory limits
 =====================
 
+The practical memory limit will always be less than the service physical memory limit.
+
 **All services are subject to operating overhead:**
 
 - A small amount of memory is required by the operating system kernel to manage system resources, including networking functions and disk buffers.
-- Aiven's cloud data platform also requires memory to monitor availability, provide metrics, logging and manage backups.
-- Some services utilize optional integrations, connection pooling, or plug-ins components that also consume system resources.
+- Aiven's cloud data platform requires memory to monitor availability, provide metrics, logging and manage backups.
+- Services may utilize optional components, service integrations, connection pooling, or plug-ins that also consume system resources.
 
 In most instances, the combined overhead is negligible; however, it is **critically important to maintain availability**.
 
-If a service consumes too much memory, the operating system or management components, including backups and availability monitoring, may fail status checks or timed operations due to limited system resources. In severe instances, the node may fail completely with an ``Out of Memory`` condition. 
+If a service consumes too much memory, the operating system, or management layer, including backups and availability monitoring, may fail status checks or operations due to resource contention.
+In severe instances, the node may fail completely with an :doc:`Out Of Memory <out-of-memory-conditions>` condition. 
 
-A memory limit is applied to the primary process of the following Aiven services:
+For database services with unbounded memory allocation, a memory limit is placed on the primary service.
 
-- InfluxDB®
-- MySQL
-- PostgreSQL®
-
-With all new instances, a limit of 80% of available memory (RAM - 350MB) is assigned to the primary process, with the remainder reserved for operating overhead and mitigation of potential ``Out of Memory`` conditions.
-
-.. note:: Reserved memory for non-service use is capped to a maximum of 4GB.
-
-.. note:: For MySQL, a minimum of 600MB is always guaranteed.
-
+.. include:: /includes/services-memory-capped.rst

--- a/includes/services-memory-capped.rst
+++ b/includes/services-memory-capped.rst
@@ -1,0 +1,14 @@
+Services with memory limits
+-----------------------------------------------------
+
+A memory limit is applied to the primary process of the following Aiven services:
+
+- InfluxDB®
+- MySQL
+- PostgreSQL®
+
+With all new instances, a limit of 80% of available memory (RAM - 350MB) is assigned to the primary process, with the remainder reserved for operating overhead and page cache.
+
+.. note:: Reserved memory for non-service use is capped to a maximum of 4GB.
+
+.. note:: For MySQL, a minimum of 600MB is always guaranteed.


### PR DESCRIPTION
# What changed, and why it matters
Rework: service-memory-limits to move the list of services
into an include file. This allows for multiple articles to reference the
same set with only 1 file to maintain.

Added: out-of-memory conditions to explain OOM behaviour
and how Aiven uses containers to prevent uncontrolled shutdowns.
This is also a replacement for:
https://help.aiven.io/en/articles/4509218-out-of-memory-killer