### PR TITLE
SEO: Remove duplicate canonical

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -10,7 +10,7 @@
 <meta name="twitter:site" content="@aiven_io">
 <meta name="twitter:title" content="{{ docstitle|striptags|e }}">
 <meta name="twitter:description" content="{{ body|striptags|replace("\u00B6", '')|truncate(200) }}">
-<meta name="twitter:image" content="https://developer.aiven.io/_static/images/site-preview.png">
+<meta name="twitter:image" content="https://docs.aiven.io/_static/images/site-preview.png">
 
 <!-- Snowplow Analytics -->
 <script type="text/javascript" async=1>

--- a/_templates/base.html
+++ b/_templates/base.html
@@ -3,7 +3,6 @@
 {%- block extrahead %}
 {{ super() }}
 
-<link rel="canonical" href="https://developer.aiven.io/{{ pagename }}" />
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
 
 <!-- Twitter Cards -->


### PR DESCRIPTION
# What changed, and why it matters
Currently there are duplicate canonical tag in each page. This issue seems to happen (22.7) after an update to the Furo theme in this [PR](https://github.com/aiven/devportal/pull/1170) - duplicate canonical in the [PR preview page](https://deploy-preview-1170--developer-aiven-io-preview.netlify.app/).
 
Adding to confusion are the difference in the domain - the auto generated has been updated to docs.aiven.io based on this [PR](https://github.com/aiven/devportal/pull/1259), while the hardcoded on is still developer.aiven.io 

<img width="851" alt="Screenshot 2022-08-26 at 12 16 13" src="https://user-images.githubusercontent.com/3796599/186871325-e8447031-03a8-417b-88d5-bb1b9f0bb7c7.png">

# Solution
Removed the hardcoded canonical tag and let the theme Furo to handle the canonical tag. [Preview](https://deploy-preview-1314--developer-aiven-io-preview.netlify.app/) - only one canonical tag. The drawback is we will not have control of the canonical url.  Worth mentioning there was a [PR](https://github.com/aiven/devportal/pull/1314) related to canonical url naming convention which will not be applicable anymore since we removed the hardcoded canonical tag in this PR.

Fixes #1278 