### PR TITLE
Add redirects for deleted files

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -26,7 +26,8 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 /docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html
 /docs/products/kafka/howto/enable-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/enable-schema-registry-authorization.html
 /docs/products/kafka/howto/manage-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/manage-schema-registry-authorization.html
-
+/docs/platform/howto/renaming-a-service.html                            /docs/platform/howto/rename-a-service.html
+/docs/platform/howto/recovering-a-deleted-service                       /docs/platform/howto/recover-a-deleted-service.html
 # Redirect from .index.html to specific page names for landing
 
 # with one section and no subsections, i. e. docs/platform


### PR DESCRIPTION
On the following commits file name changed,

ee76b0c
054a595

It is missing redirects for those files, from
the deleted ones.

# What changed, and why it matters


