### PR TITLE
redirect test remove extension

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -3,20 +3,20 @@ http://developer.aiven.io/*  https://docs.aiven.io/:splat 301!
 https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 
 # Convenience URLs
-/kafka              /docs/products/kafka/index.html
-/postgresql         /docs/products/postgresql/index.html
-/flink              /docs/products/flink/index.html
-/clickhouse         /docs/products/clickhouse/index.html
-/opensearch         /docs/products/opensearch/index.html
-/m3db               /docs/products/m3db/index.html
-/mysql              /docs/products/mysql/index.html
-/redis              /docs/products/redis/index.html
-/cassandra          /docs/products/cassandra/index.html
-/grafana            /docs/products/grafana/index.html
+/kafka              /docs/products/kafka
+/postgresql         /docs/products/postgresql
+/flink              /docs/products/flink
+/clickhouse         /docs/products/clickhouse
+/opensearch         /docs/products/opensearch
+/m3db               /docs/products/m3db
+/mysql              /docs/products/mysql
+/redis              /docs/products/redis
+/cassandra          /docs/products/cassandra
+/grafana            /docs/products/grafana
 
-/api                /docs/tools/api/index.html
+/api                /docs/tools/api
 /cli                /docs/tools/cli.html
-/terraform          /docs/tools/terraform/index.html
+/terraform          /docs/tools/terraform
 
 # Renamed/deleted files
 /docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
@@ -54,16 +54,16 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 # Redirect from .index.html to specific page names for landing
 
 # with one section and no subsections, i. e. docs/platform
-# /docs/:section/index.html                                              /docs/:section
-# /docs/:section/index                                                   /docs/:section
-# /docs/:section/                                                        /docs/:section
+/docs/:section/index.html                                              /docs/:section
+/docs/:section/index                                                   /docs/:section
+/docs/:section/                                                        /docs/:section
 
-# # with one subsection, i. e. docs/products/cassandra
-# /docs/:section/:subsection/index.html                                  /docs/:section/:subsection
-# /docs/:section/:subsection/index                                       /docs/:section/:subsection
-# /docs/:section/:subsection/                                            /docs/:section/:subsection
+# with one subsection, i. e. docs/products/cassandra
+/docs/:section/:subsection/index.html                                  /docs/:section/:subsection
+/docs/:section/:subsection/index                                       /docs/:section/:subsection
+/docs/:section/:subsection/                                            /docs/:section/:subsection
 
-# # with a subsubsection, i. e. docs/products/opensearch/dashboards
-# /docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
-# /docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
-# /docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection
+# with a subsubsection, i. e. docs/products/opensearch/dashboards
+/docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
+/docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
+/docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection

--- a/_redirects
+++ b/_redirects
@@ -61,7 +61,7 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 # with one subsection, i. e. docs/products/cassandra
 /docs/:section/:subsection/index.html                                  /docs/:section/:subsection
 /docs/:section/:subsection/index                                       /docs/:section/:subsection
-/docs/:section/:subsection/                                            /docs/:section/:subsection
+#/docs/:section/:subsection/                                            /docs/:section/:subsection
 
 # with a subsubsection, i. e. docs/products/opensearch/dashboards
 /docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection

--- a/_redirects
+++ b/_redirects
@@ -56,14 +56,11 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 # with one section and no subsections, i. e. docs/platform
 /docs/:section/index.html                                              /docs/:section
 /docs/:section/index                                                   /docs/:section
-/docs/:section/                                                        /docs/:section
 
 # with one subsection, i. e. docs/products/cassandra
 /docs/:section/:subsection/index.html                                  /docs/:section/:subsection
 /docs/:section/:subsection/index                                       /docs/:section/:subsection
-#/docs/:section/:subsection/                                            /docs/:section/:subsection
 
 # with a subsubsection, i. e. docs/products/opensearch/dashboards
 /docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
 /docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
-/docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection

--- a/_redirects
+++ b/_redirects
@@ -54,16 +54,16 @@ https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
 # Redirect from .index.html to specific page names for landing
 
 # with one section and no subsections, i. e. docs/platform
-/docs/:section/index.html                                              /docs/:section
-/docs/:section/index                                                   /docs/:section
-/docs/:section/                                                        /docs/:section
+# /docs/:section/index.html                                              /docs/:section
+# /docs/:section/index                                                   /docs/:section
+# /docs/:section/                                                        /docs/:section
 
-# with one subsection, i. e. docs/products/cassandra
-/docs/:section/:subsection/index.html                                  /docs/:section/:subsection
-/docs/:section/:subsection/index                                       /docs/:section/:subsection
-/docs/:section/:subsection/                                            /docs/:section/:subsection
+# # with one subsection, i. e. docs/products/cassandra
+# /docs/:section/:subsection/index.html                                  /docs/:section/:subsection
+# /docs/:section/:subsection/index                                       /docs/:section/:subsection
+# /docs/:section/:subsection/                                            /docs/:section/:subsection
 
-# with a subsubsection, i. e. docs/products/opensearch/dashboards
-/docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
-/docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
-/docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection
+# # with a subsubsection, i. e. docs/products/opensearch/dashboards
+# /docs/:section/:subsection/:subsubsection/index.html                   /docs/:section/:subsection/:subsubsection
+# /docs/:section/:subsection/:subsubsection/index                        /docs/:section/:subsection/:subsubsection
+# /docs/:section/:subsection/:subsubsection/                             /docs/:section/:subsection/:subsubsection


### PR DESCRIPTION
# What changed, and why it matters
Page not found in the following url pattern is returning redirect loop:
/docs/:section -> eg: https://docs.aiven.io/docs/random
/docs/:section/:subsection -> eg: https://docs.aiven.io/docs/section/random
/docs/:section/:subsection/:subsubsection -> eg: https://docs.aiven.io/docs/section/subsection/random

[Slack comm](https://aiven-io.slack.com/archives/C02PR706PDL/p1668012109511639)

## When does the 404 stop working for above url pattern?
Since July 6 - [PR 1120](https://github.com/aiven/devportal/pull/1120) even though the PR itself has no changes affecting the redirect - [preview doesn’t return 404](https://deploy-preview-1120--developer-aiven-io-preview.netlify.app/docs/product/badger). As it was still working in [PR 1119 preview](https://deploy-preview-1119--developer-aiven-io-preview.netlify.app/docs/product/badger).

Not sure why, perhaps Netlify changes the way the redirect works with backslash within the same timeframe.

# Solution
Remove the redirect rule that causes this redirect loop. Drawback:
`/docs/:section/` will not redirect to `/docs/:section`
`/docs/:section/:subsection/ `will not redirect to `/docs/:section/:subsection`
`/docs/:section/:subsection/:subsubsection/` will not redirect to `/docs/:section/:subsection/:subsubsection`

The following preview now correctly redirect to 404:
https://deploy-preview-1555--developer-aiven-io-preview.netlify.app/docs/random
https://deploy-preview-1555--developer-aiven-io-preview.netlify.app/docs/section/random
https://deploy-preview-1555--developer-aiven-io-preview.netlify.app/docs/section/subsection/random

## Removing extra redirect chain
Removed /`index.html` from Convenience URLs to eliminate extra redirect chain. Eg:
`/kafka` currently have [2 redirect chain](https://www.redirect-checker.org/index.php)
`/kafka `-> `/docs/products/kafka/index.html` -> `/docs/products/kafka`



