### PR TITLE
Include analytics cookies 2 to disable anonymous tracking

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -56,8 +56,8 @@ function OptanonWrapper() {
     return;
   }
 
-  if (window.OnetrustActiveGroups.includes('115')) {
-    // Consent given for Snowplow cookies
+  if (window.OnetrustActiveGroups.includes('115') || window.OnetrustActiveGroups.includes('2')) {
+    // Consent given for Snowplow cookies. UX cookies 115. Performance cookies 2.
     snowplow('disableAnonymousTracking');
   } else {
     // enable fully anonymous tracking


### PR DESCRIPTION
# What changed, and why it matters
Disable anonymous tracking if user accepted performance cookies. 
2: Performance cookies
115: UX cookies

Performance cookies: These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance

UX cookies: These cookies help us inform our choices on user experience for the marketing website and Aiven Console.



