### PR TITLE
Add a new rule to check for markdown-style links

### DIFF
--- a/.github/vale/styles/Aiven/markdown_links.yml
+++ b/.github/vale/styles/Aiven/markdown_links.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: Markdown links like '%s' won't work in reStructuredText
+level: error
+scope: raw
+ignorecase: true
+raw:
+    - '\[.*\]\(.*\)'

--- a/.github/vale/tests/markdown_links.rst
+++ b/.github/vale/tests/markdown_links.rst
@@ -1,0 +1,8 @@
+Using a markdown link like [Some text](https://example.com) isn't going
+to end well in reStructuredText.
+
+Here's a minimalist example []() (what would markdown do with that?)
+
+We don't care about [text] (text).
+
+We do care about [text](url)

--- a/.github/vale/tests/shelltest.test
+++ b/.github/vale/tests/shelltest.test
@@ -117,3 +117,12 @@ $ vale --output=line --sort .github/vale/tests/missing_image_alt.rst
 .github/vale/tests/missing_image_alt.rst:20:1:Aiven.missing_alt_in_image:Missing ':alt:' in '.. image:: images/eof.png :width: 100% '
 >=1
 
+# ---------------------------------------------------------------
+# Markdown-style links don't work in reStructuredText, so report them
+
+$ vale --output=line --sort .github/vale/tests/markdown_links.rst
+>
+.github/vale/tests/markdown_links.rst:1:28:Aiven.markdown_links:Markdown links like '[Some text](https://example.com)' won't work in reStructuredText
+.github/vale/tests/markdown_links.rst:4:29:Aiven.markdown_links:Markdown links like '[]() (what would markdown do with that?)' won't work in reStructuredText
+.github/vale/tests/markdown_links.rst:8:18:Aiven.markdown_links:Markdown links like '[text](url)' won't work in reStructuredText
+>=1


### PR DESCRIPTION
If one uses both reStructuredText and markdown, it's surprisingly easy to use a markdown style link (`[text](url)`) by mistake in a reStructuredText document. This new rule gives an error when it finds such.


