### PR TITLE
Updating connector config operator to be consistent.

### DIFF
--- a/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
@@ -80,10 +80,10 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
 ``services.tf`` file:
 
 .. code:: terraform
-
-    
+  
+  
   # PostgreSQL Service
-
+  
   resource "aiven_pg" "demo-pg" {
     project                 = var.project_name
     cloud_name              = "google-northamerica-northeast1"
@@ -93,9 +93,9 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     maintenance_window_dow  = "sunday"
     maintenance_window_time = "10:00:00"
   }
-
+  
   # M3DB Service
-
+  
   resource "aiven_m3db" "demo-m3db" {
     project                 = var.project_name
     cloud_name              = "google-northamerica-northeast1"
@@ -103,19 +103,19 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name            = join("-", [var.service_name_prefix, "m3db"])
     maintenance_window_dow  = "sunday"
     maintenance_window_time = "10:00:00"
-
+  
     m3db_user_config {
       m3db_version = 1.1
-
+  
       namespaces {
         name = "my_ns1"
         type = "unaggregated"
       }
     }
   }
-
+  
   # Grafana Service
-
+  
   resource "aiven_grafana" "demo-grafana" {
     project                 = var.project_name
     cloud_name              = "google-northamerica-northeast1"
@@ -123,34 +123,34 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name            = join("-", [var.service_name_prefix, "grafana"])
     maintenance_window_dow  = "sunday"
     maintenance_window_time = "10:00:00"
-
+  
     grafana_user_config {
       alerting_enabled = true
-
+  
       public_access {
         grafana = true
       }
     }
   }
-
+  
   # PostgreSQL-M3DB Metrics Service Integration
-
+  
   resource "aiven_service_integration" "postgresql_to_m3db" {
     project                  = var.project_name
     integration_type         = "metrics"
     source_service_name      = aiven_pg.demo-pg.service_name
     destination_service_name = aiven_m3db.demo-m3db.service_name
   }
-
+  
   # M3DB-Grafana Dashboard Service Integration
-
+  
   resource "aiven_service_integration" "m3db-to-grafana" {
     project                  = var.project_name
     integration_type         = "dashboard"
     source_service_name      = aiven_grafana.demo-grafana.service_name
     destination_service_name = aiven_m3db.demo-m3db.service_name
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -77,7 +77,7 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
 ``services.tf`` file:
 
 .. code:: terraform
-
+    
     # Kafka service
     resource "aiven_kafka" "application-logs" {
       project                 = var.project_name
@@ -145,8 +145,8 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
       service_name   = aiven_kafka.application-logs.service_name
       connector_name = "kafka-os-con1"
       config = {
-        "topics" = aiven_kafka_topic.topic-logs-app-1.topic_name
-        "connector.class" = "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
+        "topics"                         = aiven_kafka_topic.topic-logs-app-1.topic_name
+        "connector.class"                = "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
         "type.name"                      = "os-connector"
         "name"                           = "kafka-os-con1"
         "connection.url"                 = "https://${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"
@@ -172,7 +172,7 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
         opensearch_version = "1"
       }
     }
-
+    
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -146,7 +146,7 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
       connector_name = "kafka-os-con1"
       config = {
         "topics" = aiven_kafka_topic.topic-logs-app-1.topic_name
-        "connector.class" : "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
+        "connector.class" = "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
         "type.name"                      = "os-connector"
         "name"                           = "kafka-os-con1"
         "connection.url"                 = "https://${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"

--- a/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
@@ -78,7 +78,7 @@ Here is the sample Terraform script to stand-up Aiven for Apache Kafka and relat
 ``services.tf`` file:
 
 .. code:: terraform
-
+  
   resource "aiven_kafka" "demo-kafka" {
     project                 = var.project_name
     cloud_name              = "google-europe-west1"
@@ -87,44 +87,44 @@ Here is the sample Terraform script to stand-up Aiven for Apache Kafka and relat
     maintenance_window_dow  = "sunday"
     maintenance_window_time = "01:00:00"
     default_acl             = false
-
+  
     kafka_user_config {
       kafka_rest      = true
       kafka_connect   = false
       schema_registry = true
       kafka_version   = "3.2"
-
+  
       kafka {
-        auto_create_topics_enable    = true
-        num_partitions               = 3
-        default_replication_factor   = 2
-        min_insync_replicas          = 2
+        auto_create_topics_enable  = true
+        num_partitions             = 3
+        default_replication_factor = 2
+        min_insync_replicas        = 2
       }
-
+  
       kafka_authentication_methods {
         certificate = true
       }
-
+  
       public_access {
-        kafka_rest    = true
+        kafka_rest = true
       }
     }
   }
-
+  
   resource "aiven_kafka_topic" "demo-kafka-topic" {
-    project                = var.project_name
-    service_name           = aiven_kafka.demo-kafka.service_name
-    topic_name             = "demo-kafka-topic"
-    partitions             = 5
-    replication            = 3
+    project      = var.project_name
+    service_name = aiven_kafka.demo-kafka.service_name
+    topic_name   = "demo-kafka-topic"
+    partitions   = 5
+    replication  = 3
   }
-
+  
   resource "aiven_kafka_user" "demo-kafka-user" {
     project      = var.project_name
     service_name = aiven_kafka.demo-kafka.service_name
     username     = var.kafka_user_name
   }
-
+  
   resource "aiven_kafka_acl" "demo-kafka-user-acl" {
     project      = var.project_name
     service_name = aiven_kafka.demo-kafka.service_name
@@ -132,7 +132,7 @@ Here is the sample Terraform script to stand-up Aiven for Apache Kafka and relat
     permission   = "read"
     topic        = aiven_kafka_topic.demo-kafka-topic.topic_name
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -83,14 +83,14 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
 The ``services.tf`` file for the provisioning of these three services, service integration, and related resource is this:
 
 .. code:: terraform
-
+  
   resource "aiven_pg" "demo-pg" {
     project      = var.project_name
     service_name = "demo-postgres"
     cloud_name   = "google-europe-north1"
     plan         = "business-4"
   }
-
+  
   resource "aiven_kafka" "demo-kafka" {
     project                 = var.project_name
     cloud_name              = "azure-norway-west"
@@ -103,21 +103,21 @@ The ``services.tf`` file for the provisioning of these three services, service i
       kafka_connect   = false
       schema_registry = true
       kafka_version   = "3.2"
-
+  
       kafka {
         auto_create_topics_enable  = true
         num_partitions             = 3
         default_replication_factor = 2
         min_insync_replicas        = 2
       }
-
+  
       kafka_authentication_methods {
         certificate = true
       }
-
+  
     }
   }
-
+  
   resource "aiven_kafka_connect" "demo-kafka-connect" {
     project                 = var.project_name
     cloud_name              = "google-europe-north1"
@@ -126,24 +126,24 @@ The ``services.tf`` file for the provisioning of these three services, service i
     service_name            = "demo-kafka-connect"
     maintenance_window_dow  = "monday"
     maintenance_window_time = "10:00:00"
-
+  
     kafka_connect_user_config {
       kafka_connect {
         consumer_isolation_level = "read_committed"
       }
-
+  
       public_access {
         kafka_connect = true
       }
     }
   }
-
+  
   resource "aiven_service_integration" "i1" {
     project                  = var.project_name
     integration_type         = "kafka_connect"
     source_service_name      = aiven_kafka.demo-kafka.service_name
     destination_service_name = aiven_kafka_connect.demo-kafka-connect.service_name
-
+  
     kafka_connect_user_config {
       kafka_connect {
         group_id             = "connect"
@@ -152,12 +152,12 @@ The ``services.tf`` file for the provisioning of these three services, service i
       }
     }
   }
-
+  
   resource "aiven_kafka_connector" "kafka-pg-source" {
     project        = var.project_name
     service_name   = aiven_kafka_connect.demo-kafka-connect.service_name
     connector_name = "kafka-pg-source"
-
+  
     config = {
       "name"                      = "kafka-pg-source"
       "connector.class"           = "io.debezium.connector.postgresql.PostgresConnector"
@@ -180,7 +180,7 @@ The ``services.tf`` file for the provisioning of these three services, service i
     }
     depends_on = [aiven_service_integration.i1]
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -79,7 +79,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
 ``services.tf`` file:
 
 .. code:: terraform
-
+  
   resource "aiven_flink" "flink" {
     project      = var.project_name
     cloud_name   = "google-europe-west1"
@@ -124,13 +124,13 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     table_name     = "iot_measurements_table"
     kafka_topic    = aiven_kafka_topic.source.topic_name
     schema_sql     = <<-EOF
-          hostname STRING,
-          cpu STRING,
-          usage DOUBLE,
-          occurred_at BIGINT,
-          time_ltz AS TO_TIMESTAMP_LTZ(occurred_at, 3),
-          WATERMARK FOR time_ltz AS time_ltz - INTERVAL '10' SECOND
-    EOF
+            hostname STRING,
+            cpu STRING,
+            usage DOUBLE,
+            occurred_at BIGINT,
+            time_ltz AS TO_TIMESTAMP_LTZ(occurred_at, 3),
+            WATERMARK FOR time_ltz AS time_ltz - INTERVAL '10' SECOND
+      EOF
   }
   
   resource "aiven_flink_table" "sink" {
@@ -140,11 +140,11 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     table_name     = "cpu_high_usage_table"
     kafka_topic    = aiven_kafka_topic.sink.topic_name
     schema_sql     = <<-EOF
-          time_ltz TIMESTAMP(3),
-          hostname STRING,
-          cpu STRING,
-          usage DOUBLE
-    EOF
+            time_ltz TIMESTAMP(3),
+            hostname STRING,
+            cpu STRING,
+            usage DOUBLE
+      EOF
   }
   
   resource "aiven_flink_job" "flink_job" {
@@ -156,17 +156,17 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
       aiven_flink_table.sink.table_id
     ]
     statement = <<-EOF
-          INSERT INTO ${aiven_flink_table.sink.table_name}
-          SELECT
-            time_ltz,
-            hostname,
-            cpu,
-            usage
-          FROM ${aiven_flink_table.source.table_name}
-          WHERE usage > 85
-    EOF
+            INSERT INTO ${aiven_flink_table.sink.table_name}
+            SELECT
+              time_ltz,
+              hostname,
+              cpu,
+              usage
+            FROM ${aiven_flink_table.source.table_name}
+            WHERE usage > 85
+      EOF
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
@@ -73,7 +73,7 @@ Here is the sample Terraform file to stand-up a single Apache Kafka server and c
 ``services.tf`` file:
 
 .. code:: terraform
-
+   
    resource "aiven_kafka" "demo-kafka" {
      project                 = var.project_name
      cloud_name              = "google-northamerica-northeast1"

--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -96,66 +96,66 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
 ``services.tf`` file:
 
 .. code:: terraform
-
+  
   resource "aiven_kafka_mirrormaker" "mm" {
     project      = var.project_name
     cloud_name   = "google-europe-west1"
     plan         = "business-4"
     service_name = "mm"
-
+  
     kafka_mirrormaker_user_config {
       ip_filter = [
         "0.0.0.0/0"
       ]
-
-    kafka_mirrormaker {
-      refresh_groups_interval_seconds = 600
-      refresh_topics_enabled          = true
-      refresh_topics_interval_seconds = 600
+  
+      kafka_mirrormaker {
+        refresh_groups_interval_seconds = 600
+        refresh_topics_enabled          = true
+        refresh_topics_interval_seconds = 600
+      }
     }
-   }
   }
-
+  
   resource "aiven_service_integration" "source-kafka-to-mm" {
     project                  = var.project_name
     integration_type         = "kafka_mirrormaker"
     source_service_name      = aiven_kafka.source.service_name
     destination_service_name = aiven_kafka_mirrormaker.mm.service_name
-
+  
     kafka_mirrormaker_user_config {
       cluster_alias = "source"
     }
   }
-
+  
   resource "aiven_service_integration" "mm-to-target-kafka" {
     project                  = var.project_name
     integration_type         = "kafka_mirrormaker"
     source_service_name      = aiven_kafka.target.service_name
     destination_service_name = aiven_kafka_mirrormaker.mm.service_name
-
+  
     kafka_mirrormaker_user_config {
       cluster_alias = "target"
     }
   }
-
+  
   resource "aiven_mirrormaker_replication_flow" "mm-replication-flow" {
     project        = var.project_name
     service_name   = aiven_kafka_mirrormaker.mm.service_name
     source_cluster = aiven_service_integration.source-kafka-to-mm.kafka_mirrormaker_user_config[0].cluster_alias
     target_cluster = aiven_service_integration.mm-to-target-kafka.kafka_mirrormaker_user_config[0].cluster_alias
     enable         = true
-
+  
     topics = [
       ".*",
     ]
-
+  
     topics_blacklist = [
       ".*[\\-\\.]internal",
       ".*\\.replica",
       "__.*"
     ]
   }
-
+  
   resource "aiven_kafka" "source" {
     project                 = var.project_name
     cloud_name              = "google-europe-west1"
@@ -163,7 +163,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name            = "source"
     maintenance_window_dow  = "monday"
     maintenance_window_time = "10:00:00"
-
+  
     kafka_user_config {
       kafka_version = "3.1"
       kafka {
@@ -172,7 +172,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       }
     }
   }
-
+  
   resource "aiven_kafka_topic" "source" {
     project      = var.project_name
     service_name = aiven_kafka.source.service_name
@@ -180,7 +180,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     partitions   = 3
     replication  = 2
   }
-
+  
   resource "aiven_kafka" "target" {
     project                 = var.project_name
     cloud_name              = "google-europe-west1"
@@ -188,7 +188,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name            = "target"
     maintenance_window_dow  = "monday"
     maintenance_window_time = "10:00:00"
-
+  
     kafka_user_config {
       kafka_version = "3.1"
       kafka {
@@ -197,7 +197,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       }
     }
   }
-
+  
   resource "aiven_kafka_topic" "target" {
     project      = var.project_name
     service_name = aiven_kafka.target.service_name
@@ -205,7 +205,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     partitions   = 3
     replication  = 2
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -93,7 +93,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
 ``services.tf`` file:
 
 .. code:: terraform
-
+  
   resource "aiven_kafka" "demo-kafka" {
     project                 = var.project_name
     cloud_name              = "google-northamerica-northeast1"
@@ -106,7 +106,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       kafka_rest    = true
       kafka_version = "3.1"
       kafka {
-        auto_create_topics_enable    = true
+        auto_create_topics_enable = true
       }
     }
   }
@@ -116,19 +116,19 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name   = aiven_kafka.demo-kafka.service_name
     connector_name = "mongodb-source-connector"
     config = {
-      "name" = "mongodb-source-connector"
-      "connector.class" = "com.mongodb.kafka.connect.MongoSourceConnector"
-      "connection.uri" = var.mongodb_connection_uri
-      "database" = "sample_airbnb"
-      "collection" = "listingsAndReviews"
-      "copy.existing" = "true"
-      "poll.await.time.ms" = "1000"
-      "output.format.value" = "json"
-      "output.format.key" = "json"
+      "name"                       = "mongodb-source-connector"
+      "connector.class"            = "com.mongodb.kafka.connect.MongoSourceConnector"
+      "connection.uri"             = var.mongodb_connection_uri
+      "database"                   = "sample_airbnb"
+      "collection"                 = "listingsAndReviews"
+      "copy.existing"              = "true"
+      "poll.await.time.ms"         = "1000"
+      "output.format.value"        = "json"
+      "output.format.key"          = "json"
       "publish.full.document.only" = "true"
     }
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -116,16 +116,16 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     service_name   = aiven_kafka.demo-kafka.service_name
     connector_name = "mongodb-source-connector"
     config = {
-      "name" : "mongodb-source-connector"
-      "connector.class" : "com.mongodb.kafka.connect.MongoSourceConnector"
+      "name" = "mongodb-source-connector"
+      "connector.class" = "com.mongodb.kafka.connect.MongoSourceConnector"
       "connection.uri" = var.mongodb_connection_uri
-      "database" : "sample_airbnb"
-      "collection" : "listingsAndReviews"
-      "copy.existing" : "true"
-      "poll.await.time.ms" : "1000"
-      "output.format.value" : "json"
-      "output.format.key" : "json"
-      "publish.full.document.only" : "true"
+      "database" = "sample_airbnb"
+      "collection" = "listingsAndReviews"
+      "copy.existing" = "true"
+      "poll.await.time.ms" = "1000"
+      "output.format.value" = "json"
+      "output.format.key" = "json"
+      "publish.full.document.only" = "true"
     }
   }
 

--- a/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
@@ -81,16 +81,16 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
 ``services.tf`` file:
 
 .. code:: terraform
- 
+  
   resource "aiven_m3db" "demo-m3db" {
     project      = var.project_name
     cloud_name   = "google-northamerica-northeast1"
     plan         = "business-8"
     service_name = join("-", [var.service_name_prefix, "m3db"])
-
+  
     m3db_user_config {
       m3db_version = 1.5
-
+  
       namespaces {
         name = "m3_default_unaggregated_ns"
         type = "unaggregated"
@@ -132,28 +132,28 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       }
     }
   }
-
-
+  
+  
   // Setting up aggregation
-
+  
   resource "aiven_m3aggregator" "demo-m3a" {
     project      = var.project_name
     cloud_name   = "google-northamerica-northeast1"
     plan         = "business-8"
     service_name = join("-", [var.service_name_prefix, "m3a"])
-
+  
     m3aggregator_user_config {
       m3aggregator_version = 1.5
     }
   }
-
+  
   resource "aiven_service_integration" "int-m3db-aggr" {
     project                  = var.project_name
     integration_type         = "m3aggregator"
     source_service_name      = aiven_m3db.demo-m3db.service_name
     destination_service_name = aiven_m3aggregator.demo-m3a.service_name
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -72,7 +72,7 @@ Here is the sample Terraform file to deploy all three services. Keep in mind tha
 ``services.tf`` file:
 
 .. code:: terraform
-
+   
    # European Postgres Service
    resource "aiven_pg" "aws-eu-pg" {
      project                = var.project_name
@@ -99,7 +99,7 @@ Here is the sample Terraform file to deploy all three services. Keep in mind tha
      service_name           = "postgres-as-gcp"
      termination_protection = true
    }
-
+   
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
@@ -101,10 +101,10 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       backup_minute             = 30
       shared_buffers_percentage = 40
   
-      ip_filter           = ["0.0.0.0/0"]
-      admin_username      = var.admin_username
-      admin_password      = var.admin_password
-      
+      ip_filter      = ["0.0.0.0/0"]
+      admin_username = var.admin_username
+      admin_password = var.admin_password
+  
       ## project_to_fork_from  = "source-project-name" 
       ## service_to_fork_from  = "source-pg-service"   
       ## pg_read_replica       = true                  
@@ -116,7 +116,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       }
     }
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -130,7 +130,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
       aiven_pg.demo-postgresql-primary,
     ]
   }
-
+  
 .. dropdown:: Expand to check out how to execute the Terraform files.
 
     The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.


### PR DESCRIPTION
# What changed, and why it matters

`:` and `=` are interchangeable for object k/v pairs so the code works fine. This PR brings in consistency in the config so that we don't have a mixed `:` and `=`.
