### PR TITLE
services-forking: update article to address customer concern

### DIFF
--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -10,7 +10,7 @@ When you fork a service, the following items are copied into the new service:
 - Service users
 - Connection pools
 
-Rest assured that forking your production cluster does not cause any additional load to it, because the new fork does not communicate with old database cluster. Data is restored from the latest backup that is hosted outside of the old cluster.
+Forking a service does not cause any additional load to it, because the new fork does not communicate with the original service. The data is restored from the latest backup stored separately from the service.
 
 .. Warning::
         The service integrations are not copied over to the forked version, and need to be re-established for each new copy.

--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -10,8 +10,10 @@ When you fork a service, the following items are copied into the new service:
 - Service users
 - Connection pools
 
+Rest assured that forking your production cluster does not cause any additional load to it, because the new fork does not communicate with old database cluster. Data is restored from the latest backup that is hosted outside of the old cluster.
+
 .. Warning::
-        The service integrations are not copied over to the forked version, and need to be re-established for each new copy. 
+        The service integrations are not copied over to the forked version, and need to be re-established for each new copy.
 
 You can fork the following Aiven services:
 
@@ -25,7 +27,7 @@ You can fork the following Aiven services:
 - M3DB
 - Grafana®
 
-When forking a service with Point in Time Recovery (PITR), you can choose to fork from the latest transaction or select a specific point in the past to fork from. 
+When forking a service with Point in Time Recovery (PITR), you can choose to fork from the latest transaction or select a specific point in the past to fork from.
 
 ------
 


### PR DESCRIPTION
# What changed, and why it matters

Some customers may want to fork their production clusters. One of them recently reached out to us asking if there are any additional load to their production cluster when the fork is being made.

The short answer is no, and this article is now updated to address this concern from customers by giving a short paragraph to emphasize that the fork cluster does not communicate with the old cluster at all and so will not cause any load to it.




