### PR TITLE
Set Snowplow storage strategy when disabling anonymoius tracking

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -58,7 +58,7 @@ function OptanonWrapper() {
 
   if (window.OnetrustActiveGroups.includes('115') || window.OnetrustActiveGroups.includes('2')) {
     // Consent given for Snowplow cookies. UX cookies 115. Performance cookies 2.
-    snowplow('disableAnonymousTracking');
+    snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
   } else {
     // enable fully anonymous tracking
     snowplow('clearUserData');


### PR DESCRIPTION
# What changed, and why it matters

This will set the domain user_id values correctly for users that have given consent to analytics cookies.

