### PR TITLE
Correct variable spelling

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
@@ -76,7 +76,7 @@ The connector configurations in a file (we'll refer to it with the name ``s3_sin
 .. code-block:: json
 
     {
-        "name": "<CONECTOR_NAME>",
+        "name": "<CONNECTOR_NAME>",
         "connector.class": "io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector",
         "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",
         "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
@@ -40,7 +40,7 @@ Define the connector configurations in a file (we'll refer to it with the name `
 ::
 
     {
-        "name": "<CONECTOR_NAME>",
+        "name": "<CONNECTOR_NAME>",
         "connector.class": "io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector",
         "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",
         "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",

--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-confluent.rst
@@ -36,7 +36,7 @@ Define the connector configurations in a file (we'll refer to it with the name `
 ::
 
     {
-        "name": "<CONECTOR_NAME>",
+        "name": "<CONNECTOR_NAME>",
         "topics": "<TOPIC_NAME>",
         "connector.class": "io.confluent.connect.s3.S3SinkConnector",
         "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",


### PR DESCRIPTION
# What changed, and why it matters

Spotted a tiny typo in the kafka connector config examples for S3 (at least, I think this is a correct change, but just close if not!)

