### PR TITLE
Migration article PG promote to master

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -163,7 +163,7 @@ entries:
             - file: docs/tools/terraform/howto/config-postgresql-provider
               title: Use PostgreSQL provider alongside Aiven Terraform Provider  
             - file: docs/tools/terraform/howto/promote-to-master-pg-rr
-              title: "promote to master" on PostgreSQL read replica  
+              title: Promote PostgreSQL read replica to master 
         - file: docs/tools/terraform/concepts
           title: Concepts
           entries:

--- a/_toc.yml
+++ b/_toc.yml
@@ -162,6 +162,8 @@ entries:
               title: Upgrade the Aiven Terraform Provider from v1 to v2
             - file: docs/tools/terraform/howto/config-postgresql-provider
               title: Use PostgreSQL provider alongside Aiven Terraform Provider  
+            - file: docs/tools/terraform/howto/promote-to-master-pg-rr
+              title: "promote to master" on PostgreSQL read replica  
         - file: docs/tools/terraform/concepts
           title: Concepts
           entries:

--- a/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
+++ b/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
@@ -73,4 +73,6 @@ Run ``terraform apply`` to have the read replica promoted to master and both Aiv
 
 .. note::
     In order for the promotion to master to succeed, the resource "aiven_service_integration" must be used when creating the primary and read replica services and subsequently removed. 
+
+
   

--- a/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
+++ b/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
@@ -1,0 +1,76 @@
+Terraform to apply "promote to master" on PostgreSQL® read replica
+##################################################################
+
+On the Aiven console, if you use "service integrations" to create a read replica from an existing PostgreSQL or MySQL service, there is an option for the read replica service to promote to master using the 
+**Promote to master** button under the *Overview* tab. While the Terraform documentation does not explicitly mention how to promote the read replica to master, you can remove the service integration between services to accomplish the task.
+
+Let's create Aiven for PostgreSQL® primary and a read replica using the following Terraform file:
+
+.. code:: terraform
+  
+  resource "aiven_pg" "demo-postgresql-primary" {
+    project                 = var.project_name
+    service_name            = "demo-postgresql-primary"
+    cloud_name              = "google-northamerica-northeast1"
+    plan                    = "startup-4"
+    maintenance_window_dow  = "sunday"
+    maintenance_window_time = "10:00:00"
+    termination_protection  = false
+  }
+  
+  resource "aiven_pg" "demo-postgresql-read-replica" {
+    project                 = var.project_name
+    cloud_name              = "google-northamerica-northeast1"
+    service_name            = "demo-postgresql-read-replica"
+    plan                    = "startup-4"
+    maintenance_window_dow  = "sunday"
+    maintenance_window_time = "10:00:00"
+    termination_protection  = false
+  
+    service_integrations {
+      integration_type    = "read_replica"
+      source_service_name = aiven_pg.demo-postgresql-primary.service_name
+    }
+  
+    depends_on = [
+      aiven_pg.demo-postgresql-primary,
+    ]
+  }
+  
+  resource "aiven_service_integration" "pg-readreplica" {
+    project                  = var.project_name
+    integration_type         = "read_replica"
+    source_service_name      = aiven_pg.demo-postgresql-primary.service_name
+    destination_service_name = aiven_pg.demo-postgresql-read-replica.service_name
+  }
+  
+You can get the read replica promoted to master by removing the resource ``aiven_service_integration``, the code blocks ``service_integrations`` and ``depends_on`` under ``demo-postgresql-read-replica`` resource above.
+Once you remove these code blocks, your Terraform script will look something like this:
+
+.. code:: terraform
+  
+  resource "aiven_pg" "demo-postgresql-primary" {
+    project                 = var.project_name
+    service_name            = "demo-postgresql-primary"
+    cloud_name              = "google-northamerica-northeast1"
+    plan                    = "startup-4"
+    maintenance_window_dow  = "sunday"
+    maintenance_window_time = "10:00:00"
+    termination_protection  = false
+  }
+  
+  resource "aiven_pg" "demo-postgresql-read-replica" {
+    project                 = var.project_name
+    cloud_name              = "google-northamerica-northeast1"
+    service_name            = "demo-postgresql-read-replica"
+    plan                    = "startup-4"
+    maintenance_window_dow  = "sunday"
+    maintenance_window_time = "10:00:00"
+    termination_protection  = false
+  }
+  
+Run ``terraform apply`` to have the read replica promoted to master and both Aiven for PostgreSQL services will run as independent services.
+
+.. note::
+    In order for the promotion to master to succeed, the resource "aiven_service_integration" must be used when creating the primary and read replica services and subsequently removed. 
+  

--- a/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
+++ b/docs/tools/terraform/howto/promote-to-master-pg-rr.rst
@@ -72,7 +72,7 @@ Once you remove these code blocks, your Terraform script will look something lik
 Run ``terraform apply`` to have the read replica promoted to master and both Aiven for PostgreSQL services will run as independent services.
 
 .. note::
-    In order for the promotion to master to succeed, the resource "aiven_service_integration" must be used when creating the primary and read replica services and subsequently removed. 
+    In order for the promotion to master to succeed, the resource ``aiven_service_integration`` must be used when creating the primary and read replica services and subsequently removed. 
 
 
   


### PR DESCRIPTION
# What changed, and why it matters

This is a migration task which brings https://help.aiven.io/en/articles/5372422-terraform-to-apply-promote-to-master-on-postgresql-mysql-replica to https://docs.aiven.io/.

We're not a big fan of screenshots unless they are absolutely necessary to convey the instruction. That's why I didn't include the screenshot from the help article.

Following a `terraform apply` with the service integration removed, there's an error:

```
Error: 400: {"errors":[{"message":"pg_read_replica can only be set during service creation","status":400}],"message":"pg_read_replica can only be set during service creation"}
```

The service integration gets removed regardless and the read replica is promoted to master. However, I'll request the reviewer to kindly validate the above error when testing the setup.
