### PR TITLE
Fix JSON syntax error that breaks highlighting

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
@@ -78,7 +78,7 @@ The connector configurations in a file (we'll refer to it with the name ``s3_sin
     {
         "name": "<CONNECTOR_NAME>",
         "connector.class": "io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector",
-        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",
+        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
         "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
         "topics": "<TOPIC_NAME>",
         "aws.sts.role.arn": "<AWS_ROLE_ARN>",


### PR DESCRIPTION
# What changed, and why it matters

The JSON syntax was invalid and causing a warning about syntax highlighting. This fixes the stray `"` character (the small fixes are the best!)
