### PR TITLE
Changed keystore and truststore title to be more searchable

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -217,6 +217,7 @@ entries:
             title: Security
             entries:
               - file: docs/products/kafka/howto/keystore-truststore
+                title: Configure Java SSL keystore and trustore to access Apache Kafka
               - file: docs/products/kafka/howto/manage-acls
               - file: docs/products/kafka/howto/monitor-logs-acl-failure
               - file: docs/products/kafka/howto/kafka-sasl-auth

--- a/_toc.yml
+++ b/_toc.yml
@@ -217,7 +217,7 @@ entries:
             title: Security
             entries:
               - file: docs/products/kafka/howto/keystore-truststore
-                title: Configure Java SSL keystore and trustore to access Apache Kafka
+                title: Configure Java SSL keystore and truststore to access Apache Kafka
               - file: docs/products/kafka/howto/manage-acls
               - file: docs/products/kafka/howto/monitor-logs-acl-failure
               - file: docs/products/kafka/howto/kafka-sasl-auth

--- a/docs/products/kafka/howto/keystore-truststore.rst
+++ b/docs/products/kafka/howto/keystore-truststore.rst
@@ -1,5 +1,5 @@
-Configure Java SSL to access Apache Kafka®
-=================================================
+Configure Java SSL keystore and trustore to access Apache Kafka®
+================================================================
 
 Aiven for Apache Kafka® utilises TLS (SSL) to secure the traffic between its services and client applications. This means that clients must be configured with the
 right tools to be able to communicate with the Aiven services.

--- a/docs/products/kafka/howto/keystore-truststore.rst
+++ b/docs/products/kafka/howto/keystore-truststore.rst
@@ -1,5 +1,5 @@
-Configure Java SSL keystore and trustore to access Apache Kafka®
-================================================================
+Configure Java SSL keystore and truststore to access Apache Kafka®
+==================================================================
 
 Aiven for Apache Kafka® utilises TLS (SSL) to secure the traffic between its services and client applications. This means that clients must be configured with the
 right tools to be able to communicate with the Aiven services.


### PR DESCRIPTION
# What changed, and why it matters

Changed Java keystore and truststore title to add keystore and truststore words to make it more searchable


