### PR TITLE
Fix code sample reference

### DIFF
--- a/docs/products/cassandra.rst
+++ b/docs/products/cassandra.rst
@@ -34,4 +34,18 @@ Take your first steps with Aiven for Apache Cassandra® by following our :doc:`/
         :shadow: md
         :margin: 2 2 0 0
 
+        💻 :doc:`/docs/products/cassandra/howto`
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
         📖 :doc:`/docs/products/cassandra/reference`
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        🧰 :doc:`Code samples </docs/products/cassandra/howto/list-code-samples>`
+
+

--- a/docs/products/kafka.rst
+++ b/docs/products/kafka.rst
@@ -49,6 +49,11 @@ Take your first steps with Aiven for Apache Kafka by following our :doc:`/docs/p
 
         📖 :doc:`/docs/products/kafka/reference`
 
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        🧰 :doc:`Code samples </docs/products/kafka/howto/list-code-samples>`
 
 Apache Kafka resources
 ----------------------

--- a/docs/products/mysql.rst
+++ b/docs/products/mysql.rst
@@ -36,6 +36,12 @@ Our :doc:`getting started guide </docs/products/mysql/get-started>` will get you
 
         📖 :doc:`Reference </docs/products/mysql/reference>`
 
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        🧰 :doc:`Code samples </docs/products/mysql/howto/list-code-samples>`
+
 
 More MySQL resources
 ====================

--- a/docs/products/opensearch.rst
+++ b/docs/products/opensearch.rst
@@ -44,7 +44,7 @@ Try the :doc:`sample recipes dataset </docs/products/opensearch/howto/sample-dat
         :shadow: md
         :margin: 2 2 0 0
 
-        🧰 :doc:`Code </docs/products/opensearch/howto/opensearch-with-curl>`
+        🧰 :doc:`Code samples </docs/products/opensearch/howto/opensearch-with-curl>`
 
 
 Ways to use OpenSearch

--- a/docs/products/postgresql.rst
+++ b/docs/products/postgresql.rst
@@ -29,7 +29,7 @@ Aiven for PostgreSQL is the perfect fit for your relational data. A scalable SQL
         :shadow: md
         :margin: 2 2 0 0
 
-        🧰 :doc:`/docs/products/postgresql/howto/list-code-samples`
+        🧰 :doc:`Code samples </docs/products/postgresql/howto/list-code-samples>`
 
 
 PostgreSQL resources

--- a/docs/products/redis.rst
+++ b/docs/products/redis.rst
@@ -45,7 +45,7 @@ Take your first steps with Aiven for Redis by following our :doc:`getting starte
         :shadow: md
         :margin: 2 2 0 0
 
-        🧰 :doc:`/docs/products/redis/howto/list-code-samples`
+        🧰 :doc:`Code samples </docs/products/redis/howto/list-code-samples>`
 
 
 Ways to use Aiven for Redis


### PR DESCRIPTION
Some products already have code samples.
This proposes to add those code samples to their
product landing page.

Signed-off-by: laysa.uchoa <laysa.uchoa@aiven.io>