### PR TITLE
Remove unnecessary space in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sphinx-panels==0.6.0
 sphinxcontrib-mermaid==0.7.1
 sphinx-external-toc==0.2.3
 sphinx-copybutton==0.5.0
-sphinx_gitstamp== 0.3.2
+sphinx_gitstamp==0.3.2
 beautifulsoup4==4.9.3
 opensearch-py==1.0.0
 requests==2.25.1


### PR DESCRIPTION
# What changed, and why it matters

Just a little hobgoblin for consistency -- apparently the space works with `pip install -r FILE`  but no spaces are allowed with `pip install sphinx_gitstamp== 0.3.2`.
