### PR TITLE
Updating page title per discussion

### DIFF
--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -21,6 +21,7 @@ exceptions:
   - ClickHouse
   - CloudWatch
   - Connect
+  - Cookbook
   - Dashboards
   - Datadog
   - Debezium

--- a/docs/tools/terraform/reference/cookbook.rst
+++ b/docs/tools/terraform/reference/cookbook.rst
@@ -1,5 +1,5 @@
-Cookbook
-=========
+Aiven Terraform Cookbook
+========================
 
 Sometimes an example is easier to understand than a long tutorial or detailed configuration documentation. We've put together some of the most common terraform setups, and listed them here. Use them as they are, or combine them to cook up something new and tasty for your own needs.
 


### PR DESCRIPTION
# What changed, and why it matters

This PR updates https://docs.aiven.io/docs/tools/terraform/reference/cookbook.html page title to "Aiven Terraform Cookbook" from "Cookbook" per discussion.

