### PR TITLE
Fixes #1317: changed Cassandra CA advice to use project ca-get

### DIFF
--- a/docs/products/cassandra/howto/connect-python.rst
+++ b/docs/products/cassandra/howto/connect-python.rst
@@ -27,7 +27,7 @@ Variable                Description
 
 .. Tip::
 
-    The Aiven for Cassandra CA certificate can be downloaded from the `Aiven Console <https://console.aiven.io/>`_, on the service detail page or with the :ref:`dedicated Aiven CLI command <avn_service_ca_get>`.
+    The Aiven for Cassandra CA certificate can be downloaded from the `Aiven Console <https://console.aiven.io/>`_, on the service detail page or with the :ref:`dedicated Aiven CLI command <avn_project_ca_get>`.
 
 Connect to the database
 '''''''''''''''''''''''

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -161,6 +161,8 @@ Manage project certificates
 
 CA certificates are managed at the project level.
 
+.. _avn_project_ca_get:
+
 ``avn project ca-get``
 ''''''''''''''''''''''
 


### PR DESCRIPTION
The service CA get command seems to not actually work right now.
But, CA's are shared by the project so using the project CA fetch works (and is working).

The only reference to this was in the Cassandra Python example so I've changed it there plus added the matching anchor in the `avn project` docs.


