### PR TITLE
remove domain redirect OPS-2287

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,7 +1,3 @@
-# Domain level redirect for path forwarding
-http://developer.aiven.io/*  https://docs.aiven.io/:splat 301!
-https://developer.aiven.io/* https://docs.aiven.io/:splat 301!
-
 # Convenience URLs
 /kafka              /docs/products/kafka
 /postgresql         /docs/products/postgresql


### PR DESCRIPTION
# What changed, and why it matters
Currently, we are using Netlify _redirect.txt from [domain level redirect](https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects), however since we are moving to Cloudflare Pages by end of Nov, it [doesn’t support domain level redirect](https://developers.cloudflare.com/pages/platform/redirects/). For that, we would need to rely on Route 53 to do the redirect. Related ticket [OPS-2287](https://aiven.atlassian.net/browse/OPS-2287)

# When to merge this PR
Once the domain level path forwarding redirect [PR](https://github.com/aiven/cloud_infra_tf_aiven/pull/143) is merged.

