### PR TITLE
Add explicit beta tags for Flink and ClickHouse

### DIFF
--- a/docs/products/clickhouse.rst
+++ b/docs/products/clickhouse.rst
@@ -1,5 +1,5 @@
 ClickHouse® |beta|
-===================================================================
+==================
 
 .. note::
    The Aiven for ClickHouse® service is currently available as a beta release and is intended for **non-production use**.

--- a/docs/products/clickhouse/getting-started.rst
+++ b/docs/products/clickhouse/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started with Aiven for ClickHouse®
-==========================================
+Getting started with Aiven for ClickHouse® |beta|
+=================================================
 
 The first step in using Aiven for ClickHouse® is to create a service and a database that you can use to try out the service. You can do this in the `Aiven web console <https://console.aiven.io/>`_.
 

--- a/docs/products/flink/getting-started.rst
+++ b/docs/products/flink/getting-started.rst
@@ -1,5 +1,5 @@
-Getting started with Aiven for Apache Flink®
-============================================
+Getting started with Aiven for Apache Flink® |beta|
+===================================================
 
 The first step in using Aiven for Apache Flink® is to create a service. You can do this in the `Aiven web console <https://console.aiven.io/>`_ or with the `Aiven CLI <https://github.com/aiven/aiven-client>`_.
 


### PR DESCRIPTION
This is a request from support to make it
more visible that those products are on beta
stage. Helps to manage expectations between
our clients and our support team about those
two products.

Fixes: https://github.com/aiven/devportal/issues/1512


