### PR TITLE
Changed reference to docker image

### DIFF
--- a/docs/products/clickhouse/howto/connect-with-clickhouse-cli.rst
+++ b/docs/products/clickhouse/howto/connect-with-clickhouse-cli.rst
@@ -6,7 +6,7 @@ It's recommended to connect to a ClickHouse® cluster with the ClickHouse® clie
 Use the ClickHouse® client
 --------------------------
 
-To use the ClickHouse® client across different operating systems, we recommend utilizing `Docker <https://www.docker.com/>`_. You can get the latest image of the ClickHouse Server which contains the most recent ClickHouse Client directly from `the dedicated page in Docker hub <https://hub.docker.com/r/clickhouse/clickhouse-server>`_.
+To use the ClickHouse® client across different operating systems, we recommend utilizing `Docker <https://www.docker.com/>`_. You can get the latest image of the ClickHouse server which contains the most recent ClickHouse client directly from `the dedicated page in Docker hub <https://hub.docker.com/r/clickhouse/clickhouse-server>`_.
 
 .. note::
 

--- a/docs/products/clickhouse/howto/connect-with-clickhouse-cli.rst
+++ b/docs/products/clickhouse/howto/connect-with-clickhouse-cli.rst
@@ -6,7 +6,7 @@ It's recommended to connect to a ClickHouse® cluster with the ClickHouse® clie
 Use the ClickHouse® client
 --------------------------
 
-To use the ClickHouse® client across different operating systems, we recommend utilizing `Docker <https://www.docker.com/>`_. You can get the latest image of the ClickHouse client directly from `the dedicated page in Docker hub <https://hub.docker.com/r/clickhouse/clickhouse-client>`_.
+To use the ClickHouse® client across different operating systems, we recommend utilizing `Docker <https://www.docker.com/>`_. You can get the latest image of the ClickHouse Server which contains the most recent ClickHouse Client directly from `the dedicated page in Docker hub <https://hub.docker.com/r/clickhouse/clickhouse-server>`_.
 
 .. note::
 
@@ -25,7 +25,7 @@ The command to connect to the service looks like this, substitute the placeholde
 .. code:: bash
 
     docker run -it \
-    --rm clickhouse/clickhouse-client \
+    --rm clickhouse/clickhouse-server clickhouse-client \
     --user USERNAME \
     --password PASSWORD \
     --host HOST \
@@ -48,7 +48,7 @@ Alternatively, sometimes you might want to run individual queries and be able to
 .. code:: bash
 
     docker run --interactive            \
-    --rm clickhouse/clickhouse-client   \
+    --rm clickhouse/clickhouse-server clickhouse-client \
     --user USERNAME                     \
     --password PASSWORD                 \
     --host HOST                         \
@@ -59,7 +59,7 @@ Alternatively, sometimes you might want to run individual queries and be able to
 Similar to above example, you can request the list of present databases directly::
 
     docker run --interactive            \
-    --rm clickhouse/clickhouse-client   \
+    --rm clickhouse/clickhouse-server clickhouse-client \
     --user USERNAME                     \
     --password PASSWORD                 \
     --host HOST                         \

--- a/docs/products/clickhouse/howto/load-dataset.rst
+++ b/docs/products/clickhouse/howto/load-dataset.rst
@@ -46,7 +46,7 @@ To connect to the server, use the connection details that you can find in the *C
 .. code:: bash
 
     docker run --interactive            \
-    --rm clickhouse/clickhouse-client   \
+    --rm clickhouse/clickhouse-server clickhouse-client   \
     --user USERNAME                     \
     --password PASSWORD                 \
     --host HOST                         \
@@ -83,7 +83,7 @@ Now that you have a dataset with two empty tables, we'll load data into each of 
 
         cat hits_v1.tsv | docker run        \
         --interactive                       \
-        --rm clickhouse/clickhouse-client   \
+        --rm clickhouse/clickhouse-server clickhouse-client  \
         --user USERNAME                     \
         --password PASSWORD                 \
         --host HOST                         \
@@ -98,7 +98,7 @@ Now that you have a dataset with two empty tables, we'll load data into each of 
 
         cat visits_v1.tsv | docker run      \
         --interactive                       \
-        --rm clickhouse/clickhouse-client   \
+        --rm clickhouse/clickhouse-server clickhouse-client   \
         --user USERNAME                     \
         --password PASSWORD                 \
         --host HOST                         \

--- a/docs/products/clickhouse/sample-dataset.rst
+++ b/docs/products/clickhouse/sample-dataset.rst
@@ -46,7 +46,7 @@ To connect to the server, use the connection details that you can find in the *C
 .. code:: bash
 
     docker run --interactive            \
-    --rm clickhouse/clickhouse-client   \
+    --rm clickhouse/clickhouse-server clickhouse-client   \
     --user USERNAME                     \
     --password PASSWORD                 \
     --host HOST                         \
@@ -83,7 +83,7 @@ Now that you have a dataset with two empty tables, we'll inject data into each o
 
         cat hits_v1.tsv | docker run        \
         --interactive                       \
-        --rm clickhouse/clickhouse-client   \
+        --rm clickhouse/clickhouse-server clickhouse-client   \
         --user USERNAME                     \
         --password PASSWORD                 \
         --host HOST                         \
@@ -98,7 +98,7 @@ Now that you have a dataset with two empty tables, we'll inject data into each o
 
         cat visits_v1.tsv | docker run      \
         --interactive                       \
-        --rm clickhouse/clickhouse-client   \
+        --rm clickhouse/clickhouse-server clickhouse-client   \
         --user USERNAME                     \
         --password PASSWORD                 \
         --host HOST                         \


### PR DESCRIPTION
# What changed, and why it matters

Changed references to clickhouse-client docker image to clickhouse-server image as recommended by clickhouse docker page, https://hub.docker.com/r/clickhouse/clickhouse-client

The clickhouse-client docker image is no longer being updated.  In addition, the clickhouse-client image will not run on Apple M1, whereas the clickhouse-server image is supported on both Apple processors.



