### PR TITLE
Adding CLI reference to console docs.

### DIFF
--- a/docs/platform/howto/create_authentication_token.rst
+++ b/docs/platform/howto/create_authentication_token.rst
@@ -30,4 +30,4 @@ To create an authentication token:
 You can now use the authentication token to access your Aiven resources from the CLI or API.
 
 .. note::
-    You can :ref:`create an authentication token using the Aiven CLI <avn-user-access-token-create>` as well.
+    You can :ref:`create an authentication token <avn-user-access-token-create>` via the :doc:`Aiven CLI </docs/tools/cli>` as well.

--- a/docs/platform/howto/create_authentication_token.rst
+++ b/docs/platform/howto/create_authentication_token.rst
@@ -28,3 +28,6 @@ To create an authentication token:
 9. Click **Close**.
 
 You can now use the authentication token to access your Aiven resources from the CLI or API.
+
+.. note::
+    You can :ref:`create an authentication token using the Aiven CLI <avn-user-access-token-create>` as well.

--- a/docs/platform/howto/create_authentication_token.rst
+++ b/docs/platform/howto/create_authentication_token.rst
@@ -30,4 +30,4 @@ To create an authentication token:
 You can now use the authentication token to access your Aiven resources from the CLI or API.
 
 .. note::
-    You can :ref:`create an authentication token <avn-user-access-token-create>` via the :doc:`Aiven CLI </docs/tools/cli>` as well.
+    You can :ref:`create an authentication token using the Aiven CLI <avn-user-access-token-create>` as well.

--- a/docs/platform/howto/create_new_service.rst
+++ b/docs/platform/howto/create_new_service.rst
@@ -52,4 +52,5 @@ To create a new service:
 
    The status is *Rebuilding* while the service is being created for you. Once the service is ready, the status changes to *Running*. While services typically start up in a couple of minutes, the performance varies between cloud providers and regions, and it may take longer in some circumstances.
 
-   
+.. note::
+    You can also use the :ref:`dedicated user-create function <avn-service-create>` to create a new service user via the :doc:`Aiven CLI </docs/tools/cli>`.

--- a/docs/platform/howto/create_new_service.rst
+++ b/docs/platform/howto/create_new_service.rst
@@ -53,4 +53,4 @@ To create a new service:
    The status is *Rebuilding* while the service is being created for you. Once the service is ready, the status changes to *Running*. While services typically start up in a couple of minutes, the performance varies between cloud providers and regions, and it may take longer in some circumstances.
 
 .. note::
-    You can also use the :ref:`dedicated user-create function <avn-service-create>` to create a new service user via the :doc:`Aiven CLI </docs/tools/cli>`.
+    You can :ref:`create a service using the Aiven CLI <avn-cli-service-create>` as well.

--- a/docs/platform/howto/create_new_service_user.rst
+++ b/docs/platform/howto/create_new_service_user.rst
@@ -21,4 +21,4 @@ Service users are users that only exist in the scope of the corresponding Aiven 
     Service user 'testuser' has been created.
 
 .. note::
-    You can also :ref:`create a new service user <avn-service-user-create>` via the :doc:`Aiven CLI </docs/tools/cli>`.
+    You can :ref:`create a new service user using the Aiven CLI <avn-service-user-create>` as well.

--- a/docs/platform/howto/create_new_service_user.rst
+++ b/docs/platform/howto/create_new_service_user.rst
@@ -20,4 +20,5 @@ Service users are users that only exist in the scope of the corresponding Aiven 
     Success!
     Service user 'testuser' has been created.
 
-YOu can also use the :ref:`dedicated user-create function <avn-service-user-create>` to create a new service user via the :doc:`Aiven CLI </docs/tools/cli>`.
+.. note::
+    You can also :ref:`create a new service user <avn-service-user-create>` via the :doc:`Aiven CLI </docs/tools/cli>`.

--- a/docs/platform/howto/scale-services.rst
+++ b/docs/platform/howto/scale-services.rst
@@ -11,5 +11,5 @@ When creating a new Aiven service, you are not tied to a plan. Your services can
 
 Your service will be in a *Rebuilding* state, and once complete will be on the new plan. The service will still be accessible through the process. 
 
-
-You can also use the :ref:`dedicated service update function <avn-cli-service-update>` to scale your service plan via the :doc:`Aiven CLI </docs/tools/cli>`.
+.. note::
+    You can also use the :ref:`dedicated service update function <avn-cli-service-update>` to scale your service plan via the :doc:`Aiven CLI </docs/tools/cli>`.

--- a/docs/tools/cli/user/user-access-token.rst
+++ b/docs/tools/cli/user/user-access-token.rst
@@ -9,6 +9,8 @@ Manage access tokens
 
 Commands for managing user's access tokens.
 
+.. _avn-user-access-token-create:
+
 ``avn user access-token create``
 ''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
# What changed, and why it matters

This PR adds a few CLI references to existing console documentation. 
