### PR TITLE
Add a note regarding play connectivity.

### DIFF
--- a/docs/products/clickhouse/howto/use-play.rst
+++ b/docs/products/clickhouse/howto/use-play.rst
@@ -11,5 +11,5 @@ ClickHouse® includes a built-in user interface for running SQL queries. You can
 #. Click **Run**.
 
 .. note::
-    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is :doc:`restricted by IP addresses </docs/platform/howto/restrict-access.html>`_ or in a :doc:`VPC without public access </docs/platform/howto/public-access-in-vpc.html>`_, you can use the :doc:`query editor <use-query-editor>` instead.
+    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is :doc:`restricted by IP addresses </docs/platform/howto/restrict-access.html>` or in a :doc:`VPC without public access </docs/platform/howto/public-access-in-vpc.html>`, you can use the :doc:`query editor <use-query-editor>` instead.
     The query editor can be accessed directly from the console to run requests on behalf of the default user.

--- a/docs/products/clickhouse/howto/use-play.rst
+++ b/docs/products/clickhouse/howto/use-play.rst
@@ -11,5 +11,5 @@ ClickHouse® includes a built-in user interface for running SQL queries. You can
 #. Click **Run**.
 
 .. note::
-    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is `restricted by IP addresses <https://developer.aiven.io/docs/platform/howto/restrict-access.html>`_ or in a `VPC without public access <https://developer.aiven.io/docs/platform/howto/public-access-in-vpc.html>`_, you can use the :doc:`query editor <use-query-editor>` instead.
+    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is :doc:`restricted by IP addresses </docs/platform/howto/restrict-access.html>`_ or in a :doc:`VPC without public access </docs/platform/howto/public-access-in-vpc.html>`_, you can use the :doc:`query editor <use-query-editor>` instead.
     The query editor can be accessed directly from the console to run requests on behalf of the default user.

--- a/docs/products/clickhouse/howto/use-play.rst
+++ b/docs/products/clickhouse/howto/use-play.rst
@@ -11,4 +11,5 @@ ClickHouse® includes a built-in user interface for running SQL queries. You can
 #. Click **Run**.
 
 .. note::
-    `/play` is an alternative to the :doc:`query editor <use-query-editor>`. The query editor can be accessed directly from the console to run requests on behalf of the default user.
+    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is `restricted by IP addresses <https://developer.aiven.io/docs/platform/howto/restrict-access.html>`_ or in a `VPC without public access <https://developer.aiven.io/docs/platform/howto/public-access-in-vpc.html>`_, you can use the :doc:`query editor <use-query-editor>` instead.
+    The query editor can be accessed directly from the console to run requests on behalf of the default user.

--- a/docs/products/clickhouse/howto/use-play.rst
+++ b/docs/products/clickhouse/howto/use-play.rst
@@ -11,5 +11,5 @@ ClickHouse® includes a built-in user interface for running SQL queries. You can
 #. Click **Run**.
 
 .. note::
-    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is :doc:`restricted by IP addresses </docs/platform/howto/restrict-access.html>` or in a :doc:`VPC without public access </docs/platform/howto/public-access-in-vpc.html>`, you can use the :doc:`query editor <use-query-editor>` instead.
+    The play interface is only available if you can connect directly to ClickHouse from your browser. If the service is :doc:`restricted by IP addresses </docs/platform/howto/restrict-access>` or in a :doc:`VPC without public access </docs/platform/howto/public-access-in-vpc>`, you can use the :doc:`query editor <use-query-editor>` instead.
     The query editor can be accessed directly from the console to run requests on behalf of the default user.


### PR DESCRIPTION
# What changed, and why it matters

Since the HTTPS link to **play** will not work with VPC and filtered networks, I'm adding a note/warning per @kmichel-aiven 
for services that are either restricted by IP addressed or are within a VPC without public access.

