### PR TITLE
Adding link on how to create the token.

### DIFF
--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -57,4 +57,4 @@ It is also good practice to rotate your authorization tokens on a regular basis,
 
 .. note::
 
-    Follow :doc:`Create an authentication token <../howto/create_authentication_token>` to check how you can create an authentication token from the Aiven console or the Aiven CLI.
+    Follow :doc:`Create an authentication token <../howto/create_authentication_token>` to create an authentication token from the Aiven console or the Aiven CLI.

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -54,3 +54,4 @@ Rotate tokens regularly
 
 It is also good practice to rotate your authorization tokens on a regular basis, for example each month. You can have as many tokens active at one time as you need, so you can create a new token, replace it as needed, check everything works, and then remove the old token once you are confident that all changes have completed successfully.
 
+Follow :doc:`Create an authentication token <../howto/create_authentication_token>` to check how you can create an authentication token from the Aiven console or the Aiven CLI.

--- a/docs/platform/concepts/authentication-tokens.rst
+++ b/docs/platform/concepts/authentication-tokens.rst
@@ -54,4 +54,7 @@ Rotate tokens regularly
 
 It is also good practice to rotate your authorization tokens on a regular basis, for example each month. You can have as many tokens active at one time as you need, so you can create a new token, replace it as needed, check everything works, and then remove the old token once you are confident that all changes have completed successfully.
 
-Follow :doc:`Create an authentication token <../howto/create_authentication_token>` to check how you can create an authentication token from the Aiven console or the Aiven CLI.
+
+.. note::
+
+    Follow :doc:`Create an authentication token <../howto/create_authentication_token>` to check how you can create an authentication token from the Aiven console or the Aiven CLI.


### PR DESCRIPTION
# What changed, and why it matters

https://docs.aiven.io/docs/platform/concepts/authentication-tokens.html has the concepts but this page should also contain a link on how to actually create the token.

This PR fixes this gap.
