### PR TITLE
Open Issue if linkcheck fails

### DIFF
--- a/.github/ISSUE_TEMPLATE/linkcheck_report.md
+++ b/.github/ISSUE_TEMPLATE/linkcheck_report.md
@@ -1,0 +1,10 @@
+---
+title: 🚨 Weekly linkcheck failed
+labels: Maintanance, bug
+---
+
+On devportal, we check the links on a weekly basis to ensure the links in on our docs are working.
+
+The last ``linkcheck`` run failed, so it may have found broken links on the devportal docs.
+
+You can check the [last workflow run](https://github.com/aiven/devportal/actions/workflows/linkcheck.yaml) on {{ date | date('dddd, MMM Do YYYY, hh:mm A') }} (UTC) to see the broken links and fix it.

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -22,3 +22,10 @@ jobs:
           pip install -r requirements.txt
       - name: LinkCheck
         run: make linkcheck
+      - name: Create Issue
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/test.md

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,17 +49,19 @@ The instructions for setting up local development are in the ``README``.
 
    If there is an associated issue, add ``Fixes <issue-URL>`` to the PR description text - this means the issue will automatically get closed when the PR is merged.
 
-3. We have an automated build process that checks your work against our in-house styles, gets product names with the right capitalization, and checks links. Please don't be alarmed if your build fails! View the output of the failed jobs to find out what happened, or we can advise when we review. You can run these locally if you like: ``make spell`` and ``make linkcheck``.
-
+3. We have an automated build process that checks your work against our in-house styles, gets product names with the right capitalization, and checks links that you added. Please don't be alarmed if your build fails! View the output of the failed jobs to find out what happened, or we can advise when we review. You can run these locally if you like: ``make spell`` and ``make linkcheck``.
+   
 .. tip::
 
     Don't add commands to the accepted words list, these should always be in ``literal`` markup and ignored by the spell checker. Literal markup can't be used inside link text, so reword your link and sentence to avoid this.
+    
+4. On devportal, some CI/CD processes run weekly. Some of those processes are automation that helps to keep our documentation up-to-date. In another process we [check](https://github.com/aiven/devportal/blob/main/.github/workflows/linkcheck.yaml) for broken links in our docs. If the build fails, a GitHub Issue is open to inform collaborators and maintainers about it.
 
-4. Every pull request generates a preview link, that will be added to your pull request as a comment. This link is publicly available and does not change during the lifetime of your pull request. Feel free to share it with others who might want a preview of your changes.
+5. Every pull request generates a preview link, that will be added to your pull request as a comment. This link is publicly available and does not change during the lifetime of your pull request. Feel free to share it with others who might want a preview of your changes.
 
-5. Our docs team will review your pull request, and you will receive some feedback. It's expected that there will be 2 or 3 rounds of revisions, but if you'd rather we just made changes ourselves, let us know.
+6. Our docs team will review your pull request, and you will receive some feedback. It's expected that there will be 2 or 3 rounds of revisions, but if you'd rather we just made changes ourselves, let us know.
 
-6. The reviewer will merge the pull request once it is ready and has been approved.
+7. The reviewer will merge the pull request once it is ready and has been approved.
 
 
 Style guide


### PR DESCRIPTION
We are running our ``linkcheck`` on weekly basis
for all the files on devportal to check if we
spot broken links on the documentation.

We can manually check after the job run
if it failed and check why.

You can do this by going to
GitHub Action > Workflows > ``LinkCheck - All files``
and see the error messages.

This could easily go unnoticed. We need an explicit
way to show to the devportal maintainers
if something is wrong with the devportal links.

A proposal is to open a GitHub issue in case
broken links are spotted on the periodical checks.

Fixes: https://github.com/aiven/devportal/issues/1275

Tests: I've tested this on a fork project and seems to be working.
