### PR TITLE
Adjust description of parameter indices_recovery_max_bytes_per_sec for improved clarity

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -648,6 +648,12 @@ entries:
         title: Concepts
         entries:
           - glob: docs/products/cassandra/concepts/*
+      - file: docs/products/cassandra/howto
+        title: HowTo
+        entries:
+          - file: docs/products/cassandra/howto/list-code-samples
+            entries:
+              - file: docs/products/cassandra/howto/connect-go
       - file: docs/products/cassandra/reference
         title: Reference
         entries:

--- a/code/products/cassandra/connect.go
+++ b/code/products/cassandra/connect.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/gocql/gocql"
+)
+
+func main() {
+	var args = parseArgs()
+	cassandraExample(args)
+}
+
+type Args struct {
+	Host        string
+	Port        int
+	Username    string
+	Password    string
+	SSLCertfile string
+}
+
+func parseArgs() Args {
+	var args Args
+	flag.StringVar(&args.Host, "host", "", "Cassandra host")
+	flag.IntVar(&args.Port, "port", -1, "Cassandra port")
+	flag.StringVar(&args.Username, "username", "avnadmin", "Cassandra username")
+	flag.StringVar(&args.Password, "password", "", "Cassandra password")
+	flag.StringVar(&args.SSLCertfile, "ssl-certfile", "./ca.pem", "Path to project CA certificate")
+	flag.Parse()
+
+	if args.Host == "" {
+		fail("-host is required")
+	} else if args.Port == -1 {
+		fail("-port is required")
+	} else if args.Password == "" {
+		fail("-password is required")
+	}
+	return args
+}
+
+func fail(message string) {
+	flag.Usage()
+	log.Fatal(message)
+}
+
+func cassandraExample(args Args) {
+	var session = createSession(args)
+	defer session.Close()
+	createSchema(session)
+	writeData(session)
+	readData(session)
+}
+
+func createSession(args Args) gocql.Session {
+	cluster := gocql.NewCluster(args.Host)
+	cluster.ConnectTimeout = 10 * time.Second
+	cluster.Port = args.Port
+	cluster.ProtoVersion = 4
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: args.Username,
+		Password: args.Password,
+	}
+	cluster.SslOpts = &gocql.SslOptions{
+		SSLCertfile: args.SSLCertfile,
+	}
+	cluster.Consistency = gocql.Quorum
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return *session
+}
+
+func createSchema(session gocql.Session) {
+	if err := session.Query(
+		"CREATE KEYSPACE IF NOT EXISTS example_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'aiven': 3}",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+	if err := session.Query(
+		"CREATE TABLE IF NOT EXISTS example_keyspace.example_go (id int PRIMARY KEY, message text)",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func writeData(session gocql.Session) {
+	if err := session.Query(
+		"INSERT INTO example_keyspace.example_go (id, message) VALUES (?, ?)", 1, "hello world",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func readData(session gocql.Session) {
+	iter := session.Query("SELECT id, message FROM example_keyspace.example_go").Iter()
+	var id int
+	var message string
+	for iter.Scan(&id, &message) {
+		fmt.Printf("Row: id = %d, message = %s\n", id, message)
+	}
+	if err := iter.Close(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/code/products/cassandra/connect.go
+++ b/code/products/cassandra/connect.go
@@ -26,7 +26,7 @@ func parseArgs() Args {
 	var args Args
 	flag.StringVar(&args.Host, "host", "", "Cassandra host")
 	flag.IntVar(&args.Port, "port", -1, "Cassandra port")
-	flag.StringVar(&args.Username, "username", "avnadmin", "Cassandra username")
+	flag.StringVar(&args.Username, "user", "avnadmin", "Cassandra username")
 	flag.StringVar(&args.Password, "password", "", "Cassandra password")
 	flag.StringVar(&args.SSLCertfile, "ssl-certfile", "./ca.pem", "Path to project CA certificate")
 	flag.Parse()
@@ -64,7 +64,7 @@ func createSession(args Args) gocql.Session {
 		Password: args.Password,
 	}
 	cluster.SslOpts = &gocql.SslOptions{
-		SSLCertfile: args.SSLCertfile,
+		CaPath: args.SSLCertfile,
 	}
 	cluster.Consistency = gocql.Quorum
 

--- a/docs/products/cassandra/howto.rst
+++ b/docs/products/cassandra/howto.rst
@@ -1,0 +1,6 @@
+HowTo
+=====
+
+Check out the common tasks for working with Aiven for Apache Cassandra®.
+
+.. tableofcontents::

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -1,0 +1,44 @@
+Connect with Go
+---------------
+
+This example connects to an Aiven for Apache Cassandra® service from Go as the ``avnadmin`` user by making use of the ``gocql`` library. 
+
+Variables
+'''''''''
+
+These are the placeholders you will need to replace in the code sample:
+
+==================      =============================================================
+Variable                Description
+==================      =============================================================
+``HOST``                Host name of your Cassandra service 
+``PORT``                Port number to use for connection to your Cassandra service 
+``PASSWORD``            Password of the ``avnadmin`` user
+``SSL-CERTFILE``        Path to the `CA Certificate` file of your Cassandra service
+==================      =============================================================
+
+Pre-requisites
+''''''''''''''
+
+Get the ``gocql`` library::
+
+    go get github.com/gocql/gocql
+
+Code
+''''
+1. Create a new file named ``main.go`` and add the following content:
+
+.. literalinclude:: /code/products/cassandra/connect.go
+   :language: go
+
+This code first creates a keyspace named ``example_keyspace`` and a table named ``example_go`` that contains an ``id`` and a ``message``. Then, it writes a new 
+entry into the table with the values ``1`` and ``hello world``. Finally, it reads the entry from the table and prints it.
+
+2. Execute the following from a terminal window to build an executable:: 
+
+    go build main.go
+
+3. Run the program with the required flags to pass the necessary connection details:: 
+
+    ./main --HOST <HOST> --PORT <PORT> --USER avnadmin --PASSWORD <PASSWORD> --SSL-CERTFILE <PATH TO CERTFILE>
+

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -41,5 +41,5 @@ entry into the table with the values ``1`` and ``hello world``. Finally, it read
 
 3. Run the program with the required flags to pass the necessary connection details:: 
 
-    ./main --HOST <HOST> --PORT <PORT> --USER avnadmin --PASSWORD <PASSWORD> --SSL-CERTFILE <PATH TO CERTFILE>
+    ./main --host <HOST> --port <PORT> --user avnadmin --password <PASSWORD> --ssl-certfile <PATH TO CERTFILE>
 

--- a/docs/products/cassandra/howto/connect-go.rst
+++ b/docs/products/cassandra/howto/connect-go.rst
@@ -8,14 +8,15 @@ Variables
 
 These are the placeholders you will need to replace in the code sample:
 
-==================      =============================================================
+==================      ================================================================================
 Variable                Description
-==================      =============================================================
+==================      ================================================================================
 ``HOST``                Host name of your Cassandra service 
-``PORT``                Port number to use for connection to your Cassandra service 
+``PORT``                Port number used for connecting to your Cassandra service 
+``USER``                Username used for connecting to your Cassandra service. Defaults to ``avnadmin`` 
 ``PASSWORD``            Password of the ``avnadmin`` user
 ``SSL-CERTFILE``        Path to the `CA Certificate` file of your Cassandra service
-==================      =============================================================
+==================      ================================================================================
 
 Pre-requisites
 ''''''''''''''

--- a/docs/products/cassandra/howto/list-code-samples.rst
+++ b/docs/products/cassandra/howto/list-code-samples.rst
@@ -1,0 +1,4 @@
+Code samples
+============
+
+.. tableofcontents::

--- a/includes/config-opensearch.rst
+++ b/includes/config-opensearch.rst
@@ -84,7 +84,7 @@
     **indices.queries.cache.size** Percentage value. Default is 10%. Maximum amount of heap used for query cache. This is an expert setting. Too low value will decrease query performance and increase performance for other operations; too high value will cause issues with other OpenSearch functionality.
 
   ``indices_recovery_max_bytes_per_sec`` => *integer*
-    **indices.recovery.max_bytes_per_sec** Limits total inbound and outbound recovery traffic for each node. Applies to both peer recoveries as well as snapshot recoveries (i.e., restores from a snapshot). Defaults to 40mb
+    **indices.recovery.max_bytes_per_sec** Limits total inbound and outbound recovery traffic for each node. Applies to both peer recoveries as well as snapshot recoveries (i.e., restores from a snapshot). Defaults to 40mb per CPU. 
 
   ``indices_recovery_max_concurrent_file_chunks`` => *integer*
     **indices.recovery.max_concurrent_file_chunks** Number of file chunks sent in parallel for each recovery. Defaults to 2.


### PR DESCRIPTION
# What changed, and why it matters
I added a clarification that the default for the advanced Opensearch parameter `indices_recovery_max_bytes_per_sec` is 40 MB *per CPU*. 

Fixes #1245.  

