### PR TITLE
Only show top-level titles in tableofcontents output by default

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,5 +1,5 @@
 root: index
-options:
+defaults:
   maxdepth: 1
 
 entries:


### PR DESCRIPTION
# What changed, and why it matters

We need to talk about and test this one I think. There are lots of places where we use a `.. tableofcontents::` entry to list all the pages in a section, particularly the howto and concepts sections. It doesn't look really great and I'm looking at ways we can restyle it. This change switches the default to be to show only the page titles and not the subheadings on a page as a first step - my idea is that we can then try to style the list items more nicely.

Does this work? Or does it make things worse?

Example of the current state: https://docs.aiven.io/docs/products/postgresql/concepts.html
And the preview of just the pages list: https://deploy-preview-1562--developer-aiven-io-preview.netlify.app/docs/products/postgresql/concepts.html
