### PR TITLE
Edited GCP Marketplace migration instructions for clarity

### DIFF
--- a/docs/platform/howto/move-to-gcp-marketplace-billing.rst
+++ b/docs/platform/howto/move-to-gcp-marketplace-billing.rst
@@ -11,10 +11,18 @@ Follow the steps to :doc:`set up Google Cloud Platform Marketplace for Aiven Ser
 Gather the required information
 -------------------------------
 
-Aiven will need the name of the project which currently contains your services and the account name for the new project (in the format `E-1234-1234-1234-1234`) which is shown in the "Settings" screen for your new project in the Aiven GCP console (`https://console.gcp.aiven.io <https://console.gcp.aiven.io>`_).
+Aiven will need some information from both your existing and your new subscriptions in order to perform the migration.
+
+**From your existing Aiven account:**
+
+* The name of the project (or projects) that contain the services you wish to move. 
+
+**From your new GCP Marketplace subscription:**
+
+* Your Account ID (in the format ``E-1234-1234-1234-1234``), as shown in the Aiven GCP console "Settings" screen
 
 Send the request to Aiven
 -------------------------
 
-Once you have the account ID, send this and the name of the project which contains the relevant services to `sales@Aiven.io <mailto:sales@Aiven.io>`_ and someone will be in touch to complete the process.
+Once you have collected the information above, send it by email to `sales@Aiven.io <mailto:sales@Aiven.io>`_ and someone will be in touch to complete the process.
 

--- a/docs/platform/howto/move-to-gcp-marketplace-billing.rst
+++ b/docs/platform/howto/move-to-gcp-marketplace-billing.rst
@@ -11,7 +11,7 @@ Follow the steps to :doc:`set up Google Cloud Platform Marketplace for Aiven Ser
 Gather the required information
 -------------------------------
 
-Aiven will need some information from both your existing and your new subscriptions in order to perform the migration.
+Aiven will need some information from both your existing and new subscriptions in order to perform the migration.
 
 **From your existing Aiven account:**
 
@@ -19,7 +19,7 @@ Aiven will need some information from both your existing and your new subscripti
 
 **From your new GCP Marketplace subscription:**
 
-* Your Account ID (in the format ``E-1234-1234-1234-1234``), as shown in the Aiven GCP console "Settings" screen
+* Your Account ID (in the format ``E-1234-1234-1234-1234``), as shown in the Aiven GCP console **Settings** screen.
 
 Send the request to Aiven
 -------------------------


### PR DESCRIPTION
# What changed, and why it matters

We require information from both old and new environments to complete the migration. The way this was written (all combined in one sentence) was unclear in my view, so I've separated things out to make it more obvious what is what. 
