### PR TITLE
Added ML Commons plugin to the list

### DIFF
--- a/docs/products/opensearch/reference/plugins.rst
+++ b/docs/products/opensearch/reference/plugins.rst
@@ -25,6 +25,7 @@ These plugins are enabled on all Aiven for OpenSearch services by default:
 * `Scheduler for Dashboards Reports <https://github.com/opensearch-project/dashboards-reports>`__
 * `OpenSearch Dashboards Gantt Charts <https://opensearch.org/docs/latest/dashboards/gantt/>`__
 * `OpenSearch Dashboards Trace Analytics <https://opensearch.org/docs/latest/monitoring-plugins/trace/index/>`__
+* `ML Commons plugin <https://opensearch.org/docs/latest/ml-commons-plugin/index/>`_
 
 
 ------


### PR DESCRIPTION
# What changed, and why it matters
Add ML Commons plugin to the list of plugins supported in OpenSearch

