### PR TITLE
fix-1313 kafka mm recipe won't work

### DIFF
--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -95,8 +95,8 @@ The ``".*"`` wildcard in the MirrorMaker 2 configuration means that all the topi
   resource "aiven_mirrormaker_replication_flow" "mm-replication-flow" {
     project        = var.project_name
     service_name   = aiven_kafka_mirrormaker.mm.service_name
-    source_cluster = aiven_kafka.source.service_name
-    target_cluster = aiven_kafka.target.service_name
+    source_cluster = aiven_service_integration.source-kafka-to-mm.kafka_mirrormaker_user_config[0].cluster_alias
+    target_cluster = aiven_service_integration.mm-to-target-kafka.kafka_mirrormaker_user_config[0].cluster_alias
     enable         = true
 
     topics = [


### PR DESCRIPTION
Fixes https://github.com/aiven/devportal/issues/1313

# What changed, and why it matters

The Terraform code for [Cross-cluster replication with Apache Kafka® MirrorMaker 2](https://docs.aiven.io/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.html#)
will create all the resources, there is no error reported from Terraform but Mirror Maker won't start the flow, issue is due to the source and target used in the aiven_mirrormaker_replication_flow, as per[ terraform docs](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/mirrormaker_replication_flow) they should be the aliases from the service integration. 

I have tested the current code which does not complete the MM flow, and the fix in this PR works OK.  

