### PR TITLE
Don't make docs in directory `venv`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,7 @@ templates_path = ['_templates']
 exclude_patterns = [
     '_build', 'Thumbs.db', '.DS_Store', 'README*', 'scripts', 'utils',
     'CONTRIBUTING.rst', 'REVIEWING.rst', 'includes',
-    '.github/vale', '.venv',
+    '.github/vale', '.venv', 'venv',
 ]
 
 # gitstamp config


### PR DESCRIPTION
The README suggests creating a Python virtual environment in directory `venv` in the devportal top level directory. The existing `conf.py` looks for files to convert to HTML in that directory, if it's present, which is confusing. So exclude the directory `venv`.

Fixes #1511

(for how to test, see the report in the issue)



