### PR TITLE
Add redirects for renamed files

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,7 +38,7 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 
 # Renamed/deleted files
 /docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
-/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html
+/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html                                  301!
+/docs/tools/terraform/upgrade-provider-v1-v2.html                     /docs/tools/terraform/howto/upgrade-provider-v1-v2.html             301!
 /docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections.html
 /docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html
-/docs/tools/terraform/upgrade-provider-v1-v2                          /docs/tools/terraform/howto/upgrade-provider-v1-v2

--- a/_redirects
+++ b/_redirects
@@ -39,3 +39,6 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 # Renamed/deleted files
 /docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
 /docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html
+/docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections.html
+/docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html
+/docs/tools/terraform/upgrade-provider-v1-v2                          /docs/tools/terraform/howto/upgrade-provider-v1-v2

--- a/_redirects
+++ b/_redirects
@@ -18,6 +18,12 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 /cli                /docs/tools/cli.html
 /terraform          /docs/tools/terraform/index.html
 
+# Renamed/deleted files
+/docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
+/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html
+/docs/tools/terraform/upgrade-provider-v1-v2.html                     /docs/tools/terraform/howto/upgrade-provider-v1-v2.html
+/docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections.html
+/docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html
 
 # Redirect from .index.html to specific page names for landing
 
@@ -35,10 +41,3 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 /docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
 /docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
 /docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection
-
-# Renamed/deleted files
-/docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
-/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html                                  301!
-/docs/tools/terraform/upgrade-provider-v1-v2.html                     /docs/tools/terraform/howto/upgrade-provider-v1-v2.html             301!
-/docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections.html
-/docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html


### PR DESCRIPTION
# What changed, and why it matters

When we move or rename a file (which should be avoided if possible), it breaks the URL since the URL is made from the directory and file names. We do have a redirects setup to handle the special cases where we have moved something, however we have had some broken links and redirects reported when our SEO agency were doing some analysis on the docs. This pull request updates the reported URLs.