### PR TITLE
Update opensearch log integration

### DIFF
--- a/docs/products/opensearch/howto/opensearch-log-integration.rst
+++ b/docs/products/opensearch/howto/opensearch-log-integration.rst
@@ -20,7 +20,7 @@ Here are the steps needed to enable logs integration. This allows you to send yo
 
 3. Select an existing OpenSearch instance or create a new one, then select **Continue**.
     - When creating a new service you will need to select the cloud, region and plan to use. You should also give your service a name. The service overview page shows the nodes rebuilding, and then indicates when they are ready.
-    - If you're already using OpenSearch on Aiven, you can use your running OpenSearch service as a destination for your metrics data. If you are a member of more than one Aiven projects with *operator* or *admin* access right, you need to choose the project first then your target OpenSearch service.
+    - If you're already using OpenSearch on Aiven, you can use your running OpenSearch service as a destination for your metrics data. If you are a member of more than one Aiven project with *operator* or *admin* access rights, you need to choose the project first then your target OpenSearch service.
 
 4. Configure your ``index prefix`` and ``index retention limit`` parameters, then select **Enable**.
 
@@ -52,9 +52,9 @@ You can change the configuration of the ``index prefix`` and ``index retention l
 
 4. On the **Enabled service integrations** list, find the service to configure.
 
-5. Click on **Edit** button, and edit the parameters.
+5. Click **Edit**, and edit the parameters.
 
-6. Once the parameters are chosen, click the **Edit** button.
+6. Once the parameters are chosen, click **Edit**.
 
 Your log integration parameters should be updated after those steps.
 
@@ -69,6 +69,6 @@ In case, you are no longer interested in sending the logs from your service to O
 
 3. On the **Enabled service integrations** list, find the service to disable the integration.
 
-4. Click the **Delete** button.
+4. Click **Delete**.
 
 Your log integration for OpenSearch should be successfully disabled after those steps.

--- a/docs/products/opensearch/howto/opensearch-log-integration.rst
+++ b/docs/products/opensearch/howto/opensearch-log-integration.rst
@@ -14,15 +14,15 @@ Enable log integration
 
 Here are the steps needed to enable logs integration. This allows you to send your service's logs to your Aiven for OpenSearch® from another Aiven service.
 
-1. On the *Services* page, click a service name.
+1. On the **Services** page, click a service name.
 
-2. On the *Logs* tab, click on *Enable logs integration*. 
+2. On the **Logs** tab, click on **Enable logs integration**.
 
-3. Select an existing OpenSearch instance or create a new one, then select *Continue*.
+3. Select an existing OpenSearch instance or create a new one, then select **Continue**.
     - When creating a new service you will need to select the cloud, region and plan to use. You should also give your service a name. The service overview page shows the nodes rebuilding, and then indicates when they are ready.
     - If you're already using OpenSearch on Aiven, you can use your running OpenSearch service as a destination for your metrics data. If you are a member of more than one Aiven projects with *operator* or *admin* access right, you need to choose the project first then your target OpenSearch service.
 
-4. Configure your ``index prefix`` and ``index retention limit`` parameters, then select *Enable*.
+4. Configure your ``index prefix`` and ``index retention limit`` parameters, then select **Enable**.
 
 .. note::
     If you want to effectively disable the ``index retention limit``, you can set it to the maximum value which is 10000 days.
@@ -44,17 +44,17 @@ There are two parameters that you can adjust when integrating logs to your OpenS
 
 You can change the configuration of the ``index prefix`` and ``index retention limit`` after the integration is enabled.
 
-1. On the *Services* page, click a service name.
+1. On the **Services** page, click a service name.
    
-2. On the *Overview* page, scroll down to the *Service integrations*.
+2. On the **Overview** page, scroll down to the **Service integrations**.
 
-3. Click on *Manage integrations*.
+3. Click on **Manage integrations**.
 
-4. On the *Enabled service integrations* list, find the service to configure.
+4. On the **Enabled service integrations** list, find the service to configure.
 
-5. Click on *Edit* button, and edit the parameters.
+5. Click on **Edit** button, and edit the parameters.
 
-6. Once the parameters are chosen, click the *Edit* button. 
+6. Once the parameters are chosen, click the **Edit** button.
 
 Your log integration parameters should be updated after those steps.
 
@@ -63,12 +63,12 @@ Disable logs integration
 
 In case, you are no longer interested in sending the logs from your service to OpenSearch, follow those steps to disable the integration:
 
-1. On the *Overview* page, scroll down to the *Service integrations*.
+1. On the **Overview** page, scroll down to the **Service integrations**.
 
-2. Click on *Manage integrations*.
+2. Click on **Manage integrations**.
 
-3. On the *Enabled service integrations* list, find the service to disable the integration.
+3. On the **Enabled service integrations** list, find the service to disable the integration.
 
-4. Click the *Delete* button.
+4. Click the **Delete** button.
 
 Your log integration for OpenSearch should be successfully disabled after those steps.

--- a/docs/products/opensearch/howto/opensearch-log-integration.rst
+++ b/docs/products/opensearch/howto/opensearch-log-integration.rst
@@ -14,15 +14,15 @@ Enable log integration
 
 Here are the steps needed to enable logs integration. This allows you to send your service's logs to your Aiven for OpenSearch® from another Aiven service.
 
-1. On the **Services** page, scroll down and choose **Service integrations**.
+1. On the *Services* page, click a service name.
 
-2. On the **Logs** tab, click on **Use Integration**. 
+2. On the *Logs* tab, click on *Enable logs integration*. 
 
-3. Select an existing OpenSearch instance or create a new one, then select **Continue**.
+3. Select an existing OpenSearch instance or create a new one, then select *Continue*.
     - When creating a new service you will need to select the cloud, region and plan to use. You should also give your service a name. The service overview page shows the nodes rebuilding, and then indicates when they are ready.
     - If you're already using OpenSearch on Aiven, you can use your running OpenSearch service as a destination for your metrics data. If you are a member of more than one Aiven projects with *operator* or *admin* access right, you need to choose the project first then your target OpenSearch service.
 
-4. Configure your ``index prefix`` and ``index retention limit`` parameters, then select **Enable**
+4. Configure your ``index prefix`` and ``index retention limit`` parameters, then select *Enable*.
 
 .. note::
     If you want to effectively disable the ``index retention limit``, you can set it to the maximum value which is 10000 days.
@@ -44,15 +44,17 @@ There are two parameters that you can adjust when integrating logs to your OpenS
 
 You can change the configuration of the ``index prefix`` and ``index retention limit`` after the integration is enabled.
 
-1. On the **Overview** page, scroll down to the **Service integrations**.
+1. On the *Services* page, click a service name.
+   
+2. On the *Overview* page, scroll down to the *Service integrations*.
 
-2. Click on **Manage integrations**.
+3. Click on *Manage integrations*.
 
-3. On the **Enabled service integrations** list, find the service to configure.
+4. On the *Enabled service integrations* list, find the service to configure.
 
-4. Click on **Edit** button, and edit the parameters.
+5. Click on *Edit* button, and edit the parameters.
 
-5. Once the parameters are chosen, click in **Edit**
+6. Once the parameters are chosen, click the *Edit* button. 
 
 Your log integration parameters should be updated after those steps.
 
@@ -61,12 +63,12 @@ Disable logs integration
 
 In case, you are no longer interested in sending the logs from your service to OpenSearch, follow those steps to disable the integration:
 
-1. On the *Overview* page, scroll down to the **Service integrations**.
+1. On the *Overview* page, scroll down to the *Service integrations*.
 
-2. Click on **Manage integrations**.
+2. Click on *Manage integrations*.
 
-3. On the **Enabled service integrations** list, find the service to disable the integration.
+3. On the *Enabled service integrations* list, find the service to disable the integration.
 
-4. Click on the **Delete** button.
+4. Click the *Delete* button.
 
 Your log integration for OpenSearch should be successfully disabled after those steps.


### PR DESCRIPTION
Fixing some of those instructions to make it clearer. There are two ways to configure log integration on OpenSearch via the "Manage integration" or "Logs" maybe having it directly for logs it is easier for the user. This commit is showing this way for enabling integration.