### PR TITLE
Clarify pgbouncer client connection size and postgresql server max_connections

### DIFF
--- a/docs/products/postgresql/concepts/pg-connection-pooling.rst
+++ b/docs/products/postgresql/concepts/pg-connection-pooling.rst
@@ -4,8 +4,16 @@ Connection pooling
 Connection pooling in Aiven for PostgreSQL® services allows you to maintain very large numbers of connections to a database while minimizing the consumption of server resources.
 
 
-Aiven for PostgreSQL connection pooling uses `PgBouncer <https://www.pgbouncer.org/>`_ to manage the database connection. 
-**Each pool can handle minimum 5000 up to 500 * GB of RAM in the service plan and <= 50000 client connections.**
+Aiven for PostgreSQL connection pooling uses `PgBouncer <https://www.pgbouncer.org/>`_ to manage the database connection.
+
+.. Note::
+    
+    Each pool can handle from a minimum of 5000 client connections to a maximum defined by the lower threshold between:
+    
+    * 500 for each GB of RAM in the service plan
+    * A total of 50000 client connections
+
+
 Unlike when you connect directly to the PostgreSQL® server, each client connection does not require a separate backend process on the server. PgBouncer automatically inserts the client queries and only uses a limited number of actual backend connections, leading to lower resource usage on the server and better total performance.
 
 Why connection pooling?

--- a/docs/products/postgresql/concepts/pg-connection-pooling.rst
+++ b/docs/products/postgresql/concepts/pg-connection-pooling.rst
@@ -4,7 +4,9 @@ Connection pooling
 Connection pooling in Aiven for PostgreSQL® services allows you to maintain very large numbers of connections to a database while minimizing the consumption of server resources.
 
 
-Aiven for PostgreSQL connection pooling uses `PgBouncer <https://www.pgbouncer.org/>`_ to manage the database connection. Each pool can handle up to 5000 database client connections. Unlike when you connect directly to the PostgreSQL® server, each client connection does not require a separate backend process on the server. PgBouncer automatically inserts the client queries and only uses a limited number of actual backend connections, leading to lower resource usage on the server and better total performance.
+Aiven for PostgreSQL connection pooling uses `PgBouncer <https://www.pgbouncer.org/>`_ to manage the database connection. 
+**Each pool can handle minimum 5000 up to 500 * GB of RAM in the service plan and <= 50000 client connections.**
+Unlike when you connect directly to the PostgreSQL® server, each client connection does not require a separate backend process on the server. PgBouncer automatically inserts the client queries and only uses a limited number of actual backend connections, leading to lower resource usage on the server and better total performance.
 
 Why connection pooling?
 ------------------------

--- a/docs/products/postgresql/howto/manage-pool.rst
+++ b/docs/products/postgresql/howto/manage-pool.rst
@@ -31,8 +31,13 @@ To manage the connection pools, follow the steps below:
    * **Pool Size:** Select how many PostgreSQL server connections this pool can use at a time. 
    
    .. important:: 
-    Pool Size parameter is NOT the maximum number of client connections of this pool, the client connections for each pool is
-    minimum 5000 up to 500 * GB of RAM in the service plan and <= 50000
+    Pool Size parameter is NOT the maximum number of client connections of this pool.
+    
+    Each pool can handle from a minimum of 5000 client connections to a maximum defined by the lower threshold between:
+    
+    * 500 for each GB of RAM in the service plan
+    * A total of 50000 client connections
+
  
 
 3. Click **Info** on an existing pool.

--- a/docs/products/postgresql/howto/manage-pool.rst
+++ b/docs/products/postgresql/howto/manage-pool.rst
@@ -28,8 +28,12 @@ To manage the connection pools, follow the steps below:
    * **Database**: Choose the database that you want to connect to. Each pool can only connect to a single database.
    * **Username:** Select the database username that you want to use when connecting to the backend database.
    * **Pool Mode:** Select the pooling mode as described in more detail above.
-   * **Pool Size:** Select how many PostgreSQL server connections this pool can use at a time.
-
+   * **Pool Size:** Select how many PostgreSQL server connections this pool can use at a time. 
+   
+   .. important:: 
+    Pool Size parameter is NOT the maximum number of client connections of this pool, the client connections for each pool is
+    minimum 5000 up to 500 * GB of RAM in the service plan and <= 50000
+ 
 
 3. Click **Info** on an existing pool.
 


### PR DESCRIPTION
This is to clarify the confusion of client connections of pgbouncer and server connections to postgresql.
The current information `Each pool can handle up to 5000 database client connections. `
does not align with our code logic:
https://github.com/aiven/aiven-core/blob/70ff62b6f476f39f57088b311f5d3e0da66fa408/aiven/prune/services/pg/pgbouncer.py#L419
```
    # Scale max connections dynamically based on plan size. Allow 500 connections per each
    # gigabyte of memory with minimum set to 5000 and maximum to 50000
 ```
 slack thread: https://aiven-io.slack.com/archives/C01TF0Z0M8E/p1661264887701069