### PR TITLE
Fixed two warnings that were appearing after the recent merges

### DIFF
--- a/docs/platform/reference/password-policy.rst
+++ b/docs/platform/reference/password-policy.rst
@@ -38,7 +38,7 @@ Password tips
 
 -  Select a password that is not usual and memorable only to you
 
-Selecting a strong password is a first step in securing your account. To know more about how you can strengthen your security by adding a two factor authentication, please refer :doc:`./user-2fa`.
+Selecting a strong password is a first step in securing your account. To know more about how you can strengthen your security by adding a two factor authentication, please refer :doc:`../howto/user-2fa`.
 
 If you forget your password, you may reset your password by selecting **Forgot Password**  on the `Aiven Console login <https://console.aiven.io/>`_ page.
 

--- a/docs/platform/reference/password-policy.rst
+++ b/docs/platform/reference/password-policy.rst
@@ -38,7 +38,7 @@ Password tips
 
 -  Select a password that is not usual and memorable only to you
 
-Selecting a strong password is a first step in securing your account. To know more about how you can strengthen your security by adding a two factor authentication, please refer :doc:`../howto/user-2fa`.
+Selecting a strong password is a first step in securing your account. To know more about how you can strengthen your security by adding a two factor authentication, please refer to :doc:`../howto/user-2fa`.
 
 If you forget your password, you may reset your password by selecting **Forgot Password**  on the `Aiven Console login <https://console.aiven.io/>`_ page.
 

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -91,7 +91,7 @@ Terraform knows it from the ``depends_on`` block. Here are some configurations t
 - ``service_to_fork_from``: This is the source Aiven for PostgreSQL service.
 - ``idle_in_transaction_session_timeout``: Kills an idle session after specified number of seconds.
 - ``server_reset_query_always``: This PgBouncer configuration, when set to ``false``, causes the ``server_reset_query`` to not take effect for transaction pooling.
-According to the PostgreSQL documentation, when transaction pooling is used, the ``server_reset_query`` should be empty, as clients should not use any session features.
+  According to the PostgreSQL documentation, when transaction pooling is used, the ``server_reset_query`` should be empty, as clients should not use any session features.
 - ``max_failover_replication_time_lag``: In case of a failover, this is the replication time lag after which ``failover_command`` will be executed and a ``failover_has_happened`` file will be created.
 
 More resources


### PR DESCRIPTION
# What changed, and why it matters


Fixed

```
/Users/francescotisiot/Documents/GitHub/devportal/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst:94: WARNING: Bullet list ends without a blank line; unexpected unindent.
```

and 

```
/Users/francescotisiot/Documents/GitHub/devportal/docs/platform/reference/password-policy.rst:41: WARNING: unknown document: ./user-2fa 
```

