### PR TITLE
Add a test for missing :alt: in image directives

### DIFF
--- a/.github/vale/styles/Aiven/missing_alt_in_image.yml
+++ b/.github/vale/styles/Aiven/missing_alt_in_image.yml
@@ -1,0 +1,17 @@
+extends: existence
+message: Missing ':alt:' in '%s'
+level: error
+scope: raw
+ignorecase: true
+# We look for:
+#   * `.. image:: `
+#   * zero or more of:
+#     * newline
+#     * spaces
+#     * :<text that isn't alt>:
+#     * space
+#     * any text
+#   * two newlines or a newline at end of file
+# (you do alway end your file with a newline, don't you?)
+raw:
+  - '\.\. image::.*(\n\s*:((?!alt).*): .*)*\n(\n|$)'

--- a/.github/vale/tests/missing_image_alt.rst
+++ b/.github/vale/tests/missing_image_alt.rst
@@ -1,0 +1,21 @@
+Some text
+
+.. image:: images/image.png
+   :width: 100%
+   :alt: Some text
+   :fred: jim
+
+Some more text
+
+.. image:: images/image.png
+   :width: 100%
+   :fred: jim
+
+Some more text
+
+.. image:: images/image.png
+
+and at the end of the file:
+
+.. image:: images/eof.png
+   :width: 100%

--- a/.github/vale/tests/shelltest.test
+++ b/.github/vale/tests/shelltest.test
@@ -107,3 +107,13 @@ $ vale --output=line --sort .github/vale/tests/sentence_case_title_bad.rst
 .github/vale/tests/sentence_case_title_bad.rst:6:1:Aiven.capitalization_headings:'This is a subtitle Not in sentence case by Tony' should be in sentence case
 .github/vale/tests/sentence_case_title_bad.rst:11:1:Aiven.capitalization_headings:'Short and Bad' should be in sentence case
 >=0
+
+# ---------------------------------------------------------------
+# We always want :alt: in an image directive
+
+$ vale --output=line --sort .github/vale/tests/missing_image_alt.rst
+.github/vale/tests/missing_image_alt.rst:10:1:Aiven.missing_alt_in_image:Missing ':alt:' in '.. image:: images/image.png :width: 100% :fred: jim '
+.github/vale/tests/missing_image_alt.rst:16:1:Aiven.missing_alt_in_image:Missing ':alt:' in '.. image:: images/image.png '
+.github/vale/tests/missing_image_alt.rst:20:1:Aiven.missing_alt_in_image:Missing ':alt:' in '.. image:: images/eof.png :width: 100% '
+>=1
+

--- a/docs/platform/howto/create_new_service.rst
+++ b/docs/platform/howto/create_new_service.rst
@@ -12,6 +12,7 @@ To create a new service:
    This opens a new page with the available service options.
 
    .. image:: /images/tools/console/console_create_service.png
+      :alt: Aiven Console view for creating a new service
 
 3. Select the main properties for your service:
 
@@ -49,6 +50,7 @@ To create a new service:
    The *Overview* page for the service opens.
 
    .. image:: /images/tools/console/console_service.png
+      :alt: Aiven Console service Overview page
 
    This view shows you the connection parameters for your service, its current status, and the configuration options.
 

--- a/docs/platform/howto/manage-project.rst
+++ b/docs/platform/howto/manage-project.rst
@@ -11,7 +11,7 @@ In the `Aiven web console <https://console.aiven.io/>`_, follow these steps to c
 3. Select an Account to add the project to.
 4. In **Payment method** select a project to copy the billing details from, or select **Use a new credit card**.
 
-When you create a new project, you will need to enable :doc:`billing for creating new services <docs/platform/howto/list-billing>`.
+When you create a new project, you will need to enable :doc:`billing for creating new services </docs/platform/howto/list-billing>`.
 
 .. note::
     You can :ref:`create a project using the Aiven CLI <avn-create-update-project>` as well.

--- a/docs/platform/howto/use-aws-privatelinks.rst
+++ b/docs/platform/howto/use-aws-privatelinks.rst
@@ -129,6 +129,7 @@ currently support AWS PrivateLink.
          want and switch it on.
 
          .. image:: /images/platform/howto/use-aws-privatelink_image1.png
+            :alt: Aiven Console private link configuration
 
       #. | Click **Save advanced configuration** .
 

--- a/docs/products/grafana.rst
+++ b/docs/products/grafana.rst
@@ -42,7 +42,7 @@ Integrates with your existing Aiven tools
 Grafana is highly compatible with other Aiven products. You can set up your other Aiven services as data sources for Grafana, and monitor their health.
 
 
-Check out all the features on our `Grafana product page <https://aiven.io/grafana#full-feature-list>`_. 
+Check out all the features on our `Grafana product page <https://aiven.io/grafana>`_. 
 
 
 

--- a/docs/products/grafana/get-started.rst
+++ b/docs/products/grafana/get-started.rst
@@ -15,7 +15,8 @@ You can add services for Grafana in the Aiven web console.
 
 
 .. image:: /images/products/grafana/get-started-grafana.gif
-    :width: 500px
+   :width: 500px
+   :alt: Grafana in action
 
 
 To create a new Aiven for Grafana service:

--- a/docs/products/grafana/howto/log-in.rst
+++ b/docs/products/grafana/howto/log-in.rst
@@ -8,7 +8,8 @@ Log in to Aiven for Grafana® to start monitoring your data sources.
 
 
 .. image:: /images/products/grafana/log-in-grafana.gif
-    :width: 500px
+   :width: 500px
+   :alt: Log in Grafana
 
 
 To log in:

--- a/docs/products/m3db.rst
+++ b/docs/products/m3db.rst
@@ -58,7 +58,7 @@ M3 is highly compatible with other Aiven products for the following tasks:
 
 - To create dashboards and query available features using Grafana® and PromQL.
 
-Check out all the features on our `M3 product page <https://aiven.io/m3#full-feature-list>`_. 
+Check out all the features on our `M3 product page <https://aiven.io/m3>`_. 
 
 
 

--- a/docs/products/m3db/getting-started.rst
+++ b/docs/products/m3db/getting-started.rst
@@ -13,6 +13,7 @@ If you're just trying out M3DB, a single-node setup is available with our startu
 Finally, give the service a name and then select "Create Service", and your shiny new M3 database will start building. While it does that, you can already visit the service overview page to see the details of the service.
 
 .. image:: /images/products/m3db/m3db-connection-details.png
+   :alt: M3DB connection details
 
 Connection details
 ------------------

--- a/docs/products/postgresql/howto/manage-pool.rst
+++ b/docs/products/postgresql/howto/manage-pool.rst
@@ -45,6 +45,7 @@ To manage the connection pools, follow the steps below:
    This shows you the database connection settings for the pool, similar to the below
 
 .. image:: /images/products/postgresql/connection-pool-details.png
+   :alt: Connection pool details
 
 
 Connection pools for replicas

--- a/docs/products/postgresql/reference/list-of-extensions.rst
+++ b/docs/products/postgresql/reference/list-of-extensions.rst
@@ -231,7 +231,7 @@ The following extensions can only be installed by superusers, **and are not gene
 ``amcheck`` - https://www.postgresql.org/docs/current/amcheck.html
     Functions for verifying relation integrity.
 
-``autoinc`` - https://www.postgresql.org/docs/current/contrib-spi.html#id-1.11.7.47.6
+``autoinc`` - https://www.postgresql.org/docs/current/contrib-spi.html
     Functions for auto-incrementing fields.
 
 ``bool_plperlu`` - https://www.postgresql.org/docs/current/plperl-funcs.html
@@ -249,13 +249,13 @@ The following extensions can only be installed by superusers, **and are not gene
 ``hstore_plperlu`` - https://www.postgresql.org/docs/current/hstore.html
     Transform between ``hstore`` and ``plperlu``.
 
-``insert_username`` - https://www.postgresql.org/docs/current/contrib-spi.html#id-1.11.7.47.7
+``insert_username`` - https://www.postgresql.org/docs/current/contrib-spi.html
     Functions for tracking who changed a table.
 
 ``jsonb_plperlu`` - https://www.postgresql.org/docs/current/datatype-json.html
     Transform between ``jsonb`` and ``plperlu``.
 
-``moddatetime`` - https://www.postgresql.org/docs/10/contrib-spi.html#id-1.11.7.46.9
+``moddatetime`` - https://www.postgresql.org/docs/10/contrib-spi.html
     Functions for tracking last modification time.
 
 ``old_snapshot`` - https://www.postgresql.org/docs/current/oldsnapshot.html
@@ -276,5 +276,5 @@ The following extensions can only be installed by superusers, **and are not gene
 ``plperlu`` - https://www.postgresql.org/docs/current/plperl-trusted.html
     PL/PerlU untrusted procedural language.
 
-``refint`` - https://www.postgresql.org/docs/current/contrib-spi.html#id-1.11.7.47.5
+``refint`` - https://www.postgresql.org/docs/current/contrib-spi.html
     Functions for implementing referential integrity (obsolete).


### PR DESCRIPTION
We always want alt text on our images.

This check looks for image directives that are missing the `:alt:` part.

Since the regular expression is a little complex, I've tried to explain it in a comment.

Note: if you have `.. image: <some image>` at the end of the file and don't have a newline at the end of your final line, then (a) this check won't find it, and (b) you've not been meant to do that for the last several decades at least, so please end your files with a newline at the end of the last line.

