### PR TITLE
Add manual trigger

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -3,9 +3,10 @@ name: "LinkCheck - All files"
 on:
   schedule:
     - cron: "0 5 * * 2"
+  workflow_dispatch:
 
 jobs:
-  run-checks:
+  linkcheck-files:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
Current, workflow runs periodically.
There is no option to trigger it manually.
Having the option can be useful for the
contributor if the user can not run the checks
locally but still want to see if any links are broken.
In addition, this is useful for debugging when
the build fails, and we want to reproduce the error
again.

GitHub provides a way to do this
with the ``workflow_dispatch``.

This commit is adding this option to the workflow.




