### PR TITLE
Adjust Snowplow actions based on cookie consent

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -44,18 +44,35 @@ snowplow("newTracker", "at", "dc.aiven.io", {
   }
 });
 
-// enable fully anonymous tracking
-snowplow('clearUserData');
-
-snowplow("trackPageView");
-
 </script>
 <!-- End Snowplow Analytics -->
 
 <!-- OneTrust Cookies Consent Notice start for aiven.io -->
-<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="0623fbc6-a463-4822-a7a4-fdb5afcc3afb" ></script>
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="0623fbc6-a463-4822-a7a4-fdb5afcc3afb" onerror="snowplow('trackPageView');"></script>
 <script type="text/javascript">
-function OptanonWrapper() { }
+function OptanonWrapper() {
+  if (!Optanon.IsAlertBoxClosed()) {
+    window.firstTimeVisit = true; // User has not given consent to aiven.io
+    snowplow('trackPageView'); // Initial page view anonymously.
+    return;
+  }
+
+  if (window.OnetrustActiveGroups.includes('115')) {
+    // Consent given for Snowplow cookies
+    snowplow('disableAnonymousTracking');
+  } else {
+    // enable fully anonymous tracking
+    snowplow('clearUserData');
+  }
+
+  if (window.firstTimeVisit) {
+    // Consent was just given so track the cookie banner click.
+    snowplow('trackLinkClick', { targetUrl: 'https://aiven.io/cookies' });
+  } else {
+    // Consent has already been given in a previous visit so track page views normally.
+    snowplow('trackPageView');
+  }
+}
 </script>
 <!-- OneTrust Cookies Consent Notice end for aiven.io -->
 {% endblock %}


### PR DESCRIPTION
# What changed, and why it matters

Snowplow anonymization is now set based on the consent given by users
and correct cookies are in place if UX cookies are accepted.


