### PR TITLE
Replace master to main

### DIFF
--- a/.github/workflows/linkcheck-changed-files.yaml
+++ b/.github/workflows/linkcheck-changed-files.yaml
@@ -2,7 +2,7 @@ name: "LinkCheck - Changed files"
 "on":
   push:
     branches:
-      - master
+      - main
     tags:
       - "**"
   pull_request: null

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: Linting
 on:
   push:
     branches:
-      - master
+      - main
     tags:
-      - '**'
+      - "**"
   pull_request:
 
 jobs:


### PR DESCRIPTION
We do not have a master branch,
so we should run those jobs in the
main branch instead.

If something changes in the main branch,
for example.



