### PR TITLE
Fixing file name in mongo source connector

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.rst
+++ b/docs/products/kafka/kafka-connect/howto/mongodb-poll-source-connector.rst
@@ -81,7 +81,7 @@ To create the connector, access the `Aiven Console <https://console.aiven.io/>`_
 2. Clink on **Create New Connector**, the button is enabled only for services :doc:`with Kafka Connect enabled <enable-connect>`.
 3. Select the **MongoDB Kafka Source Connector**
 4. Under the *Common* tab, locate the **Connector configuration** text box and click on **Edit**
-5. Paste the connector configuration (stored in the ``mongodb_sink.json`` file) in the form
+5. Paste the connector configuration (stored in the ``mongodb_source.json`` file) in the form
 6. Click on **Apply**
 
 .. Note::


### PR DESCRIPTION
# What changed, and why it matters
It is a minor change, I was reading the document and found that the file they are  referring to is `mongodb_source.json` file that was previously created.
