### PR TITLE
Add Avro to supported ClickHouse-Kafka exchange formats

### DIFF
--- a/docs/products/clickhouse/reference/supported-input-output-formats.rst
+++ b/docs/products/clickhouse/reference/supported-input-output-formats.rst
@@ -4,16 +4,21 @@ Formats for ClickHouse®-Kafka® data exchange
 When connecting ClickHouse® to Kafka® using Aiven integrations, data exchange is possible with the following formats only:
 
 ============================     ====================================================================================
-Format name                      Example
+Format name                      Notes
 ============================     ====================================================================================
-CSV                              ``123,"Hello"``
-JSONASString                     ``{"x":123,"y":"hello"}``
-JSONCompactEachRow               ``[123,"Hello"]``
-JSONCompactStringsEachRow        ``["123","Hello"]``
-JSONEachRow                      ``{"x":123,"y":"hello"}``
-JSONStringsEachRow               ``{"x":"123","y":"hello"}``
-MsgPack                          ``{\xc4\x05hello``
-TSKV                             ``x=123\ty=hello``
-TSV                              ``123\thello``
-TabSeparated                     ``123\thello``
+Avro                             Only supports binary Avro format with embedded schema.
+
+                                 Libraries and documentation: https://avro.apache.org/
+CSV                              Example: ``123,"Hello"``
+JSONASString                     Example: ``{"x":123,"y":"hello"}``
+JSONCompactEachRow               Example: ``[123,"Hello"]``
+JSONCompactStringsEachRow        Example: ``["123","Hello"]``
+JSONEachRow                      Example: ``{"x":123,"y":"hello"}``
+JSONStringsEachRow               Example: ``{"x":"123","y":"hello"}``
+MsgPack                          Example: ``{\xc4\x05hello``
+
+                                 Libraries and documentation: https://msgpack.org/
+TSKV                             Example: ``x=123\ty=hello``
+TSV                              Example: ``123\thello``
+TabSeparated                     Example: ``123\thello``
 ============================     ====================================================================================


### PR DESCRIPTION
# What changed, and why it matters
Add Avro to the list of formats.

The binary format for Avro is way too long to fit in the documentation.
Instead I added a note and moved the example label.


