### PR TITLE
Unify kafka connect with java instructions with other ones

### DIFF
--- a/docs/products/kafka/howto/connect-with-java.rst
+++ b/docs/products/kafka/howto/connect-with-java.rst
@@ -61,64 +61,107 @@ Variable                     Description
 ========================     =======================================================================================================
 
 
+Connect a producer
+------------------
+
+Set up properties to connect to the cluster and create a producer:
 
 With SSL authentication
------------------------
-
-Set up properties to connect to the cluster and create a producer and a consumer:
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code::
 
-    Properties properties = new Properties();
-    properties.put("bootstrap.servers", "{HOST}:{SSL_PORT}");
-    properties.put("security.protocol", "SSL");
-    properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
-    properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
-    properties.put("ssl.keystore.type", "PKCS12");
-    properties.put("ssl.keystore.location", "{KEYSTORE_LOCATION}");
-    properties.put("ssl.keystore.password", "{KEYSTORE_PASSWORD}");
-    properties.put("ssl.key.password", "{KEY_PASSWORD}");
-    properties.put("key.serializer", "{SERIALIZER}");
-    properties.put("value.serializer", {SERIALIZER}");
-    properties.put("key.deserializer", "{DESERIALIZER}");
-    properties.put("value.deserializer", "{DESERIALIZER}");
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "{HOST}:{SSL_PORT}");
+        properties.put("security.protocol", "SSL");
+        properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
+        properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
+        properties.put("ssl.keystore.type", "PKCS12");
+        properties.put("ssl.keystore.location", "{KEYSTORE_LOCATION}");
+        properties.put("ssl.keystore.password", "{KEYSTORE_PASSWORD}");
+        properties.put("ssl.key.password", "{KEY_PASSWORD}");
+        properties.put("key.serializer", "{SERIALIZER}");
+        properties.put("value.serializer", "{SERIALIZER}");
 
-    // create a producer
-    KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
-    // create a consumer
-    KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
+        // create a producer
+        KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
 
-With SASL-SSL authentication
------------------------------
+With SASL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set up properties to connect to the cluster and create a producer and a consumer:
+.. code::    
+      
+        String sasl_username = "{USER_NAME}";
+        String sasl_password = "{SASL_PASSWORD}";
+        String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
+        String jaasConfig = String.format(jaasTemplate, sasl_username, sasl_password);
+          
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "{HOST}:{SASL_PORT}");
+        properties.put("security.protocol", "SASL_SSL");
+        properties.put("sasl.mechanism", "SCRAM-SHA-256");
+        properties.put("sasl.jaas.config", jaasConfig);
+        properties.put("ssl.endpoint.identification.algorithm", ""); 
+        properties.put("ssl.truststore.type", "jks");
+        properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
+        properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
+        properties.put("key.serializer", "{SERIALIZER}");
+        properties.put("value.serializer", "{SERIALIZER}");
+          
+        // create a producer
+        KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+
+Connect a consumer
+------------------
+
+Set up properties to connect to the cluster and create a consumer:
+
+With SSL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code::
 
-    Properties properties = new Properties();
+        String group_id = "groupid";
 
-    String sasl_username = "{USER_NAME}";
-    String sasl_password = "{SASL_PASSWORD}";
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "{HOST}:{SSL_PORT}");
+        properties.put("security.protocol", "SSL");
+        properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
+        properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
+        properties.put("ssl.keystore.type", "PKCS12");
+        properties.put("ssl.keystore.location", "{KEYSTORE_LOCATION}");
+        properties.put("ssl.keystore.password", "{KEYSTORE_PASSWORD}");
+        properties.put("ssl.key.password", "{KEY_PASSWORD}");
+        properties.put("key.deserializer", "{DESERIALIZER}");
+        properties.put("value.deserializer", "{DESERIALIZER}");
+        properties.put("group.id", group_id);
 
-    String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
-    String jaasConfig = String.format(jaasTemplate, sasl_username, sasl_password);
+        // create a consumer
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
 
-    properties.put("bootstrap.servers", "{HOST}:{SASL_PORT}");
-    properties.put("security.protocol", "SASL_SSL");
-    properties.put("sasl.mechanism", "SCRAM-SHA-256");
-    properties.put("sasl.jaas.config", jaasConfig);
-    properties.put("ssl.endpoint.identification.algorithm", "");
+With SASL authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    properties.put("ssl.truststore.type", "jks");
-    properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
-    properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
+.. code::
 
-    properties.put("key.serializer", "{SERIALIZER}");
-    properties.put("value.serializer", {SERIALIZER}");
-    properties.put("key.deserializer", "{DESERIALIZER}");
-    properties.put("value.deserializer", "{DESERIALIZER}");
+        String group_id = "groupid";
+        String sasl_username = "{USER_NAME}";
+        String sasl_password = "{SASL_PASSWORD}";
+        String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
+        String jaasConfig = String.format(jaasTemplate, sasl_username, sasl_password);
+          
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "{HOST}:{SASL_PORT}");
+        properties.put("security.protocol", "SASL_SSL");
+        properties.put("sasl.mechanism", "SCRAM-SHA-256");
+        properties.put("sasl.jaas.config", jaasConfig);
+        properties.put("ssl.endpoint.identification.algorithm", ""); 
+        properties.put("ssl.truststore.type", "jks");
+        properties.put("ssl.truststore.location", "{TRUSTSTORE_LOCATION}");
+        properties.put("ssl.truststore.password", "{TRUSTSTORE_PASSWORD}");
+        properties.put("key.deserializer", "{DESERIALIZER}");
+        properties.put("value.deserializer", "{DESERIALIZER}");
+        properties.put("group.id", group_id);
 
-    // create a producer
-    KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
-    // create a consumer
-    KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
+        // create a consumer
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);


### PR DESCRIPTION
- document format taken from how to connect to kafka with python
- SSL and SASL have now own code snippets for producers and consumer
- will continue unifying kafka instructions in other PRs

Fixes https://github.com/aiven/devportal/issues/1520


