### PR TITLE
Made search results require 2 matching query blocks

### DIFF
--- a/netlify/functions/search/search.js
+++ b/netlify/functions/search/search.js
@@ -32,6 +32,7 @@ const handler = async (event) => {
         from: (currentPage - 1) * pageSize,
         query: {
           bool: {
+            minimum_should_match: 2,
             should: [
               {
                 match: {


### PR DESCRIPTION
Prevents all pages being returned for all queries.  Fixes #1441 
