### PR TITLE
Fix link redirects: use `https` instead of `http`

### DIFF
--- a/docs/products/grafana/reference/plugins.rst
+++ b/docs/products/grafana/reference/plugins.rst
@@ -32,7 +32,7 @@ Clock - `Grafana <https://grafana.com/grafana/plugins/grafana-clock-panel/>`__ |
 D3 Gauge - `Grafana <https://grafana.com/grafana/plugins/briangann-gauge-panel/>`__ | `GitHub <https://github.com/briangann/grafana-gauge-panel>`__
     Provides a D3-based gauge panel for Grafana 6.x/7.x
 
-Dashboard list - `Grafana <https://grafana.com/grafana/plugins/dashlist/>`__ | `Grafana Docs <http://docs.grafana.org/reference/dashlist/>`__
+Dashboard list - `Grafana <https://grafana.com/grafana/plugins/dashlist/>`__ | `Grafana Docs <https://docs.grafana.org/reference/dashlist/>`__
     Allows you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, a search query and/or dashboard tags.
 
 Diagram - `Grafana <https://grafana.com/grafana/plugins/jdbranham-diagram-panel/>`__ | `GitHub <https://github.com/jdbranham/grafana-diagram>`__
@@ -56,7 +56,7 @@ Getting Started
 Graph - `Grafana Docs <https://grafana.com/docs/grafana/latest/features/panels/graph/>`__
     Included with Grafana, provides a very rich set of graphing options.
 
-Heatmap - `Grafana <https://grafana.com/grafana/plugins/heatmap/>`__ | `Grafana Docs <http://docs.grafana.org/features/panels/heatmap/>`__ 
+Heatmap - `Grafana <https://grafana.com/grafana/plugins/heatmap/>`__ | `Grafana Docs <https://docs.grafana.org/features/panels/heatmap/>`__
     Allows you to view histograms over time.
 
 Histogram - `Grafana <https://grafana.com/grafana/plugins/mtanda-histogram-panel/>`__ | `GitHub <https://github.com/mtanda/grafana-histogram-panel>`__
@@ -83,7 +83,7 @@ Plugin list - `Grafana <https://grafana.com/grafana/plugins/pluginlist/>`__
 Singlestat Math - `Grafana <https://grafana.com/grafana/plugins/blackmirror1-singlestat-math-panel/>`__
     A modification of the native single stat panel to support math functions across series.
 
-Stat - `Grafana Docs <http://docs.grafana.org/reference/singlestat/>`__
+Stat - `Grafana Docs <https://docs.grafana.org/reference/singlestat/>`__
     Included with Grafana, allows you to show the one main summary stat of a SINGLE series.
 
 State timeline
@@ -122,10 +122,10 @@ Altinity plugin for ClickHouse® - `GitHub <https://github.com/Altinity/clickhou
 Azure Monitor - `Grafana <https://grafana.com/grafana/plugins/grafana-azure-monitor-datasource/>`__ | `GitHub <https://github.com/grafana/azure-monitor-datasource>`__
     Provides a single source for monitoring Azure resources. 
 
-CloudWatch - `Grafana <https://grafana.com/grafana/plugins/cloudwatch/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/cloudwatch/>`__
+CloudWatch - `Grafana <https://grafana.com/grafana/plugins/cloudwatch/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/cloudwatch/>`__
     Build dashboards for your CloudWatch metrics.
 
-Elasticsearch - `Grafana <https://grafana.com/grafana/plugins/elasticsearch/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/elasticsearch/>`__
+Elasticsearch - `Grafana <https://grafana.com/grafana/plugins/elasticsearch/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/elasticsearch/>`__
     Performs Elasticsearch queries to visualize logs or metrics stored in Elasticsearch. Annotate your graphs with log events stored in Elasticsearch.
 
 GitHub - `GitHub <https://github.com/grafana/github-datasource>`__
@@ -137,10 +137,10 @@ Google BigQuery - `GitHub <https://github.com/doitintl/bigquery-grafana>`__
 Google Sheets - `Grafana <https://grafana.com/grafana/plugins/grafana-googlesheets-datasource/>`__ | `GitHub <https://github.com/grafana/google-sheets-datasource>`__
     Visualize your Google Spreadsheets in Grafana.
 
-Graphite - `Grafana <https://grafana.com/grafana/plugins/graphite/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/graphite/>`__
+Graphite - `Grafana <https://grafana.com/grafana/plugins/graphite/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/graphite/>`__
     Quickly navigate the metric space, add functions, change function parameters and more. 
 
-InfluxDB® - `Grafana <https://grafana.com/grafana/plugins/influxdb/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/influxdb/>`__
+InfluxDB® - `Grafana <https://grafana.com/grafana/plugins/influxdb/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/influxdb/>`__
 
 Instana - `Grafana <https://grafana.com/grafana/plugins/instana-datasource/>`__ | `GitHub <https://github.com/instana/instana-grafana-datasource>`__
     Shows metrics from Instana AI-Powered APM for dynamic applications.
@@ -154,22 +154,22 @@ Loki
 Microsoft SQL Server
     Grafana ships with a built-in Microsoft SQL Server (MSSQL) data source plugin that allows you to query and visualize data from any Microsoft SQL Server 2005 or newer.
 
-MySQL - `Grafana <https://grafana.com/grafana/plugins/mysql/>`__ | `Grafana Docs <http://docs.grafana.org/features/datasources/mysql/>`__
+MySQL - `Grafana <https://grafana.com/grafana/plugins/mysql/>`__ | `Grafana Docs <https://docs.grafana.org/features/datasources/mysql/>`__
     Allows you to query any visualize data from a MySQL compatible database.
 
 OpenSearch® - `Grafana <https://grafana.com/grafana/plugins/grafana-opensearch-datasource/>`__
     Runs many types of simple or complex OpenSearch queries to visualize logs or metrics stored in OpenSearch. Annotate your graphs with log events stored in OpenSearch. 
 
-OpenTSDB - `Grafana <https://grafana.com/grafana/plugins/opentsdb/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/opentsdb/>`__ 
+OpenTSDB - `Grafana <https://grafana.com/grafana/plugins/opentsdb/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/opentsdb/>`__
     OpenTSDB is a scalable, distributed time series database.
 
 Pagerduty - `Grafana <https://grafana.com/grafana/plugins/xginn8-pagerduty-datasource/>`__ | `GitHub <https://github.com/xginn8/grafana-pagerduty>`__
     Annotations-only datasource for Pagerduty events.
 
-PostgreSQL® - `Grafana <https://grafana.com/grafana/plugins/postgres/>`__ | `Grafana Docs <http://docs.grafana.org/features/datasources/postgres/>`__
+PostgreSQL® - `Grafana <https://grafana.com/grafana/plugins/postgres/>`__ | `Grafana Docs <https://docs.grafana.org/features/datasources/postgres/>`__
     Allows you to query and visualize data from a PostgreSQL compatible database.
 
-Prometheus - `Grafana <https://grafana.com/grafana/plugins/prometheus/>`__ | `Grafana Docs <http://docs.grafana.org/datasources/prometheus/>`__
+Prometheus - `Grafana <https://grafana.com/grafana/plugins/prometheus/>`__ | `Grafana Docs <https://docs.grafana.org/datasources/prometheus/>`__
     Work with the open-source service monitoring system and time series database.
 
 Prometheus AlertManager - `GitHub <https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource>`__

--- a/docs/products/kafka.rst
+++ b/docs/products/kafka.rst
@@ -60,7 +60,7 @@ Apache Kafka resources
 
 If you are new to Apache Kafka, try these resources to learn more:
 
-* The main Apache Kafka project page: http://kafka.apache.org/
+* The main Apache Kafka project page: https://kafka.apache.org/
 
 * The Karapace schema registry that Aiven maintains and makes available for every Aiven for Apache Kafka service: https://karapace.io/
 

--- a/docs/products/kafka/concepts/auth-types.rst
+++ b/docs/products/kafka/concepts/auth-types.rst
@@ -10,7 +10,7 @@ Transport Layer Security
 **Transport Layer Security (TLS)**, also known as Secure Sockets
 Layer (SSL), is an established standard for securing internet traffic. This method
 relies on a certificate that is provided by a Certificate
-Authority (for example, `letsencrypt.org <http://letsencrypt.org>`_ ) for your domain.
+Authority (for example, `letsencrypt.org <https://letsencrypt.org>`_ ) for your domain.
 With this certificate and the right technical setup, you can use
 your domain to encrypt the traffic to your service.
 

--- a/docs/products/kafka/kafka-connect.rst
+++ b/docs/products/kafka/kafka-connect.rst
@@ -156,7 +156,7 @@ Apache Kafka® Connect resources
 
 If you are new to Apache Kafka Connect, try these resources to learn more:
 
-* The main Apache Kafka project page: http://kafka.apache.org/
+* The main Apache Kafka project page: https://kafka.apache.org/
 
 * The Karapace schema registry that Aiven maintains and makes available for every Aiven for Apache Kafka service: https://karapace.io/
 

--- a/docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus.rst
+++ b/docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus.rst
@@ -3,7 +3,7 @@ Metrics for Aiven for Apache Kafka® Connect available via Prometheus
 
 Below you can find a summary of every metric available via Prometheus for an Aiven for Apache Kafka® Connect service. You can review the list of metrics available via Prometheus for the Aiven for Apache Kafka® service in the :doc:`dedicated document </docs/products/kafka/reference/kafka-metrics-prometheus>`.
 
-A full description of the metrics is available in the `Connect Monitoring section of the Apache Kafka® documentation <http://kafka.apache.org/documentation/#connect_monitoring>`_.
+A full description of the metrics is available in the `Connect Monitoring section of the Apache Kafka® documentation <https://kafka.apache.org/documentation/#connect_monitoring>`_.
 
 .. Note::
 

--- a/docs/products/kafka/kafka-mirrormaker.rst
+++ b/docs/products/kafka/kafka-mirrormaker.rst
@@ -46,7 +46,7 @@ Apache Kafka® MirrorMaker 2 resources
 
 If you are new to Apache Kafka® MirrorMaker 2, try these resources to learn more:
 
-* The main Apache Kafka® project page: http://kafka.apache.org/
+* The main Apache Kafka® project page: https://kafka.apache.org/
 
 * The Karapace schema registry that Aiven maintains and makes available for every Aiven for Apache Kafka® service: https://karapace.io/
 

--- a/docs/products/kafka/reference/kafka-metrics-prometheus.rst
+++ b/docs/products/kafka/reference/kafka-metrics-prometheus.rst
@@ -90,7 +90,7 @@ The list of Apache Kafka Connect metrics is available in the :doc:`dedicated pag
 Apache Kafka broker
 -------------------
 
-The descriptions for the below metrics are available in the `Monitoring section of the Apache Kafka documentation <http://kafka.apache.org/documentation/#monitoring>`_.
+The descriptions for the below metrics are available in the `Monitoring section of the Apache Kafka documentation <https://kafka.apache.org/documentation/#monitoring>`_.
 
 .. Note::
 

--- a/docs/products/postgresql/howto/pg-long-running-queries.rst
+++ b/docs/products/postgresql/howto/pg-long-running-queries.rst
@@ -5,14 +5,14 @@ Aiven does not terminate any customer queries even if they run indefinitely, but
 
 To identify and terminate such long-running queries, you can do it from either:
 
-* `Aiven Console <http://console.aiven.io>`__
+* `Aiven Console <https://console.aiven.io>`__
 * `PostgreSQL® shell <https://www.postgresql.org/docs/current/app-psql.html>`_ (``psql``)
 
 
 Terminate long running queries from the Aiven Console
 -----------------------------------------------------
 
-In the `Aiven Console <http://console.aiven.io/>`_, you can go to the **Current Queries** tab for your service.
+In the `Aiven Console <https://console.aiven.io/>`_, you can go to the **Current Queries** tab for your service.
 
 .. image:: /images/products/postgresql/pg-long-running-queries.png
     :alt: PostgreSQL® service overview tab in Aiven's console


### PR DESCRIPTION
When make linkcheck is run, there are a lot of redirected links (search for redirect in the linkcheck output)

See https://github.com/aiven/devportal/issues/1485

This PR fixes the links that used `http` instead of `https`

