### PR TITLE
Fix link redirects: Change miscellaneous permanent redirects

### DIFF
--- a/docs/platform/howto/saml/setup-saml-azure.rst
+++ b/docs/platform/howto/saml/setup-saml-azure.rst
@@ -5,7 +5,7 @@ SAML ( *Security Assertion Markup Language* ) is a standard for
 exchanging authentication and authorization data between an identity
 provider and a service provider. To read more about SAML check the :doc:`dedicated page <saml-authentication>`.
 
-The following is the procedure to setup SAML with `Microsoft Azure Active Directory <https://azure.microsoft.com/en-us/services/active-directory/>`_.
+The following is the procedure to setup SAML with `Microsoft Azure Active Directory <https://azure.microsoft.com/en-us/products/active-directory/>`_.
 
 Prerequisite steps in Aiven
 ----------------------------

--- a/docs/platform/howto/vnet-peering-azure.rst
+++ b/docs/platform/howto/vnet-peering-azure.rst
@@ -17,12 +17,12 @@ Peer your network with the VPC
 For an Azure virtual network peering's state to become **connected**
 between networks A and B, a peering must be created both from network A
 to B and from B to A. See
-`this <https://docs.microsoft.com/en-us/azure/virtual-network/create-peering-different-subscriptions>`__
+`this <https://learn.microsoft.com/en-us/azure/virtual-network/create-peering-different-subscriptions>`__
 for an overview. In the case of Project VPCs, one of the networks is
 located in the Aiven subscription and the Aiven platform handles
 creating the peering from that network to the network you wish to peer.
 For this the Aiven platform's `Active Directory application
-object <https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals>`__
+object <https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals>`__
 needs permissions in your subscription. Because the peering is between
 subscriptions with different AD tenants, an application object is also
 needed to your AD tenant, which can be used to create the peering from
@@ -31,7 +31,7 @@ your network to Aiven once it's been given permissions to do so.
 Preparation
 ~~~~~~~~~~~
 
-Please install the `Azure CLI <https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest>`__
+Please install the `Azure CLI <https://learn.microsoft.com/en-us/cli/azure/?view=azure-cli-latest>`__
 as well as the :doc:`Aiven CLI </docs/tools/cli>` to follow this guide.
 
 1. log in with an Azure admin account

--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-sql-server.rst
@@ -1,7 +1,7 @@
 Create a Debezium source connector for SQL Server
 ==================================================
 
-The SQL Server Debezium source connector is based on the `change data capture (CDC) feature <https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017>`_, extracts the database changes captured in specific `change tables <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html>`_ on a polling interval, and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
+The SQL Server Debezium source connector is based on the `change data capture (CDC) feature <https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017>`_, extracts the database changes captured in specific `change tables <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html>`_ on a polling interval, and writes them to an Apache Kafka® topic in a standard format where they can be transformed and read by multiple consumers.
 
 .. note::
 
@@ -52,7 +52,7 @@ The command above has the following parameters:
 
 * ``<DATABASE_NAME>``, ``<SCHEMA_NAME>``, ``<TABLE_NAME>``: the references to the table where CDC needs to be setup
 * ``<ROLE_NAME>``: the database role that will have access to the change tables. Leave it ``NULL`` to only allow access to members of ``sysadmin`` or ``db_owner`` groups
-* ``<FILEGROUP_NAME>``: Specifies the `file group <https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-files-and-filegroups>`_ where the files will be written, needs to be pre-existing
+* ``<FILEGROUP_NAME>``: Specifies the `file group <https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-files-and-filegroups>`_ where the files will be written, needs to be pre-existing
 
 .. Note::
 


### PR DESCRIPTION
When make linkcheck is run, there are a lot of redirected links (search for redirect in the linkcheck output)

See https://github.com/aiven/devportal/issues/1485

Change miscellaneous permanent redirects to the new URL.

**Note:** not "fixing" those redirects that go from a generic document to a specific version, as those are quite correct.

* Fix `microsoft` redirects - mostly `docs` -> `learn`

