### PR TITLE
Change our CI to use the latest version of Vale for linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       # 2020-08-12 The default branch of vale-action is `reviewdog`, which
       # defaults to using the latest version of `vale`
       # If we want a specific version, use `version:` in the `with` clause below
-      uses: errata-ai/vale-action
+      uses: errata-ai/vale-action@reviewdog
       with:
         files: '["index.rst", "docs"]'
       env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,13 +16,10 @@ jobs:
       uses: actions/checkout@master
 
     - name: Vale
-      # We want support for at least vale v2.15.3
-      # The current release of vale-action, v1.5.0, only provides vale 2.15.2
-      # So for the moment we need to use vale-action master, which provides
-      # at least vale 2.15.5.
-      # When there is a vale-action that provides a version we can use, re-pin
-      # this to a specific version of vale-action.
-      uses: errata-ai/vale-action@reviewdog
+      # 2020-08-12 The default branch of vale-action is `reviewdog`, which
+      # defaults to using the latest version of `vale`
+      # If we want a specific version, use `version:` in the `with` clause below
+      uses: errata-ai/vale-action
       with:
         files: '["index.rst", "docs"]'
       env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
       # at least vale 2.15.5.
       # When there is a vale-action that provides a version we can use, re-pin
       # this to a specific version of vale-action.
-      uses: errata-ai/vale-action@master
+      uses: errata-ai/vale-action@reviewdog
       with:
         files: '["index.rst", "docs"]'
       env:


### PR DESCRIPTION
Before, we were deliberately using the `master` branch of [vale-action](https://github.com/errata-ai/vale-action), as that *was* the best way to get a reasonably up-to-date version of Vale

However, the default branch of vale-action is now `reviewdog`, and *that* will automatically use the current latest version of vale, which is probably what we want. It also allows specifying a particular version of vale if we don't want the latest.

**Note** in fact the documentation at https://github.com/marketplace/actions/vale-linter documents using this branch of vale-action

Fixes https://github.com/aiven/devportal/issues/1235

Tested by specifying an earlier version of vale (it used it) and then allowing it to choose the latest (here).

Also, the logs provided for the `Linting / prose (pull_request)` CI check now contain useful information under `Vale`, including the version of vale that was used, and the vale output.
