### PR TITLE
Remove wrong file on the path

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -86,7 +86,6 @@ entries:
       - file: docs/platform/howto/list-billing
         title: Billing management
         entries:
-          - file: docs/platform/howto/access-suspended-due.rst-to-past-due-invoice
           - file: docs/platform/howto/manage-payment-card
           - file: docs/platform/howto/use-billing-groups
           - file: docs/platform/howto/change-billing-contact


### PR DESCRIPTION
This path does not exist, but it
was added in the path in the PR (#1459).

This commit removes the file path
added there.




