### PR TITLE
Make our Vale rules error rather than warn

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -146,6 +146,7 @@ Podman
 pooler
 PostgreSQL
 Postman
+preformatted
 privatelink
 Prometheus
 Protobuf

--- a/.github/vale/styles/Aiven/aiven_spelling.yml
+++ b/.github/vale/styles/Aiven/aiven_spelling.yml
@@ -4,5 +4,6 @@ message: "'%s' does not seem to be a recognised word"
 dicpath: .github/vale/dicts
 # We want to add our dictionary on top of the default dictionary
 append: true
+level: error
 dictionaries:
   - aiven

--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: "'%s' should be in sentence case"
-level: warning
+level: error
 scope: heading
 # $title, $sentence, $lower, $upper, or a pattern.
 match: $sentence

--- a/docs/products/clickhouse/howto/connect-with-go.rst
+++ b/docs/products/clickhouse/howto/connect-with-go.rst
@@ -83,7 +83,7 @@ Connect with HTTPS
 
 .. important::
 
-    The HTTPS connection is supported for the database/sql API only. By default, connections are established over the native protocol. The HTTPS connection needs to be enabled either by modifying the DSN to include the HTTPS protocol or by specifying the protocol in the connection options.
+    The HTTPS connection is supported for the database/SQL API only. By default, connections are established over the native protocol. The HTTPS connection needs to be enabled either by modifying the DSN to include the HTTPS protocol or by specifying the protocol in the connection options.
 
 Identify connection information
 '''''''''''''''''''''''''''''''

--- a/docs/products/clickhouse/howto/monitor-performance.rst
+++ b/docs/products/clickhouse/howto/monitor-performance.rst
@@ -3,14 +3,14 @@ Monitor Aiven for ClickHouse® metrics with Grafana®
 
 As well as offering ClickHouse®-as-a-service, the Aiven platform gives you access to monitor the database. The metrics/dashboard integration in the Aiven console allows you to create an integration and monitoring dashboards in Aiven for Grafana®. For more information on the metrics, see :doc:`Aiven for ClickHouse® metrics exposed in Aiven for Grafana® <../reference/metrics-list>`.
 
-Push ClickHouse® metrics to InfluxDB®, M3DB, or PostgreSQL
-----------------------------------------------------------
+Push ClickHouse® metrics to InfluxDB®, M3DB, or PostgreSQL®
+-----------------------------------------------------------
 
 To collect metrics about your ClickHouse® service, you will need to configure a metrics integration and nominate somewhere to store the collected metrics.
 
 1. On the service **Overview** page for your ClickHouse® service, go to **Manage Integrations** and choose the **Metrics** option with *Send service metrics to InfluxDB, M3DB or PostgreSQL service* as its description.
 
-2. Choose either a new or existing InfluxDB®, M3DB, or PostgreSQL service.
+2. Choose either a new or existing InfluxDB®, M3DB, or PostgreSQL® service.
 
    - If you choose to use a new service, follow instructions on :doc:`how to create a service </docs/platform/howto/create_new_service>`.
    - If you're already using InfluxDB, M3DB, or PostgreSQL on Aiven, you can submit your ClickHouse® metrics to the existing service.

--- a/docs/products/grafana/howto/replace-expression-string.rst
+++ b/docs/products/grafana/howto/replace-expression-string.rst
@@ -94,12 +94,12 @@ The change will be visible in the *Query* panel:
 * Before running the command, metrics start with ``elasticsearch_``:
 
   .. image:: /images/products/grafana/query-with-elasticsearch-prefix.png
-      :alt: A screenshot of the Grafana Dashboard query showing metrics prefixed with ``elasticsearch_``
+      :alt: A screenshot of the Grafana Dashboard query showing metrics with prefix
 
 * After running the command, metrics start with ``opensearch_``:
 
   .. image:: /images/products/grafana/query-with-opensearch-prefix.png
-      :alt: A screenshot of the Grafana Dashboard query showing metrics prefixed with ``opensearch_``
+      :alt: A screenshot of the Grafana Dashboard query showing metrics with prefix
 
 Use the version history to revert
 ---------------------------------

--- a/docs/products/kafka/howto/kafka-klaw.rst
+++ b/docs/products/kafka/howto/kafka-klaw.rst
@@ -70,8 +70,8 @@ Secret key configuration
 
 Set the value of ``klaw.clusterapi.access.base64.secret`` with a secret key in the form of a Base64 encoded string in the ``application.properties`` file located in the following paths: 
 
-* `klaw/cluter-api/src/main/resources`
-* `klaw/core/src/main/resources`
+* ``klaw/cluter-api/src/main/resources``
+* ``klaw/core/src/main/resources``
 
 Configure authentication protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -99,7 +99,7 @@ Configure SSL properties
 After retrieving the SSL certificate files and configuring the SSL keystore and truststore files, you need to configure these SSL values in the ``application.properties`` file.
 
 1. Get the **Cluster ID** by clicking the copy icon on the **Clusters** page in the **Klaw web interface**.  
-2. Next, open the application.properties file located in the **klaw/cluster-api/src/main/resources** directory. 
+2. Next, open the ``application.properties`` file located in the ``klaw/cluster-api/src/main/resources`` directory. 
 3. Configure the SSL properties to connect to Apache Kafka® clusters by editing the following lines:
 
    ::

--- a/docs/products/kafka/kafka-connect/howto/splunk-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/splunk-sink.rst
@@ -62,8 +62,8 @@ The configuration file contains the following entries:
 
 * ``name``: the connector name
 * ``splunk.hec.token`` and ``splunk.hec.uri``: remote Splunk server URI and authorization parameters collected in the :ref:`prerequisite <connect_splunk_sink_prereq>` phase. 
-* ``splunk.hec.raw``: if set to `false` defines the data ingestion using the `/raw` HEC endpoing instead of the default `/event` one.
-* ``splunk.hec.ack.enabled``: if set to `true`, Kafka offset is checkpointed only after receiving the ACK for the POST call to Splunk.
+* ``splunk.hec.raw``: if set to ``false`` defines the data ingestion using the ``/raw`` HEC endpoint instead of the default ``/event`` one.
+* ``splunk.hec.ack.enabled``: if set to ``true``, Kafka offset is updated only after receiving the ACK for the POST call to Splunk.
 * ``config.splunk.hec.json.event.formatted``:  Defines if events are preformatted into the proper `HEC JSON format <https://docs.splunk.com/Documentation/KafkaConnect/2.0.2/User/Parameters>`_.
 
 .. Tip::


### PR DESCRIPTION
# What changed, and why it matters

We have a policy of fixing all warnings - but they are easy to miss in the PR since they don't actually cause the build to fail. This bumps the severity of the rules so that these warnings must be fixed before merge.

Fixes #1481 