### PR TITLE
Add logs to Issue message

### DIFF
--- a/.github/ISSUE_TEMPLATE/linkcheck_report.md
+++ b/.github/ISSUE_TEMPLATE/linkcheck_report.md
@@ -5,6 +5,8 @@ labels: Maintanance, bug
 
 On devportal, we check the links on a weekly basis to ensure the links in on our docs are working.
 
-The last ``linkcheck`` run failed, so it may have found broken links on the devportal docs.
+The last ``linkcheck`` run failed, so it may have found broken links on the devportal docs. Partial logs output can be found here:
 
-You can check the [last workflow run](https://github.com/aiven/devportal/actions/workflows/linkcheck.yaml) on {{ date | date('dddd, MMM Do YYYY, hh:mm A') }} (UTC) to see the broken links and fix it.
+{{ env.BROKEN }}
+
+For full logs, check the [last workflow run](https://github.com/aiven/devportal/actions/workflows/linkcheck.yaml) on {{ date | date('dddd, MMM Do YYYY, hh:mm A') }} (UTC) to see the broken links and fix it.

--- a/.github/ISSUE_TEMPLATE/linkcheck_report.md
+++ b/.github/ISSUE_TEMPLATE/linkcheck_report.md
@@ -1,12 +1,17 @@
 ---
 title: 🚨 Weekly linkcheck failed
+about: Use this template for checking broken links
+name: Weekly linkcheck failed
 labels: Maintanance, bug
 ---
 
 On devportal, we check the links on a weekly basis to ensure the links in on our docs are working.
 
-The last ``linkcheck`` run failed, so it may have found broken links on the devportal docs. Partial logs output can be found here:
-
-{{ env.BROKEN }}
+The last ``linkcheck`` run failed, so it may have found broken links on the devportal docs. 
 
 For full logs, check the [last workflow run](https://github.com/aiven/devportal/actions/workflows/linkcheck.yaml) on {{ date | date('dddd, MMM Do YYYY, hh:mm A') }} (UTC) to see the broken links and fix it.
+
+Partial logs output can be found here:
+
+{{ env.OUTPUT }}
+

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -23,12 +23,22 @@ jobs:
       - name: LinkCheck
         id: run_tests
         run: |
-          make linkcheck > logs.txt || echo "BROKEN=$(grep -E "broken" logs.txt)" >> $GITHUB_ENV
+          make linkcheck > logs.txt || echo "OUTPUT=$(grep -E "broken" logs.txt | tr '\n' '@' | sed 's/@/<br>/g' | sed 's/broken/*\*`broken`\*\*/g' | sed $'s/\e\\[[0-9;:]*[a-zA-Z]//g')" >> $GITHUB_ENV
 
       - name: Create Issue
-        if: "${{ env.BROKEN != '' }}"
+        if: "${{ env.RES != '' }}"
         uses: dblock/create-a-github-issue@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/ISSUE_TEMPLATE/linkcheck_report.md
+
+      - name: Create Issue
+        if: "${{ env.OUTPUT != '' }}"
+        uses: dblock/create-a-github-issue@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/linkcheck_report.md
+
+      - run: echo {{ env.OUTPUT }}

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -21,10 +21,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: LinkCheck
-        run: make linkcheck
+        id: run_tests
+        run: |
+          make linkcheck > logs.txt || echo "BROKEN=$(grep -E "broken" logs.txt)" >> $GITHUB_ENV
+
       - name: Create Issue
-        if: failure()
-        uses: JasonEtco/create-an-issue@v2
+        if: "${{ env.BROKEN != '' }}"
+        uses: dblock/create-a-github-issue@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Add partial broken logs info to it. 

Linkcheck runs weekly and reports an issue when broken links are found. One has to look into the failed action and filter the broken links from the extensive list manually. This PR automates this step. by bringing the broken link messages directly to the issue.

The logs messages should be parsed to something like this:

<img width="1512" alt="Screenshot 2022-10-10 at 14 04 15" src="https://user-images.githubusercontent.com/36624597/194865889-eda2720e-21f3-4854-8e81-722f1d04c1a1.png">
