### PR TITLE
Add a missing redirect for a renamed file

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -39,6 +39,7 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 /docs/platform/howto/recovering-a-deleted-service                     /docs/platform/howto/recover-a-deleted-service
 /docs/products/opensearch/howto/upgrade-to-opensearch-with-terraform.html /docs/tools/terraform/howto/upgrade-to-opensearch.html
 /docs/products/opensearch/howto/upgrade-to-opensearch-with-terraform      /docs/tools/terraform/howto/upgrade-to-opensearch
+/docs/platform/howto/migrate-services                                 /docs/platform/howto/migrate-services-cloud-region
 
 # Redirect from .index.html to specific page names for landing
 


### PR DESCRIPTION
# What changed, and why it matters

I found that the old URLs https://help.aiven.io/en/articles/489585-selecting-the-cloud-and-region and https://help.aiven.io/en/articles/493382-can-i-migrate-my-service-to-another-cloud-or-region were not redirecting correctly, and that was because we renamed a file in https://github.com/aiven/devportal/commit/a38f4b34adc8d2e89e259b7abfa5de7e7b40e5c4 without adding a redirect
