### PR TITLE
Fix broken link

### DIFF
--- a/docs/products/postgresql/howto/connect-java.rst
+++ b/docs/products/postgresql/howto/connect-java.rst
@@ -29,7 +29,7 @@ There are several options to do that
 
     mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -Dartifact=org.postgresql:postgresql:42.3.2:jar -Ddest=postgresql-42.3.2.jar
 
-2. Manually the jar could be downloaded from https://jdbc.postgresql.org/download.html
+2. Manually the jar could be downloaded from https://jdbc.postgresql.org/download/
 
 Code
 ''''


### PR DESCRIPTION
A broken link was spotted by our weekly
link check job. The following link returns 404 code:

https://jdbc.postgresql.org/download.html

The download file can be found here:

https://jdbc.postgresql.org/download/

So this commit replaces the broken link for a valid one.

Fixes: https://github.com/aiven/devportal/issues/1373




