### PR TITLE
add path forwarding redirect from developer.aiven.io to docs.aiven.io

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,7 @@
+# Domain level redirect for path forwarding
+http://developer.aiven.io/*  https://docs.aiven.io/:splat 301!
+https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
+
 # Convenience URLs
 /kafka              /docs/products/kafka/index.html
 /postgresql         /docs/products/postgresql/index.html


### PR DESCRIPTION
# What changed, and why it matters
developer.aiven.io has been agreed to renamed to docs.aiven.io. We need to implement path forwarding redirect for developer.aiven.io URLs.

Based on the conversation at [OPS-1893](https://aiven.atlassian.net/browse/OPS-1893), since both domains are used as custom domains in Netlify, the most straightforward approach is best done in Netlify using their system of putting redirects in _redirects file. Referencing to domain-level redirects on [Redirect options](https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects)


<img width="952" alt="Screenshot 2022-08-19 at 12 59 52" src="https://user-images.githubusercontent.com/3796599/186633215-98ead85f-d260-4760-9500-eee838421c9e.png">

