### PR TITLE
Added reference to PostgreSQL extension 'file_fdw' back as part of superuser-only extensions

### DIFF
--- a/docs/products/postgresql/reference/list-of-extensions.rst
+++ b/docs/products/postgresql/reference/list-of-extensions.rst
@@ -240,6 +240,9 @@ The following extensions can only be installed by superusers, **and are not gene
 ``dict_xsyn`` - https://www.postgresql.org/docs/current/dict-xsyn.html
     Text search dictionary template for extended synonym processing.
 
+``file_fdw`` - https://www.postgresql.org/docs/current/file-fdw.html
+    Foreign-data wrapper for flat file access.
+
 ``hstore_plperl`` - https://www.postgresql.org/docs/current/hstore.html
     Transform between ``hstore`` and ``plperl``.
 


### PR DESCRIPTION
# What changed, and why it matters
I have added the PostgreSQL extension `file_fdw` back to our list of extensions as part of the superuser-only section. This extension was previously removed (see issues #705 and #706). However, since `file_fdw` is part of PostgreSQL itself: https://www.postgresql.org/docs/current/file-fdw.html we can not delete it from the output of `pg_available_extensions`. 

There were a number of other extensions that were listed in `pg_available_extensions` but could not be installed, which is why @mble created PR #1225. 

This PR adds `file_fdw` to the list introduced by Matt. 

