### PR TITLE
Fix redirect links: Change `help.aiven.io` redirects to the `docs.aiven.io` page

### DIFF
--- a/docs/platform/howto/saml/saml-authentication.rst
+++ b/docs/platform/howto/saml/saml-authentication.rst
@@ -84,11 +84,11 @@ In the Edit page, you need to input:
 
 Detailed instructions exist for the following providers:
 
-* `Okta <https://help.aiven.io/en/articles/3438800-setting-up-saml-authentication-with-okta>`_
+* `Okta <https://docs.aiven.io/docs/platform/howto/saml/setup-saml-okta>`_
 * `G-Suite <https://help.aiven.io/en/articles/3447699-setting-up-saml-authentication-with-google-g-suite>`_
-* `Azure AD <https://help.aiven.io/en/articles/3557077-setting-up-saml-authentication-with-azure>`_
-* `Auth0 <https://help.aiven.io/en/articles/3808083-setting-up-saml-with-auth0>`_
-* `Centrify <https://help.aiven.io/en/articles/4485814-setting-up-saml-with-centrify>`_
+* `Azure AD <https://docs.aiven.io/docs/platform/howto/saml/setup-saml-azure>`_
+* `Auth0 <https://docs.aiven.io/docs/platform/howto/saml/setup-saml-auth0>`_
+* `Centrify <https://docs.aiven.io/docs/platform/howto/list-saml>`_
 
 
 If your provider isn't in the list, please contact us at

--- a/docs/platform/reference/service-ip-address.rst
+++ b/docs/platform/reference/service-ip-address.rst
@@ -10,7 +10,7 @@ When a new Aiven service is created, the chosen cloud service provider will dyna
 
     Aiven also offer the ability to define :doc:`static IP addresses </docs/platform/concepts/static-ips>` in case you need them a service. For more information about how to obtain a static IP and assign it to a particular service, please check the :doc:`related guide </docs/platform/howto/static-ip-addresses>`.
 
-If you have your own cloud account and want to keep your Aiven services isolated from the public internet, you can however create a VPC and a peering connection to your own cloud account. For more information on how to setup the VPC peering, check `the related article <https://help.aiven.io/en/articles/778836-using-virtual-private-cloud-vpc-peering>`_.
+If you have your own cloud account and want to keep your Aiven services isolated from the public internet, you can however create a VPC and a peering connection to your own cloud account. For more information on how to setup the VPC peering, check `the related article <https://docs.aiven.io/docs/platform/howto/manage-vpc-peering>`_.
 
 Default service hostname
 ------------------------

--- a/docs/products/kafka/kafka-connect/howto/bring-your-own-kafka-connect-cluster.rst
+++ b/docs/products/kafka/kafka-connect/howto/bring-your-own-kafka-connect-cluster.rst
@@ -3,7 +3,7 @@ Bring your own Apache Kafka® Connect cluster
 
 Aiven provides Apache Kafka® Connect as a managed service in combination with the Aiven for Apache Kafka® managed service. However, there are circumstances where you may want to roll your own Kafka Connect cluster.
 
-The following article defines the necessary steps to integrate your own Apache Kafka Connect cluster with Aiven for Apache Kafka and use the schema registry offered by `Karapace <https://help.aiven.io/en/articles/5651983>`__. The example shows how to create a JDBC sink connector to a PostgreSQL® database.
+The following article defines the necessary steps to integrate your own Apache Kafka Connect cluster with Aiven for Apache Kafka and use the schema registry offered by `Karapace <https://docs.aiven.io/docs/products/kafka/karapace>`__. The example shows how to create a JDBC sink connector to a PostgreSQL® database.
 
 .. _bring_your_own_kafka_connect_prereq:
 
@@ -53,7 +53,7 @@ For the following example we assume:
 Configure the Aiven for Apache Kafka service
 ''''''''''''''''''''''''''''''''''''''''''''
 
-You need to enable the schema registry features offered by `Karapace <https://help.aiven.io/en/articles/5651983>`__. You can do it in the `Aiven Console <https://console.aiven.io/>`_ in the Aiven for Apache Kafka service Overview tab.
+You need to enable the schema registry features offered by `Karapace <https://docs.aiven.io/docs/products/kafka/karapace>`__. You can do it in the `Aiven Console <https://console.aiven.io/>`_ in the Aiven for Apache Kafka service Overview tab.
 
 1. Enable the **Schema Registry (Karapace)** and **Apache Kafka REST API (Karapace)**
 

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg-node-replacement.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg-node-replacement.rst
@@ -32,7 +32,7 @@ A restart can be performed manually either through the `Aiven Console <https://c
 
 .. Tip::
 
-   For automatically restarting tasks, you can set ``"_aiven.restart.on.failure": true`` in the connector's configuration ( `check the related article <https://help.aiven.io/en/articles/5088396-kafka-connect-auto-restart-on-failures>`__). Aiven automatically check tasks status for errors every 15 minutes but the interval can be customised if needed.
+   For automatically restarting tasks, you can set ``"_aiven.restart.on.failure": true`` in the connector's configuration ( `check the related article <https://docs.aiven.io/docs/products/kafka/kafka-connect/howto/enable-automatic-restart>`__). Aiven automatically check tasks status for errors every 15 minutes but the interval can be customised if needed.
 
 
 

--- a/docs/products/mysql/howto/prevent-disk-full.rst
+++ b/docs/products/mysql/howto/prevent-disk-full.rst
@@ -18,7 +18,7 @@ Identify and optimize problem tables
 
 InnoDB does not reclaim unused disk space by default and this can cause a disk to become full. 
 
-Read the help article `MySQL disk usage <https://help.aiven.io/en/articles/4808068-mysql-disk-usage>`_ for more information.
+Read the help article `MySQL disk usage <https://docs.aiven.io/docs/products/mysql/howto/reclaim-disk-space>`_ for more information.
 
 Upgrade to a larger plan
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tools/cli/account/account-authentication-method.rst
+++ b/docs/tools/cli/account/account-authentication-method.rst
@@ -12,7 +12,7 @@ Commands for managing Aiven accounts authentication methods.
 ``avn account authentication-method create``
 ''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new authentication method. More information about authentication methods creation is available at the `dedicated page <https://help.aiven.io/en/articles/3376377-saml-authentication>`_
+Creates a new authentication method. More information about authentication methods creation is available at the `dedicated page <https://docs.aiven.io/docs/platform/howto/saml/saml-authentication>`_
 
 .. list-table::
   :header-rows: 1


### PR DESCRIPTION
When make linkcheck is run, there are a lot of redirected links (search for redirect in the linkcheck output)

See https://github.com/aiven/devportal/issues/1485

This PR fixes those `help.aiven.io` links that could instead reference `docs.aiven.io` pages.

We could come back later and turn some/many of these into :doc: references instead - see https://github.com/aiven/devportal/issues/1548

Note: there seem to be some places where a newline is being added at the end of the file.
