### PR TITLE
fix/path: fix template path

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: .github/test.md
+          filename: .github/ISSUE_TEMPLATE/linkcheck_report.md


### PR DESCRIPTION
The test.md was used in local tests.
The right path name for this case is
``.github/ISSUE_TEMPLATE/linkcheck_report.md``


Introduced on: https://github.com/aiven/devportal/pull/1340

