### PR TITLE
Small number of link fixes

### DIFF
--- a/docs/platform/concepts/logs-metrics-alerts.rst
+++ b/docs/platform/concepts/logs-metrics-alerts.rst
@@ -21,5 +21,5 @@ You can create custom OpenSearch® or Grafana® dashboards to monitor the servic
 Alerts
 ------
 
-The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <https://docs.aiven.io/docs/platform/howto/technical-emails.html>`_.
+The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see :doc:`this article </docs/platform/howto/technical-emails>`.
 

--- a/docs/platform/concepts/logs-metrics-alerts.rst
+++ b/docs/platform/concepts/logs-metrics-alerts.rst
@@ -21,5 +21,5 @@ You can create custom OpenSearch® or Grafana® dashboards to monitor the servic
 Alerts
 ------
 
-The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <https://help.aiven.io/en/articles/5234705-technical-emails>`_.
+The platform also has alert policies to notify you via email when a key metric rises above or below a set threshold, such as low memory or high CPU consumption. For information on setting the addresses for these emails, see `this article <https://docs.aiven.io/docs/platform/howto/technical-emails.html>`_.
 

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -50,13 +50,13 @@ Using MirrorMaker 2, the backup cluster is running as an independent Kafka servi
 
 Note that MirrorMaker 2 provides tools for mapping between source and target offset, so the user does not need to make this calculation. For more details see the section "Offset Mapping" in the blog post `A look inside Kafka MirrorMaker 2 <https://blog.cloudera.com/a-look-inside-kafka-mirrormaker-2/>`__.
 
-An alternative is to use Kafka Connect to backup the cluster, for instance sinking data from Apache Kafka® to S3 via the `dedicated Aiven connector <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/s3-sink-prereq.html>`_.
+An alternative is to use Kafka Connect to backup the cluster, for instance sinking data from Apache Kafka® to S3 via the :doc:`dedicated Aiven connector </docs/products/kafka/kafka-connect/howto/s3-sink-prereq>`.
 
 For more information refer to
 
 - :doc:`Aiven for Apache Kafka® MirrorMaker 2 </docs/products/kafka/kafka-mirrormaker>`
 - Cloudera's `A look inside Kafka MirrorMaker 2 <https://blog.cloudera.com/a-look-inside-kafka-mirrormaker-2/>`_
-- `Configure AWS for an S3 sink connector <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/s3-sink-prereq.html>`_
+- :doc:`Configure AWS for an S3 sink connector </docs/products/kafka/kafka-connect/howto/s3-sink-prereq>`
 
 Aiven for PostgreSQL®
 '''''''''''''''''''''
@@ -66,9 +66,9 @@ You may modify the backup time configuration option in **Advanced Configuration*
 
 For more information refer to
 
-- `PostgreSQL® backups <https://developer.aiven.io/docs/products/postgresql/concepts/pg-backups.html>`_
-- `High availability <https://developer.aiven.io/docs/products/postgresql/concepts/high-availability.html>`_
-- `Create and use read-only replicas <https://developer.aiven.io/docs/products/postgresql/howto/create-read-replica.html>`_
+- :doc:`PostgreSQL® backups </docs/products/postgresql/concepts/pg-backups>`
+- :doc:`High availability </docs/products/postgresql/concepts/high-availability>`
+- :doc:`Create and use read-only replicas </docs/products/postgresql/howto/create-read-replica>`
 
 Aiven for MySQL
 '''''''''''''''''''''
@@ -77,7 +77,7 @@ Myhoard uses `Percona XtraBackup <https://www.percona.com/>`_ internally for tak
 
 You may modify the backup time configuration option in **Advanced Configuration** in the Aiven console which will begin shifting the backup schedule to the new time. If there was a recent backup taken, it may take another backup cycle before it starts applying new backup time.
 
-For more information refer to `MySQL Backups <https://docs.aiven.io/docs/products/mysql/concepts/mysql-backups.html>`_.
+For more information refer to :doc:`MySQL Backups </docs/products/mysql/concepts/mysql-backups>`.
 
 Aiven for OpenSearch®
 ''''''''''''''''''''''''''''
@@ -85,8 +85,8 @@ These databases are automatically backed up, encrypted, and stored securely in o
 
 For more information refer to
 
-- `OpenSearch backups <https://developer.aiven.io/docs/products/opensearch/concepts/backups.html>`_
-- `How to restore an OpenSearch® backup <https://developer.aiven.io/docs/products/opensearch/howto/restore_opensearch_backup.html>`_
+- :doc:`OpenSearch backups </docs/products/opensearch/concepts/backups>`
+- :doc:`How to restore an OpenSearch® backup </docs/products/opensearch/howto/restore_opensearch_backup>`
 
 Aiven for Apache Cassandra®
 '''''''''''''''''''''''''''

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -77,7 +77,7 @@ Myhoard uses `Percona XtraBackup <https://www.percona.com/>`_ internally for tak
 
 You may modify the backup time configuration option in **Advanced Configuration** in the Aiven console which will begin shifting the backup schedule to the new time. If there was a recent backup taken, it may take another backup cycle before it starts applying new backup time.
 
-For more information refer to `MySQL Backups <https://help.aiven.io/en/articles/5199859-mysql-backups>`_.
+For more information refer to `MySQL Backups <https://docs.aiven.io/docs/products/mysql/concepts/mysql-backups.html>`_.
 
 Aiven for OpenSearch®
 ''''''''''''''''''''''''''''

--- a/docs/platform/concepts/tax-information.rst
+++ b/docs/platform/concepts/tax-information.rst
@@ -41,7 +41,7 @@ Follow these steps:
 .. important::
 
     Please be aware that you can set up Billing profile per project or create a Billing Group if you want to group costs and consolidate invoices by different business units.
-    For further information please refer to `Billing Groups <https://help.aiven.io/en/articles/4693636-billing-groups>`_. 
+    For further information please refer to `Billing Groups <https://docs.aiven.io/docs/platform/concepts/billing-groups.html>`_. 
 
 Once the billing country has been updated in the billing section, it will be used in all future invoices. 
 Billing estimates are updated approximately once an hour, so it may take up to an hour for the new tax status to become visible on the invoice estimates.

--- a/docs/platform/concepts/tax-information.rst
+++ b/docs/platform/concepts/tax-information.rst
@@ -41,7 +41,7 @@ Follow these steps:
 .. important::
 
     Please be aware that you can set up Billing profile per project or create a Billing Group if you want to group costs and consolidate invoices by different business units.
-    For further information please refer to `Billing Groups <https://docs.aiven.io/docs/platform/concepts/billing-groups.html>`_. 
+    For further information please refer to :doc:`Billing Groups </docs/platform/concepts/billing-groups>`. 
 
 Once the billing country has been updated in the billing section, it will be used in all future invoices. 
 Billing estimates are updated approximately once an hour, so it may take up to an hour for the new tax status to become visible on the invoice estimates.

--- a/docs/platform/howto/use-billing-groups.rst
+++ b/docs/platform/howto/use-billing-groups.rst
@@ -26,7 +26,7 @@ To view and manage billing groups in the `Aiven Console <https://console.aiven.i
 #. Click an account that you want to manage and then click the **Billing** tab.
 
    .. Tip::
-    This window allows you to create new billing groups and assign projects to your billing groups. For more information on creating billing groups, `see the related article <https://help.aiven.io/en/articles/4634847>`__.
+    This window allows you to create new billing groups and assign projects to your billing groups. For more information on creating billing groups, `see the related article <https://help.aiven.io/en/articles/4634847-getting-started-with-billing-groups>`__.
 
 #. Click one of the listed billing groups to browse the details for that billing group.
 

--- a/docs/products/kafka/howto/kcat.rst
+++ b/docs/products/kafka/howto/kcat.rst
@@ -69,7 +69,7 @@ If :doc:`SASL authentication <kafka-sasl-auth>` is enabled, then the ``kcat`` co
 
 .. Tip::
 
-   If you're using Aiven for Apache Kafka®, you can retrieve the ``kcat`` command parameters using the dedicated :ref:`Aiven CLI command <_avn_cli_service_connection_info_kcat>`.
+   If you're using Aiven for Apache Kafka®, you can retrieve the ``kcat`` command parameters using the dedicated :ref:`Aiven CLI command <avn_cli_service_connection_info_kcat>`.
 
 Produce data to an Apache Kafka® topic
 --------------------------------------

--- a/docs/products/kafka/howto/schema-registry.rst
+++ b/docs/products/kafka/howto/schema-registry.rst
@@ -70,7 +70,7 @@ Once the schema is defined, you need to compile it, and it can be done **manuall
 Manual schema compilation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case of manual schema compilation, download ``avro-tools-1.11.0.jar`` from https://avro.apache.org/releases.html#Download or via maven using the following::
+In case of manual schema compilation, download ``avro-tools-1.11.0.jar`` from https://avro.apache.org/releases.html or via maven using the following::
 
     mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.apache.avro:avro-tools:1.11.0:jar -Ddest=avro-tools-1.11.0.jar
 

--- a/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
+++ b/docs/products/kafka/kafka-connect/concepts/connect-plugin-list-not-available.rst
@@ -13,7 +13,5 @@ There can be a number of reasons why you are seeing the above message:
 * The Apache Kafka Connect API on a Kafka cluster was just enabled. It should take a few seconds for the Apache Kafka Connect services to be operational
 * The Apache Kafka Connect cluster is in the process of setting up/reconfiguring a connector. This message should clear after a few seconds
 * The Apache Kafka Connect cluster is running out of memory. You will likely keep seeing this message unless you upgrade to a larger plan
-* One or more nodes on the Apache Kafka Connect cluster crashed. The API that fetches the connector list calls the Apache Kafka Connect cluster by it's hostname and that maps to one of the 3 workers randomly. If you see this message appear intermittently, this is likely the reason. The crashed node should recover automatically, but if it doesn't, please `contact our support <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ for further help
+* One or more nodes on the Apache Kafka Connect cluster crashed. The API that fetches the connector list calls the Apache Kafka Connect cluster by it's hostname and that maps to one of the 3 workers randomly. If you see this message appear intermittently, this is likely the reason. The crashed node should recover automatically, but if it doesn't, please `contact our support <https://aiven.io/support-services>`_ for further help
 
-
-If you are in doubt whether or not any of the following reasons above is the issue  that you are experiencing, you can `contact our support channel <https://help.aiven.io/en/articles/868101-aiven-support-details>`_ and we will be able to help you further.

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -54,7 +54,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_
 
-* `Google Cloud Storage <https://help.aiven.io/kafka/connectors/aiven-kafka-gcs-sink-connector>`_
+* `Google Cloud Storage <https://docs.aiven.io/docs/products/kafka/kafka-connect/howto/gcs-sink.html>`_
 
 * `HTTP <https://github.com/aiven/aiven-kafka-connect-http>`__ |preview|
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -44,9 +44,9 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Couchbase® <https://github.com/couchbase/kafka-connect-couchbase>`__
 
-* `OpenSearch® <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/opensearch-sink.html>`__
+* :doc:`OpenSearch® </docs/products/kafka/kafka-connect/howto/opensearch-sink>`
 
-* `Elasticsearch <https://developer.aiven.io/docs/products/kafka/kafka-connect/howto/elasticsearch-sink>`__
+* :doc:`Elasticsearch </docs/products/kafka/kafka-connect/howto/elasticsearch-sink>`
 
 * `Google BigQuery <https://github.com/confluentinc/kafka-connect-bigquery>`__
 
@@ -54,7 +54,7 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_
 
-* `Google Cloud Storage <https://docs.aiven.io/docs/products/kafka/kafka-connect/howto/gcs-sink.html>`_
+* :doc:`Google Cloud Storage </docs/products/kafka/kafka-connect/howto/gcs-sink>`
 
 * `HTTP <https://github.com/aiven/aiven-kafka-connect-http>`__ |preview|
 

--- a/docs/products/opensearch/concepts/backups.rst
+++ b/docs/products/opensearch/concepts/backups.rst
@@ -3,7 +3,7 @@
 Backups
 =======
 
-Aiven for OpenSearch® databases are automatically backed up, `encrypted <https://docs.aiven.io/docs/platform/concepts/cloud-security>`_, and stored securely in object storage. Backups are stored in the same region as the main service nodes.
+Aiven for OpenSearch® databases are automatically backed up, :doc:`encrypted </docs/platform/concepts/cloud-security>`, and stored securely in object storage. Backups are stored in the same region as the main service nodes.
 
 Depending on the service plan, we offer single backups for disaster recovery or daily backups with different retention periods:
 

--- a/docs/products/opensearch/concepts/backups.rst
+++ b/docs/products/opensearch/concepts/backups.rst
@@ -3,7 +3,7 @@
 Backups
 =======
 
-Aiven for OpenSearch® databases are automatically backed up, `encrypted <https://help.aiven.io/en/articles/977466-cloud-security-overview>`_, and stored securely in object storage. Backups are stored in the same region as the main service nodes.
+Aiven for OpenSearch® databases are automatically backed up, `encrypted <https://docs.aiven.io/docs/platform/concepts/cloud-security>`_, and stored securely in object storage. Backups are stored in the same region as the main service nodes.
 
 Depending on the service plan, we offer single backups for disaster recovery or daily backups with different retention periods:
 

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -46,7 +46,7 @@ Top-level commands for the Aiven CLI are listed here, along with some informatio
 
 Handle the accounts you have access to, and also configure the teams for the accounts.
 
-Find more info on the help article about `Accounts, Teams, Members and Roles <https://help.aiven.io/en/articles/4206498-accounts-teams-members-and-roles>`_
+Find more info on the help article about `Accounts, Teams, Members and Roles <https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html>`_
 
 :doc:`See detailed command information <cli/account>`.
 

--- a/docs/tools/cli.rst
+++ b/docs/tools/cli.rst
@@ -46,7 +46,7 @@ Top-level commands for the Aiven CLI are listed here, along with some informatio
 
 Handle the accounts you have access to, and also configure the teams for the accounts.
 
-Find more info on the help article about `Accounts, Teams, Members and Roles <https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html>`_
+Find more info on the help article about :doc:`Accounts, Teams, Members and Roles </docs/platform/concepts/projects_accounts_access>`
 
 :doc:`See detailed command information <cli/account>`.
 

--- a/docs/tools/cli/account/account-team.rst
+++ b/docs/tools/cli/account/account-team.rst
@@ -1,7 +1,7 @@
 ``avn account team``
 =======================================
 
-Here you’ll find the full list of commands for ``avn account team``.
+Here you'll find the full list of commands for ``avn account team``.
 
 
 Manage account teams
@@ -103,7 +103,7 @@ Attaches an existing account team to a project.
     - The project to attach to
   * - ``--team-type``
     - The permission level (possible values ``admin``, ``developer``, ``operator``, ``read_only``). 
-      More info at the `dedicated page <https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html>`_
+      More info at the :doc:`dedicated page </docs/platform/concepts/projects_accounts_access>`
 
 
 **Example:** Attach the team with id ``at3exxxxxxxxx`` belonging to the account ``123456789123`` to the project named ``testing-sandbox`` granting ``operator`` access.

--- a/docs/tools/cli/account/account-team.rst
+++ b/docs/tools/cli/account/account-team.rst
@@ -103,7 +103,7 @@ Attaches an existing account team to a project.
     - The project to attach to
   * - ``--team-type``
     - The permission level (possible values ``admin``, ``developer``, ``operator``, ``read_only``). 
-      More info at the `dedicated page <https://help.aiven.io/en/articles/4206498-accounts-teams-members-and-roles>`_
+      More info at the `dedicated page <https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html>`_
 
 
 **Example:** Attach the team with id ``at3exxxxxxxxx`` belonging to the account ``123456789123`` to the project named ``testing-sandbox`` granting ``operator`` access.


### PR DESCRIPTION
# What changed, and why it matters

I realised we had links pointing to help pages that have been migrated. This updates them to point to this site (I didn't replace with internal links, we have a separate item for that), and also fixes one internal broken reference.

