### PR TITLE
Fixing kafka-go link within product docs.

### DIFF
--- a/docs/products/kafka/howto/connect-with-go.rst
+++ b/docs/products/kafka/howto/connect-with-go.rst
@@ -161,7 +161,7 @@ Set up properties to connect to the cluster:
 
 With library ``kafka-go``
 --------------------------
-Install the library `kafka-go <https://github.com/segmentio/kafka-go>`_ and use code snippet according to your preferred authentication method below.
+`Install the library <https://github.com/segmentio/kafka-go>`_ ``kafka-go`` and use code snippet according to your preferred authentication method below.
 
 With SSL authentication
 ***********************

--- a/docs/products/kafka/howto/connect-with-go.rst
+++ b/docs/products/kafka/howto/connect-with-go.rst
@@ -161,7 +161,7 @@ Set up properties to connect to the cluster:
 
 With library ``kafka-go``
 --------------------------
-Install the library `Sarama <https://github.com/Shopify/sarama>`_ and use code snippet according to your preferred authentication method below.
+Install the library `kafka-go <https://github.com/segmentio/kafka-go>`_ and use code snippet according to your preferred authentication method below.
 
 With SSL authentication
 ***********************


### PR DESCRIPTION
# What changed, and why it matters

https://docs.aiven.io/docs/products/kafka/howto/connect-with-go.html has a small mistake where **With library kafka-go** section refers to the Sarama library instead of kafka-go.

This PR fixes that mistake.
