### PR TITLE
Connect nosqlbench cassandra

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -32,6 +32,7 @@ datacenter
 datacenters
 Datadog
 datasource
+Datastax
 datastore
 dashboards
 Debezium
@@ -107,6 +108,7 @@ myhoard
 namespace
 namespaces
 NodeJS
+nosqlbench
 npm
 OAuth
 Okta

--- a/_toc.yml
+++ b/_toc.yml
@@ -708,6 +708,7 @@ entries:
               - file: docs/products/cassandra/howto/connect-python
               - file: docs/products/cassandra/howto/connect-go
           - file: docs/products/cassandra/howto/connect-cqlsh-cli
+          - file: docs/products/cassandra/howto/use-nosqlbench-with-cassandra
       - file: docs/products/cassandra/reference
         title: Reference
         entries:

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -1,4 +1,4 @@
-Parform a stress test using nosqlbench
+Perform a stress test using nosqlbench
 ========================================================
 
 `Nosqlbench <https://docs.nosqlbench.io/>`_ is an open source project that can be used to stress-test and benchmark several SQL and NOSQL databases including Cassandra® and PostgreSQL®.
@@ -14,7 +14,7 @@ Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``n
    You can read more about the nosqlbench core concepts and parameters in the `dedicated documentation <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_
 
 Variables
-'''''''''
+-------------
 
 These are the placeholders you will need to replace in the code sample:
 
@@ -34,6 +34,7 @@ Variable                Description
 Run nosqlbench against your Aiven for Apache Cassandra® service
 ---------------------------------------------------------------
 
+The following sections shows how to run several nosqlbench worlkloads against an Aiven for Cassandra service.
 
 Create a schema and load data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -90,13 +91,13 @@ Customise nosqlbench workflows
 Nosqlbench uses workflows to define the load activity. You can define your own workflow to satisfy specific loading/benchmarking needs.
 
 Check the workflow details
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To check the details of the several predefined workloads and activities, you can dump the definition to a file. To have the list of all the precompiled worloads execute::
+To check the details of the several predefined workloads and activities, you can dump the definition to a file. To have the list of all the pre-compiled workloads execute::
 
    ./nb --list-workloads
 
-The above command will generate the list of precompiled workloads like::
+The above command will generate the list of pre-compiled workloads like::
 
     # An IOT workload with more optimal settings for DSE
     /activities/baselines/cql-iot-dse.yaml
@@ -122,7 +123,7 @@ Create your own workload
 Workload files can be modified and then executed with ``nb`` using the command option ``workload=WORKLOAD_NAME``.
 
 The tool expects the file ``WORKLOAD_NAME.yaml`` to be in the same directory of the ``nb`` command.
-If you create a new yaml file called ``my-workload.yaml`` in the same directory of ``nb`` command, the new workload can be run with this command line::
+If you create the file called ``my-workload.yaml`` in the same directory of ``nb`` command, the new workload can be run with this command line::
 
    ./nb run                   \
       driver=cql              \

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -4,21 +4,23 @@ Stress test Aiven for Apache Cassandra® using nosqlbench
 Downloading and installing nosqlbench
 -------------------------------------
 
-`Nosqlbench <https://docs.nosqlbench.io/>`__ was originally developed by
+`Nosqlbench <https://docs.nosqlbench.io/>`_ was originally developed by
 Datastax and then open sourced into an independent project. It is a
 great tool to stress-test and benchmark several SQL and NOSQL databases
 including Cassandra, MongoDB and PostgreSQL®.
 
-It is highly configurable, thoroughly documented and above all it really
-works !
+To download the latest release, search for "latest" in `nosqlbench GitHub repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`_.
+Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
 
-To download the latest release, search for "latest" in `nosqlbench github repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`.
-Nosqlbench can be downloaded as a linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
+Prerequisites
+-------------
+
+ADD STUFF HERE
 
 Running a nosqlbench scenario against your Aiven for Apache Cassandra® service
 ------------------------------------------------------------------------------
 
-Without getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>` , 
+Without getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_, 
 we want to provide you with a number of command lines to start using nosqlbench effectively with Aiven.
 
 Preparing to use authentication and SSL
@@ -28,15 +30,13 @@ In Aiven console, select your Cassandra service and download the SSL certificate
 file on your linux computer where you have installed the ``nb`` executable. We will assume the certificate has been  saved 
 in a file called ``ca_cassandra.pem``, in the same directory of the ``nb`` executable.
 
-The second thing to do is to create an environment variable called AVNADMPWD with the avnadmin password that can be found in the details 
+The second thing to do is to create an environment variable called ``AVNADMPWD`` with the ``avnadmin`` password that can be found in the details 
 of the Cassandra service in the Aiven console. 
-This can be done by adding this line in the ``.bashrc`` file:
+This can be done by adding this line in the ``.bashrc`` file::
 
-``export AVNADMPWD=avnadmin-password``
+   export AVNADMPWD=avnadmin-password
 
-Once you have saved and sourced the ``.bashrc`` file, you can run this ``nb`` command line to create a sample schema and load data:
-
-::
+Once you have saved and sourced the ``.bashrc`` file, you can run this ``nb`` command line to create a sample schema and load data::
 
    ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:schema cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
 
@@ -47,12 +47,11 @@ pairs for a table called ``baselines.keyvalue``.
 The ``phase`` option refers to a specific point in the **workload** definition file and specifies 
 the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
 
-In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run:
+In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run::
 
-::
     ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:rampup cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
     
-    or
+or::
 
     ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:main cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
 
@@ -60,15 +59,12 @@ where the phases ``rampup`` or ``main`` identify other activities that are defin
 
 
 To understand how the ``cql-keyvalue`` workload functions, it will help to have a look at the workload definition file for the key-value example.
-First of all you can list all the precompiled workloads:
-
-::
+First of all you can list all the precompiled workloads::
 
    ./nb --list-workloads
 
-This command will generate a list like this:
+The above command will generate a list like the following::
 
-::
     # An IOT workload with more optimal settings for DSE
     /activities/baselines/cql-iot-dse.yaml
     
@@ -90,7 +86,7 @@ this command will generate the file called ``cql-keyvalue.yaml`` which
 contatins the specifications for the keyvalue workload.
 
 Other useful ``nb`` commands
-----------------------
+----------------------------
 
 For a list of all the pre-compiled scenarios:
 
@@ -121,7 +117,6 @@ Another way to check that data has been loaded correctly is to count
 records in the table. Now, in a distributed db like Cassandra, counting
 is not the most straightforward things because depending on the
 consistency level of the request, different results may be obtained.
-`DSBULK link to DSBULK article on devportal`__,
-an open source loading, unloading and counting tool for Cassandra,
+DSBULK an open source loading, unloading and counting tool for Cassandra,
 allows for configurable consistency level and provides reliable and fast
 counting capabilities.

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -7,7 +7,7 @@ Downloading and installing nosqlbench
 `Nosqlbench <https://docs.nosqlbench.io/>`__ was originally developed by
 Datastax and then open sourced into an independent project. It is a
 great tool to stress-test and benchmark several sql and no-sql databases
-including cassandra, mongo and postgres.
+including Cassandra, MongoDB and PostgreSQL.
 
 It is highly configurable, thoroughly documented and above all it really
 works !
@@ -45,7 +45,7 @@ the ``workload``option calls a specific workload file that is compiled
 inside the ``nb`` executable and instructs ``nb`` to generate key/value
 pairs for a table called ``baselines.keyvalue``. 
 The ``phase`` option refers to a specific point in the **workload** definition file and specifies 
-the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the cassandra keyspace.
+the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
 
 In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run:
 
@@ -115,13 +115,13 @@ Use this command line to check if the sample data has been loaded into the table
 
    SSL_CERTFILE=ca_cassandra-123.pem cqlsh --ssl -u avnadmin -p $AVNADMPWD cassandra-f5c27ca-demo.aivencloud.com 20341
 
-which will open a cqlsh prompt to run queries on the cassandra db.
+which will open a cqlsh prompt to run queries on the Cassandra db.
 
 Another way to check that data has been loaded correctly is to count
-records in the table. Now, in a distributed db like cassandra, counting
+records in the table. Now, in a distributed db like Cassandra, counting
 is not the most straightforward things because depending on the
 consistency level of the request, different results may be obtained.
 `DSBULK link to DSBULK article on devportal`__,
-an open source loading, unloading and counting tool for cassandra,
+an open source loading, unloading and counting tool for Cassandra,
 allows for configurable consistency level and provides reliable and fast
 counting capabilities.

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -7,7 +7,7 @@ Downloading and installing nosqlbench
 `Nosqlbench <https://docs.nosqlbench.io/>`__ was originally developed by
 Datastax and then open sourced into an independent project. It is a
 great tool to stress-test and benchmark several sql and no-sql databases
-including Cassandra, MongoDB and PostgreSQL.
+including Cassandra, MongoDB and PostgreSQL®.
 
 It is highly configurable, thoroughly documented and above all it really
 works !

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -1,13 +1,13 @@
 Stress test Aiven for Apache Cassandra® using nosqlbench
 ========================================================
 
-Downloading and installing nosqlbench
+Download and install nosqlbench
 -------------------------------------
 
 `Nosqlbench <https://docs.nosqlbench.io/>`_ was originally developed by
 Datastax and then open sourced into an independent project. It is a
 great tool to stress-test and benchmark several SQL and NOSQL databases
-including Cassandra, MongoDB and PostgreSQL®.
+including Cassandra and PostgreSQL®.
 
 To download the latest release, search for "latest" in `nosqlbench GitHub repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`_.
 Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
@@ -15,55 +15,82 @@ Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``n
 Prerequisites
 -------------
 
-ADD STUFF HERE
-
-Running a nosqlbench scenario against your Aiven for Apache Cassandra® service
-------------------------------------------------------------------------------
-
-Without getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_, 
-we want to provide you with a number of command lines to start using nosqlbench effectively with Aiven.
-
-Preparing to use authentication and SSL
----------------------------------------
-
 In Aiven console, select your Cassandra service and download the SSL certificate to a 
-file on your linux computer where you have installed the ``nb`` executable. We will assume the certificate has been  saved 
+file on the same linux computer where you have installed the ``nb`` executable. We will assume the certificate has been  saved 
 in a file called ``ca_cassandra.pem``, in the same directory of the ``nb`` executable.
 
-The second thing to do is to create an environment variable called ``AVNADMPWD`` with the ``avnadmin`` password that can be found in the details 
-of the Cassandra service in the Aiven console. 
-This can be done by adding this line in the ``.bashrc`` file::
+The second thing to do is to create an environment variable called ``AVNADMPWD`` with the password of Aiven user ``avnadmin``. 
+This password can be copied from the Cassandra service details in the Aiven console  
+
+In order to store this password securely, add this line in the ``.bashrc`` file in the home of the user running the ``nb`` command line::
 
    export AVNADMPWD=avnadmin-password
 
-Once you have saved and sourced the ``.bashrc`` file, you can run this ``nb`` command line to create a sample schema and load data::
+Save and source the ``.bashrc`` file.
 
-   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:schema cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+Run a nosqlbench scenario against your Aiven for Apache Cassandra® service
+------------------------------------------------------------------------------
 
-where ``driver`` specifies the type of client you are going to use, in our case it's ``cql``
-the ``workload``option calls a specific workload file that is compiled
-inside the ``nb`` executable and instructs ``nb`` to generate key/value
-pairs for a table called ``baselines.keyvalue``. 
-The ``phase`` option refers to a specific point in the **workload** definition file and specifies 
-the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
+Getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_ is beyond the scope of this article.
+However the successful student will find the core concepts extemely useful to understand how ``nb`` works internally.
+The scope of this article is to provide you with a number of command lines to start using nosqlbench effectively with Aiven.
+
+
+This ``nb`` command line creates a sample schema and loads data in the new table (called ``baselines.keyvalue``)::
+
+   ./nb run \
+   driver=cql \
+   workload=cql-keyvalue \
+   username=avnadmin \
+   password=$AVNADMPWD \
+   ssl=openssl \
+   certFilePath=~/ca_cassandra.pem \
+   tags=phase:schema \
+   cycles=100k \
+   --progress console:1s \
+   host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+
+- where ``driver`` specifies the type of client you are going to use, in our case it's ``cql``
+- the ``workload``option calls a specific workload file that is compiled inside the ``nb`` executable and instructs ``nb`` to generate key/value pairs for a table called ``baselines.keyvalue``. 
+- The ``phase`` option refers to a specific point in the **workload** definition file and specifies the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
 
 In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run::
 
-    ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:rampup cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+    ./nb run \
+    driver=cql \
+    workload=cql-keyvalue \
+    username=avnadmin \
+    password=$AVNADMPWD \
+    ssl=openssl \
+    certFilePath=~/ca_cassandra.pem \
+    tags=phase:rampup \
+    cycles=100k \
+    --progress console:1s \
+    host=cassandra-f5c27ca-demo.aivencloud.com port=20341
     
 or::
 
-    ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:main cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+    ./nb run \
+    driver=cql \
+    workload=cql-keyvalue \
+    username=avnadmin \
+    password=$AVNADMPWD \
+    ssl=openssl \
+    certFilePath=~/ca_cassandra.pem \
+    tags=phase:main \
+    cycles=100k \
+    --progress console:1s \
+    host=cassandra-f5c27ca-demo.aivencloud.com port=20341
 
 where the phases ``rampup`` or ``main`` identify other activities that are defined in the ``cql-keyvalue`` workload file.
 
 
-To understand how the ``cql-keyvalue`` workload functions, it will help to have a look at the workload definition file for the key-value example.
-First of all you can list all the precompiled workloads::
+In order to see the details of the several predefined workloads and activities, it will help to dump the workload definition to a file.
+With this command line you can list all the precompiled workloads::
 
    ./nb --list-workloads
 
-The above command will generate a list like the following::
+The above command will generate a list like this below::
 
     # An IOT workload with more optimal settings for DSE
     /activities/baselines/cql-iot-dse.yaml
@@ -76,30 +103,42 @@ The above command will generate a list like the following::
 
     ...
 
-To dump and edit the particular workload file locally on disk, you can use this command line:
-
-::
+To dump and edit the particular workload file locally on disk, you can use this command line::
 
    ./nb --copy cql-keyvalue
 
 this command will generate the file called ``cql-keyvalue.yaml`` which
 contatins the specifications for the keyvalue workload.
 
-Other useful ``nb`` commands
+Create your own workload
+------------------------
+
+Workload files can be modified and customised and then run with ``nb``.
+The command option ``workload=cql-keyvalue`` expects the file ``cql-keyvalue.yaml`` to be in the same directory of the ``nb`` command.
+If you create a new yaml file called ``my-workload.yaml`` in the same directory of ``nb`` command, the new workload can be run with this command line::
+
+      ./nb run \
+    driver=cql \
+    workload=my-workload
+
+Parallelise ``nb`` execution
 ----------------------------
 
-For a list of all the pre-compiled scenarios:
-
-::
-
-   ./nb --list-scenarios
-
 This command line is similar to the one used to load the data but is
-using ``threads`` option to parallelise at the client side:
+using ``threads`` option to parallelise at the client side::
 
-::
-
-   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:main cycles=100k threads=50 --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+   ./nb run \
+   driver=cql \
+   workload=cql-keyvalue \
+   username=avnadmin \
+   password=$AVNADMPWD \
+   ssl=openssl \
+   certFilePath=~/ca_cassandra.pem \
+   tags=phase:main \
+   cycles=100k \
+   threads=50 \
+   --progress console:1s \
+   host=cassandra-f5c27ca-demo.aivencloud.com port=20341
 
 
 Check that data has been loaded

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -1,96 +1,102 @@
-Stress test Aiven for Apache Cassandra® using nosqlbench
+Parform a stress test using nosqlbench
 ========================================================
 
-`Nosqlbench <https://docs.nosqlbench.io/>`_ was originally developed by
-Datastax and then open sourced into an independent project. It is a
-great tool to stress-test and benchmark several SQL and NOSQL databases
-including Cassandra and PostgreSQL®.
-
-Download and install nosqlbench
--------------------------------------
-
-To download the latest release, search for "latest" in `nosqlbench GitHub repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`_.
-Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
+`Nosqlbench <https://docs.nosqlbench.io/>`_ is an open source project that can be used to stress-test and benchmark several SQL and NOSQL databases including Cassandra® and PostgreSQL®.
 
 Prerequisites
 -------------
 
-In Aiven console, select your Cassandra service and download the SSL certificate to a 
-file on the same linux computer where you have installed the ``nb`` executable. We will assume the certificate has been  saved 
-in a file called ``ca_cassandra.pem``, in the same directory of the ``nb`` executable.
+To download the latest nosqlbench release, search for "latest" in `nosqlbench GitHub repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`_.
+Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
 
-The second thing to do is to create an environment variable called ``AVNADMPWD`` with the password of Aiven user ``avnadmin``. 
-This password can be copied from the Cassandra service details in the Aiven console  
+.. Tip::
 
-In order to store this password securely, add this line in the ``.bashrc`` file in the home of the user running the ``nb`` command line::
+   You can read more about the nosqlbench core concepts and parameters in the `dedicated documentation <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_
 
-   export AVNADMPWD=avnadmin-password
+Variables
+'''''''''
 
-Save and source the ``.bashrc`` file.
+These are the placeholders you will need to replace in the code sample:
 
-Run a nosqlbench scenario against your Aiven for Apache Cassandra® service
-------------------------------------------------------------------------------
+==================      =============================================================
+Variable                Description
+==================      =============================================================
+``PASSWORD``            Password of the ``avnadmin`` user
+``HOST``                Host name for the connection
+``PORT``                Port number to use for the Cassandra service
+``SSL_CERTFILE``        Path of the `CA Certificate` for the Cassandra service
+==================      =============================================================
 
-Getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>`_ is beyond the scope of this article.
-However the successful student will find the core concepts extemely useful to understand how ``nb`` works internally.
-The scope of this article is to provide you with a number of command lines to start using nosqlbench effectively with Aiven.
+.. Tip::
+
+    All the above variables and the CA Certificate file can be found in the `Aiven Console <https://console.aiven.io/>`_, in the service detail page.
+
+Run nosqlbench against your Aiven for Apache Cassandra® service
+---------------------------------------------------------------
 
 
-This ``nb`` command line creates a sample schema and loads data in the new table (called ``baselines.keyvalue``)::
+Create a schema and load data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   ./nb run \
-   driver=cql \
-   workload=cql-keyvalue \
-   username=avnadmin \
-   password=$AVNADMPWD \
-   ssl=openssl \
-   certFilePath=~/ca_cassandra.pem \
-   tags=phase:schema \
-   cycles=100k \
-   --progress console:1s \
-   host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+Nosqlbench can be used to create a sample schema and load data.
 
-- where ``driver`` specifies the type of client you are going to use, in our case it's ``cql``
-- the ``workload``option calls a specific workload file that is compiled inside the ``nb`` executable and instructs ``nb`` to generate key/value pairs for a table called ``baselines.keyvalue``. 
-- The ``phase`` option refers to a specific point in the **workload** definition file and specifies the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
+The schema can be created with the following command, after substituting the placeholders for ``HOST``, ``PORT``, ``PASSWORD`` and ``SSL_CERTFILE``::
 
-In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run::
+   ./nb run                            \
+      host=HOST                        \
+      port=PORT                        \
+      username=avnadmin                \
+      password=PASSWORD                \
+      driver=cql                       \
+      workload=cql-keyvalue            \
+      ssl=openssl                      \
+      certFilePath=SSL_CERTFILE        \
+      tags=phase:schema                \
+      cycles=100k                      \
+      --progress console:1s
+      
+
+The following parameters are used: 
+
+*  ``driver``: specifies the type of client you are going to use, in the example ``cql``
+* ``workload``: option calls a specific workload file that is compiled inside the ``nb`` executable and instructs ``nb`` to generate key/value pairs for a table called ``baselines.keyvalue``. You can read more on how to define custom workloads in the :ref:`dedicated documentation <nosqlbench_cassandra>`
+* ``phase``: refers to a specific point in the ``workload`` definition file and specifies the particular ``activity`` to run. In the example, the phase is ``schema`` which means that the nosqlbench will create the schema of the Cassandra keyspace.
+
+To create client connections and produce data in the keyspace and tables created, you need to run the following command line, after substituting the placeholders for ``HOST``, ``PORT``, ``PASSWORD`` and ``SSL_CERTFILE``::
 
     ./nb run \
-    driver=cql \
-    workload=cql-keyvalue \
-    username=avnadmin \
-    password=$AVNADMPWD \
-    ssl=openssl \
-    certFilePath=~/ca_cassandra.pem \
-    tags=phase:rampup \
-    cycles=100k \
-    --progress console:1s \
-    host=cassandra-f5c27ca-demo.aivencloud.com port=20341
-    
-or::
+      host=HOST                        \
+      port=PORT                        \
+      username=avnadmin                \
+      password=PASSWORD                \
+      driver=cql                       \
+      workload=cql-keyvalue            \
+      ssl=openssl                      \
+      certFilePath=SSL_CERTFILE        \
+      tags=phase:rampup                \
+      cycles=100k                      \
+      threads=50                       \
+      --progress console:1s
 
-    ./nb run \
-    driver=cql \
-    workload=cql-keyvalue \
-    username=avnadmin \
-    password=$AVNADMPWD \
-    ssl=openssl \
-    certFilePath=~/ca_cassandra.pem \
-    tags=phase:main \
-    cycles=100k \
-    --progress console:1s \
-    host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+.. Note::
 
-where the phases ``rampup`` or ``main`` identify other activities that are defined in the ``cql-keyvalue`` workload file.
+   You can also run a command replacing the phase ``rampup`` with ``main`` to execute other activities defined in the ``cql-keyvalue`` workload file.
 
+The ``threads`` parameter, specifies the number of concurrent threads used to load the data.
 
-In order to see the details of the several predefined workloads and activities, it will help to dump the workload definition to a file.
-With this command line you can list all the precompiled workloads::
+Customise nosqlbench workflows
+------------------------------
+
+Nosqlbench uses workflows to define the load activity. You can define your own workflow to satisfy specific loading/benchmarking needs.
+
+Check the workflow details
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To check the details of the several predefined workloads and activities, you can dump the definition to a file. To have the list of all the precompiled worloads execute::
 
    ./nb --list-workloads
 
-The above command will generate a list like this below::
+The above command will generate the list of precompiled workloads like::
 
     # An IOT workload with more optimal settings for DSE
     /activities/baselines/cql-iot-dse.yaml
@@ -101,61 +107,27 @@ The above command will generate a list like this below::
     # A workload with only text keys and text values
     /activities/baselines/cql-keyvalue.yaml
 
-    ...
 
-To dump and edit the particular workload file locally on disk, you can use this command line::
+To edit a particular workload file locally, you execute the following, replacing the placeholder ``WORKLOAD_NAME`` with the name of the workload::
 
-   ./nb --copy cql-keyvalue
+   ./nb --copy WORKLOAD_NAME
 
-this command will generate the file called ``cql-keyvalue.yaml`` which
-contatins the specifications for the keyvalue workload.
+The command generates a file called ``cql-keyvalue.yaml`` containing the specifications for the keyvalue workload.
+
+.. _nosqlbench_cassandra:
 
 Create your own workload
 ------------------------
 
-Workload files can be modified and customised and then run with ``nb``.
-The command option ``workload=cql-keyvalue`` expects the file ``cql-keyvalue.yaml`` to be in the same directory of the ``nb`` command.
+Workload files can be modified and then executed with ``nb`` using the command option ``workload=WORKLOAD_NAME``.
+
+The tool expects the file ``WORKLOAD_NAME.yaml`` to be in the same directory of the ``nb`` command.
 If you create a new yaml file called ``my-workload.yaml`` in the same directory of ``nb`` command, the new workload can be run with this command line::
 
-      ./nb run \
-    driver=cql \
-    workload=my-workload
+   ./nb run                   \
+      driver=cql              \
+      workload=my-workload
 
-Parallelise ``nb`` execution
-----------------------------
+.. Tip::
 
-This command line is similar to the one used to load the data but is
-using ``threads`` option to parallelise at the client side::
-
-   ./nb run \
-   driver=cql \
-   workload=cql-keyvalue \
-   username=avnadmin \
-   password=$AVNADMPWD \
-   ssl=openssl \
-   certFilePath=~/ca_cassandra.pem \
-   tags=phase:main \
-   cycles=100k \
-   threads=50 \
-   --progress console:1s \
-   host=cassandra-f5c27ca-demo.aivencloud.com port=20341
-
-
-Check that data has been loaded
--------------------------------
-
-Use this command line to check if the sample data has been loaded into the tables:
-
-::
-
-   SSL_CERTFILE=ca_cassandra-123.pem cqlsh --ssl -u avnadmin -p $AVNADMPWD cassandra-f5c27ca-demo.aivencloud.com 20341
-
-which will open a cqlsh prompt to run queries on the Cassandra db.
-
-Another way to check that data has been loaded correctly is to count
-records in the table. Now, in a distributed db like Cassandra, counting
-is not the most straightforward things because depending on the
-consistency level of the request, different results may be obtained.
-DSBULK an open source loading, unloading and counting tool for Cassandra,
-allows for configurable consistency level and provides reliable and fast
-counting capabilities.
+   You can check the data load using ``cqlsh`` as mentioned in the :doc:`dedicated document <connect-cqlsh-cli>`.

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -1,13 +1,13 @@
 Stress test Aiven for Apache Cassandra® using nosqlbench
 ========================================================
 
-Download and install nosqlbench
--------------------------------------
-
 `Nosqlbench <https://docs.nosqlbench.io/>`_ was originally developed by
 Datastax and then open sourced into an independent project. It is a
 great tool to stress-test and benchmark several SQL and NOSQL databases
 including Cassandra and PostgreSQL®.
+
+Download and install nosqlbench
+-------------------------------------
 
 To download the latest release, search for "latest" in `nosqlbench GitHub repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`_.
 Nosqlbench can be downloaded as a Linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -1,0 +1,127 @@
+Stress test Aiven for Apache Cassandra® using nosqlbench
+========================================================
+
+Downloading and installing nosqlbench
+-------------------------------------
+
+`Nosqlbench <https://docs.nosqlbench.io/>`__ was originally developed by
+Datastax and then open sourced into an independent project. It is a
+great tool to stress-test and benchmark several sql and no-sql databases
+including cassandra, mongo and postgres.
+
+It is highly configurable, thoroughly documented and above all it really
+works !
+
+To download the latest release, search for "latest" in `nosqlbench github repository <https://github.com/nosqlbench/nosqlbench/releases/latest>`.
+Nosqlbench can be downloaded as a linux binary executable called ``nb``. The ``nb`` executable is built with all java libraries and includes a number of sample scenarios ready to be run.
+
+Running a nosqlbench scenario against your Aiven for Apache Cassandra® service
+------------------------------------------------------------------------------
+
+Without getting into the details of the `nosqlbench core concepts <https://docs.nosqlbench.io/docs/nosqlbench/core-concepts/>` , 
+we want to provide you with a number of command lines to start using nosqlbench effectively with Aiven.
+
+Preparing to use authentication and SSL
+---------------------------------------
+
+In Aiven console, select your Cassandra service and download the SSL certificate to a 
+file on your linux computer where you have installed the ``nb`` executable. We will assume the certificate has been  saved 
+in a file called ``ca_cassandra.pem``, in the same directory of the ``nb`` executable.
+
+The second thing to do is to create an environment variable called AVNADMPWD with the avnadmin password that can be found in the details 
+of the Cassandra service in the Aiven console. 
+This can be done by adding this line in the ``.bashrc`` file:
+
+``export AVNADMPWD=avnadmin-password``
+
+Once you have saved and sourced the ``.bashrc`` file, you can run this ``nb`` command line to create a sample schema and load data:
+
+::
+
+   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:schema cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+
+where ``driver`` specifies the type of client you are going to use, in our case it's ``cql``
+the ``workload``option calls a specific workload file that is compiled
+inside the ``nb`` executable and instructs ``nb`` to generate key/value
+pairs for a table called ``baselines.keyvalue``. 
+The ``phase`` option refers to a specific point in the **workload** definition file and specifies 
+the particular **activity** to run. In our case, the phase is ``schema`` which means that the nosqlbench will create the schema of the cassandra keyspace.
+
+In order to run client connections and generate actual data in the keyspace and tables created, these command lines need to be run:
+
+::
+    ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:rampup cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+    
+    or
+
+    ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:main cycles=100k --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+
+where the phases ``rampup`` or ``main`` identify other activities that are defined in the ``cql-keyvalue`` workload file.
+
+
+To understand how the ``cql-keyvalue`` workload functions, it will help to have a look at the workload definition file for the key-value example.
+First of all you can list all the precompiled workloads:
+
+::
+
+   ./nb --list-workloads
+
+This command will generate a list like this:
+
+::
+    # An IOT workload with more optimal settings for DSE
+    /activities/baselines/cql-iot-dse.yaml
+    
+    # Time-series data model and access patterns
+    /activities/baselines/cql-iot.yaml
+    
+    # A workload with only text keys and text values
+    /activities/baselines/cql-keyvalue.yaml
+
+    ...
+
+To dump and edit the particular workload file locally on disk, you can use this command line:
+
+::
+
+   ./nb --copy cql-keyvalue
+
+this command will generate the file called ``cql-keyvalue.yaml`` which
+contatins the specifications for the keyvalue workload.
+
+Other useful ``nb`` commands
+----------------------
+
+For a list of all the pre-compiled scenarios:
+
+::
+
+   ./nb --list-scenarios
+
+This command line is similar to the one used to load the data but is
+using ``threads`` option to parallelise at the client side:
+
+::
+
+   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra-frez.pem tags=phase:main cycles=100k threads=50 --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+
+
+Check that data has been loaded
+-------------------------------
+
+Use this command line to check if the sample data has been loaded into the tables:
+
+::
+
+   SSL_CERTFILE=ca_cassandra-123.pem cqlsh --ssl -u avnadmin -p $AVNADMPWD cassandra-f5c27ca-demo.aivencloud.com 20341
+
+which will open a cqlsh prompt to run queries on the cassandra db.
+
+Another way to check that data has been loaded correctly is to count
+records in the table. Now, in a distributed db like cassandra, counting
+is not the most straightforward things because depending on the
+consistency level of the request, different results may be obtained.
+`DSBULK link to DSBULK article on devportal`__,
+an open source loading, unloading and counting tool for cassandra,
+allows for configurable consistency level and provides reliable and fast
+counting capabilities.

--- a/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
+++ b/docs/products/cassandra/howto/use-nosqlbench-with-cassandra.rst
@@ -6,7 +6,7 @@ Downloading and installing nosqlbench
 
 `Nosqlbench <https://docs.nosqlbench.io/>`__ was originally developed by
 Datastax and then open sourced into an independent project. It is a
-great tool to stress-test and benchmark several sql and no-sql databases
+great tool to stress-test and benchmark several SQL and NOSQL databases
 including Cassandra, MongoDB and PostgreSQL®.
 
 It is highly configurable, thoroughly documented and above all it really
@@ -103,7 +103,7 @@ using ``threads`` option to parallelise at the client side:
 
 ::
 
-   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra-frez.pem tags=phase:main cycles=100k threads=50 --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
+   ./nb run driver=cql workload=cql-keyvalue username=avnadmin password=$AVNADMPWD ssl=openssl certFilePath=~/ca_cassandra.pem tags=phase:main cycles=100k threads=50 --progress console:1s host=cassandra-f5c27ca-demo.aivencloud.com port=20341
 
 
 Check that data has been loaded


### PR DESCRIPTION
# What changed, and why it matters

This PR is for a new article on how-to use nosqlbench to connect, load and stress test cassandra service.
Please review and let me know what I missed.


