### PR TITLE
Adding a common troubleshooting instruction.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,7 @@ Install the dependencies::
 
     pip install -r requirements.txt
 
-.. note::
-
-    You might need to run ``brew install postgres@<VERSION>`` (or a similar command for your package manager) to install PostgreSQL® as a ``psycopg2`` build dependency. 
+**Note:** You might need to run ``brew install postgresql@14`` to install PostgreSQL 14 (or a similar command for your package manager) to install PostgreSQL® as a ``psycopg2`` build dependency. 
 
 Start the HTML version with::
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Install the dependencies::
 
     pip install -r requirements.txt
 
-**Note:** You might need to run ``brew install postgresql@14`` to install PostgreSQL 14 (or a similar command for your package manager) to install PostgreSQL® as a ``psycopg2`` build dependency. 
+**Note:** If that fails because it can't install ``psycopg2-binary``, run ``brew install postgresql@14`` to install PostgreSQL 14 (or a similar command for your package manager) and then try again.
 
 Start the HTML version with::
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ Install the dependencies::
 
     pip install -r requirements.txt
 
+.. note::
+
+    You might need to run ``brew install postgres@<VERSION>`` (or a similar command for your package manager) to install PostgreSQL® as a ``psycopg2`` build dependency. 
+
 Start the HTML version with::
 
     make livehtml


### PR DESCRIPTION
# What changed, and why it matters

It seems that we're seeing the following build error frequent enough to have the fix be part of the build instructions:

```
Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
```

I wasn't sure if I could add a `code` directive within a `note` directive so I used literal symbol for the `brew install...` command. Another option is to add a troubleshooting section somewhere else. Please suggest any change that you prefer.
