### PR TITLE
Kafka Connect - added note with reference to source github repository

### DIFF
--- a/docs/platform/howto/integrations/access-jmx-metrics-jolokia.rst
+++ b/docs/platform/howto/integrations/access-jmx-metrics-jolokia.rst
@@ -3,7 +3,11 @@ Jolokia
 Access JMX metrics via Jolokia
 ===============================
 
+<<<<<<< HEAD
 `Jolokia <https://jolokia.org/>`_ is one of the external metrics integration supported on the Aiven platform besides :doc:`Datadog metrics </docs/integrations/datadog/datadog-metrics>` and :doc:`Prometheus metrics </docs/platform/howto/integrations/prometheus-metrics>`.
+=======
+`Jolokia <https://jolokia.org/>`_ is one of the external metrics integration supported on the Aiven platform besides :doc:`Datadog metrics </docs/integrations/datadog/datadog-metrics>` and :doc:`Prometheus metrics </docs/platform/howto/integrations/prometheus-metrics-limit.html>`.
+>>>>>>> b9dfaae5 (Added note with reference to source github repository)
 
 .. note:: 
 
@@ -53,7 +57,11 @@ to get the list of IP addresses associated with a DNS name:
    kafka-67bd7c5-myproject.aivencloud.com has address 35.228.234.106
    kafka-67bd7c5-myproject.aivencloud.com has address 35.228.157.197
 
+<<<<<<< HEAD
 Here's a quick example of a cURL request. :doc:`Download the CA certificate </docs/platform/howto/download-ca-cert>` first before executing the cURL request.
+=======
+Here's a quick example of a cURL request. :doc:`Download the CA certificate </docs/platform/howto/download-ca-cert>` first before executing the cURL request. 
+>>>>>>> b9dfaae5 (Added note with reference to source github repository)
 The file is identical for all endpoints and services in the same project.
 
 Please note to use port 6733 which is the default port Jolokia is

--- a/docs/platform/howto/integrations/access-jmx-metrics-jolokia.rst
+++ b/docs/platform/howto/integrations/access-jmx-metrics-jolokia.rst
@@ -3,11 +3,7 @@ Jolokia
 Access JMX metrics via Jolokia
 ===============================
 
-<<<<<<< HEAD
 `Jolokia <https://jolokia.org/>`_ is one of the external metrics integration supported on the Aiven platform besides :doc:`Datadog metrics </docs/integrations/datadog/datadog-metrics>` and :doc:`Prometheus metrics </docs/platform/howto/integrations/prometheus-metrics>`.
-=======
-`Jolokia <https://jolokia.org/>`_ is one of the external metrics integration supported on the Aiven platform besides :doc:`Datadog metrics </docs/integrations/datadog/datadog-metrics>` and :doc:`Prometheus metrics </docs/platform/howto/integrations/prometheus-metrics-limit.html>`.
->>>>>>> b9dfaae5 (Added note with reference to source github repository)
 
 .. note:: 
 
@@ -57,11 +53,7 @@ to get the list of IP addresses associated with a DNS name:
    kafka-67bd7c5-myproject.aivencloud.com has address 35.228.234.106
    kafka-67bd7c5-myproject.aivencloud.com has address 35.228.157.197
 
-<<<<<<< HEAD
 Here's a quick example of a cURL request. :doc:`Download the CA certificate </docs/platform/howto/download-ca-cert>` first before executing the cURL request.
-=======
-Here's a quick example of a cURL request. :doc:`Download the CA certificate </docs/platform/howto/download-ca-cert>` first before executing the cURL request. 
->>>>>>> b9dfaae5 (Added note with reference to source github repository)
 The file is identical for all endpoints and services in the same project.
 
 Please note to use port 6733 which is the default port Jolokia is

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-sink.rst
@@ -3,6 +3,10 @@ Create a Apache Cassandra® stream reactor sink connector
 
 **The Apache Cassandra® stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Apache Cassandra® database**. The Lenses.io implementation enables you to write `KCQL transformations <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sinks/cassandrasinkconnector/>`_ on the topic data before sending it to the Cassandra database.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.lenses.io/connectors/sink/cassandra.html>`_.
+
 
 .. _connect_cassandra_lenses_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.rst
+++ b/docs/products/kafka/kafka-connect/howto/cassandra-streamreactor-source.rst
@@ -3,6 +3,10 @@ Create a Apache Cassandra® stream reactor source connector
 
 **The Apache Cassandra® stream reactor source connector** enables you to move data from **a Apache Cassandra® database** to **an Aiven for Apache Kafka® cluster**. The Lenses.io implementation enables you to write `KCQL transformations <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/cassandrasourceconnector/>`_ on the topic data before sending it to the Apache Kafka cluster.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.lenses.io/connectors/source/cassandra.html>`_.
+
 
 .. _connect_cassandra_lenses_source_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mongodb.rst
@@ -3,6 +3,10 @@ Create a Debezium source connector for MongoDB
 
 The Debezium source connector for MongoDB tracks database changes using a MongoDB replica set or shared cluster, and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://debezium.io/docs/connectors/mongodb/>`_.
+
 .. _connect_debezium_mongodb_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-mysql.rst
@@ -3,6 +3,10 @@ Create a Debezium source connector for MySQL
 
 The MySQL Debezium source connector extracts the changes committed to the database binary log (binlog), and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://debezium.io/docs/connectors/mysql/>`_.
+
 .. _connect_debezium_mysql_schema_versioning:
 
 Schema versioning

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.rst
@@ -9,6 +9,10 @@ The Debezium source connector extracts the changes committed to the transaction 
     
     So if your system is completely idle (in which case Aiven for PostgreSQL still generates 16 MiB of WAL every 5 minutes) or changes only occur in databases Debezium is not connected to, PostgreSQL will not be able to clean up WAL and the service will eventually run out of disk space. Thus it is essential to ensure any database you connect to with Debezium is updated frequently enough.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://debezium.io/documentation/reference/stable/connectors/postgresql.html>`_.
+
 .. _connect_debezium_pg_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.rst
@@ -3,6 +3,10 @@ Create a Debezium source connector for SQL Server
 
 The SQL Server Debezium source connector is based on the `change data capture (CDC) feature <https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017>`_, extracts the database changes captured in specific `change tables <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html>`_ on a polling interval, and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html>`_.
+
 .. _connect_debezium_sql_server_schema_versioning:
 
 Enable CDC in SQL Server

--- a/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.rst
@@ -7,6 +7,10 @@ The Elasticsearch sink connector enables you to move data from an Aiven for Apac
 
     This article describes how to create a sink connector to Elasticsearch. Similar instructions are available also for OpenSearch® in the :doc:`dedicated article <opensearch-sink>`.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.confluent.io/current/connect/kafka-connect-elasticsearch/index.html>`_.
+
 .. _connect_elasticsearch_sink_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcp-bigquery-sink.rst
@@ -3,6 +3,9 @@ Create a Google BigQuery sink connector
 
 The `Google BigQuery sink connector <https://github.com/confluentinc/kafka-connect-bigquery>`_ enables you to move data from an Aiven for Apache Kafka® cluster to a set of Google BigQuery tables for further processing and analysis. 
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/confluentinc/kafka-connect-bigquery>`_.
 
 .. _connect_bigquery_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
@@ -5,7 +5,7 @@ The Apache Kafka Connect® Google Cloud Storage (GCS) sink connector by Aiven en
 
 .. note::
 
-    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.aiven.io/docs/products/kafka/kafka-connect/howto/gcs-sink.html>`_.
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-gcs>`_.
 
 Prerequisites
 -------------

--- a/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcs-sink.rst
@@ -3,7 +3,9 @@ Create a Google Cloud Storage sink connector
 
 The Apache Kafka Connect® Google Cloud Storage (GCS) sink connector by Aiven enables you to move data from an Aiven for Apache Kafka® cluster to a Google Cloud Storage bucket for long term storage. The full connector documentation is available in the dedicated `GitHub repository <https://github.com/aiven/aiven-kafka-connect-gcs>`_.
 
+.. note::
 
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.aiven.io/docs/products/kafka/kafka-connect/howto/gcs-sink.html>`_.
 
 Prerequisites
 -------------

--- a/docs/products/kafka/kafka-connect/howto/http-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/http-sink.rst
@@ -3,6 +3,9 @@ Create an HTTP sink connector
 
 The HTTP sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a remote server via HTTP. The full list of parameters and setup details is available in the `dedicated GitHub repository <https://github.com/aiven/http-connector-for-apache-kafka/>`_.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-http>`_.
 
 .. _connect_http_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/jdbc-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-sink.rst
@@ -5,7 +5,11 @@ The JDBC (Java Database Connectivity) sink connector enables you to move data fr
 
 .. Warning::
 
-    Since the JDBC sink connector is pushing data to relational databases, it can work only with topics having a schema, either defined in every message or in the schema registry features offered by `Karapace <https://help.aiven.io/en/articles/5651983>`_
+    Since the JDBC sink connector is pushing data to relational databases, it can work only with topics having a schema, either defined in every message or in the schema registry features offered by :doc:`Karapace </docs/products/kafka/karapace>`.
+
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/sink-connector.md>`_.
 
 .. _connect_jdbc_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-mysql.rst
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-mysql.rst
@@ -7,6 +7,10 @@ The JDBC source connector pushes data from a relational database, such as MySQL,
 
     Sourcing data from a database into Apache Kafka decouples the database from the set of consumers. Once the data is in Apache Kafka, multiple applications can access it without adding any additional query overhead to the source database.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`_.
+
 .. _connect_jdbc_mysql_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg.rst
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-pg.rst
@@ -7,6 +7,10 @@ The JDBC source connector pushes data from a relational database, such as Postgr
 
     Sourcing data from a database into Apache Kafka decouples the database from the set of consumers. Once the data is in Apache Kafka, multiple applications can access it without adding any additional query overhead to the source database.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`_.
+
 .. _connect_jdbc_pg_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-sql-server.rst
+++ b/docs/products/kafka/kafka-connect/howto/jdbc-source-connector-sql-server.rst
@@ -7,6 +7,10 @@ The JDBC source connector pushes data from a relational database, such as SQL Se
 
     Sourcing data from a database into Apache Kafka decouples the database from the set of consumers. Once the data is in Apache Kafka, multiple applications can access it without adding any additional query overhead to the source database.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/aiven-kafka-connect-jdbc/blob/master/docs/source-connector.md>`_.
+
 .. _connect_jdbc_sqlserver_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.rst
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.rst
@@ -7,6 +7,10 @@ The MongoDB source connector periodically queries MongoDB collections and copies
 
     The query bases approach used by this MongoDB source connector periodically pulls the new changes from a collection. The polling interval can be set as a parameter. For a log based change data capture please check the Debezium source connector for MongoDB.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.mongodb.com/kafka-connector/current/>`_.
+
 .. _connect_mongodb_pull_source_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.rst
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-lenses.rst
@@ -11,6 +11,8 @@ The MongoDB sink connector enables you to move data from an Aiven for Apache Kaf
     * The `MongoDB sink connector by Lenses.io <https://docs.lenses.io/connectors/sink/mongo.html>`_
 
     This document refers to the MongoDB sink connector by Lenses.io, you can browse the MongoDB implementation in the :doc:`related document <mongodb-sink-mongo>`
+    
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.lenses.io/connectors/sink/mongo.html>`_.
 
 .. _connect_mongodb_lenses_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/mongodb-sink-mongo.rst
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-sink-mongo.rst
@@ -12,6 +12,8 @@ The MongoDB sink connector enables you to move data from an Aiven for Apache Kaf
 
     This document refers to the MongoDB sink connector by MongoDB, you can browse the Lenses.io implementation in the :doc:`related document <mongodb-sink-lenses>`
 
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.mongodb.com/kafka-connector/current/>`_.
+
 .. _connect_mongodb_sink_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.rst
+++ b/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.rst
@@ -1,9 +1,11 @@
 Create a MQTT source connector
 ==============================
 
-The `MQTT source connector <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/mqttsourceconnector/>`_ copies messages from the MQTT topic into Apache Kafka® where they can be transformed and read by multiple consumers.
+The `MQTT source connector <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/mqttsourceconnector/>`_ copies messages from the MQTT topic into Apache Kafka® where they can be transformed and read by multiple consumers. Then, the Stream Reactor MQTT source connector creates a queue and binds it to the ``amq.topic`` defined in the KCQL statement, then messages are copied to the Apache Kafka® service. 
 
-Then, the Stream Reactor MQTT source connector creates a queue and binds it to the ``amq.topic`` defined in the KCQL statement, then messages are copied to the Apache Kafka® service. 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/mqttsourceconnector/>`_.
 
 .. Tip::
 

--- a/docs/products/kafka/kafka-connect/howto/opensearch-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/opensearch-sink.rst
@@ -7,6 +7,11 @@ The OpenSearch sink connector enables you to move data from an Aiven for Apache 
 
     This article describes how to create a sink connector to OpenSearch®. Similar instructions are available also for Elasticsearch® in the :doc:`dedicated article <elasticsearch-sink>`.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/opensearch-connector-for-apache-kafka/blob/main/docs/opensearch-sink-connector-config-options.rst>`_.
+
+
 .. _connect_opensearch_sink_prereq:
 
 Prerequisites

--- a/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/redis-streamreactor-sink.rst
@@ -3,6 +3,11 @@ Create a Redis®* stream reactor sink connector by Lenses.io
 
 **The Redis stream reactor sink connector** enables you to move data from **an Aiven for Apache Kafka® cluster** to **a Redis®* database**. The Lenses.io implementation enables you to write `KCQL transformations <https://docs.lenses.io/connectors/sink/redis.html>`_ on the topic data before sending it to the Redis database.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.lenses.io/connectors/sink/redis.html>`_.
+
+
 
 .. _connect_redis_lenses_sink_prereq:
 

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
@@ -7,6 +7,10 @@ The Apache Kafka Connect® S3 sink connector by Aiven enables you to move data f
 
     There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: one is developed by Aiven, another developed by Confluent. This article uses the Aiven version. The S3 sink connector by Confluent is discussed in a :doc:`dedicated page <s3-sink-connector-confluent>`.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/aiven/s3-connector-for-apache-kafka>`_.
+
 Prerequisites
 -------------
 

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
@@ -7,6 +7,10 @@ The **Apache Kafka Connect® S3 sink connector by Aiven** enables you to move da
 
     There are two versions of S3 sink connector available with Aiven for Apache Kafka Connect®: One is developed by Aiven, another developed by Confluent. This article uses the Confluent version. To learn about Aiven sink connector check out :doc:`the dedicated page <s3-sink-connector-aiven>`.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.confluent.io/current/connect/kafka-connect-s3/>`_.
+
 Prerequisites
 -------------
 

--- a/docs/products/kafka/kafka-connect/howto/snowflake-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/snowflake-sink.rst
@@ -3,6 +3,10 @@ Create a Snowflake sink connector
 
 The Apache Kafka Connect® Snowflake sink connector enables you to move data from an Aiven for Apache Kafka® cluster to a Snowflake database. The full connector documentation is available in the dedicated `GitHub repository <https://docs.snowflake.com/en/user-guide/kafka-connector.html>`_.
 
+.. note::
+
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`_.
+
 .. _connect_sink_snowflake_prereq:
 
 Prerequisites


### PR DESCRIPTION
# What changed, and why it matters

For each Kafka Connect connector there's now a note pointing people to the relevant github repo. 
This is a preparation step for the Kafka Connect home page redesign

Also solves some errors in a jmx file links
