### PR TITLE
Add doc on searching and filtering services in Console

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -54,6 +54,7 @@ DSBulk
 Elasticsearch
 Epicurious
 etcd
+Exoscale
 failover
 fileset
 filesets
@@ -207,6 +208,7 @@ VM
 VMs
 VPC
 VNet
+Vultr
 wget
 Workbench
 Worldmap

--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -54,7 +54,6 @@ DSBulk
 Elasticsearch
 Epicurious
 etcd
-Exoscale
 failover
 fileset
 filesets
@@ -208,7 +207,6 @@ VM
 VMs
 VPC
 VNet
-Vultr
 wget
 Workbench
 Worldmap

--- a/_toc.yml
+++ b/_toc.yml
@@ -64,6 +64,7 @@ entries:
           - file: docs/platform/howto/recover-a-deleted-service
           - file: docs/platform/howto/add-storage-space
           - file: docs/platform/howto/tag-resources
+          - file: docs/platform/howto/search-services
           - file: docs/platform/howto/access-service-logs
           - file: docs/platform/howto/prepare-for-high-load
       - file: docs/platform/howto/list-network

--- a/_toc.yml
+++ b/_toc.yml
@@ -65,6 +65,7 @@ entries:
           - file: docs/platform/howto/add-storage-space
           - file: docs/platform/howto/tag-resources
           - file: docs/platform/howto/search-services
+            title: Search for services
           - file: docs/platform/howto/access-service-logs
           - file: docs/platform/howto/prepare-for-high-load
       - file: docs/platform/howto/list-network

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -1,0 +1,3 @@
+Search for services in Aiven Console
+====================================
+

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -1,3 +1,112 @@
 Search for services in Aiven Console
 ====================================
 
+On the **Current services** page in `Aiven Console <https://console.aiven.io/>`_ you can search for services by keywords and narrow down the results using filters.
+
+Search by keyword
+------------------
+
+When you search by keyword, Aiven Console will show all services that have the maching words in the service name, plan, cloud, and tags.
+
+Filter search results
+----------------------
+
+You can narrow down your search results by clicking **Filter list** and selecting the services, statuses, and providers to filter.
+
+You can also add filters to the search box yourself. The supported filters are:
+
+* ``service``
+* ``status``
+* ``provider``
+* ``region``
+
+For example, to filter the services to show all running PostgreSQL services that are hosted on AWS or Google Cloud::
+
+    service:pg status:running provider:aws,google
+
+You can use these filters alongside keywords. For example::
+
+    prod service:kafka status:poweroff provider:google,azure
+
+
+Filter by service type
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :align: left
+    :widths: 50 25
+    :header-rows: 1
+
+    * - Service name
+      - Filter value
+    * - Cassandra
+      - cassandra 
+    * - ClickHouse
+      - clickhouse
+    * - Flink
+      - flink
+    * - Grafana
+      - grafana
+    * - InfluxDB
+      - influxdb
+    * - Kafka
+      - kafka   
+    * - M3DB
+      - m3db
+    * - M3 Aggregator
+      - m3aggregator 
+    * - M3 Coordinator
+      - m3coordinator
+    * - MySQL
+      - mysql 
+    * - OpenSearch
+      - opensearch 
+    * - PostgreSQL
+      - pg 
+    * - Redis
+      - redis  
+
+
+
+
+Filter by status
+~~~~~~~~~~~~~~~~~
+The values supported for the ``status`` filter are:
+
+* running
+* poweroff
+* rebuilding
+* rebalancing
+
+Filter by cloud provider
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. list-table::
+    :align: left
+    :widths: 50 25
+    :header-rows: 1
+
+    * - Cloud provider
+      - Filter value
+    * - Amazon Web Services (AWS)
+      - aws 
+    * - Azure
+      - azure 
+    * - Digital Ocean
+      - do 
+    * - Google Cloud Provider (GCP)
+      - google
+    * - Exoscale
+      - exoscale 
+    * - UpCloud
+      - upcloud 
+    * - Vultr
+      - vultr
+
+Filter by cloud region
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The supported values for the ``region`` filter are on the :doc:`List of available cloud regions </docs/platform/reference/list_of_clouds>` page. For example, to see all services in the AWS region eu-central-1 you would use this filter::
+
+    region:aws-eu-central-1
+
+

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -20,11 +20,11 @@ You can also add filters to the search field yourself. The supported filters are
 * ``provider``
 * ``region``
 
-You can add multiple values to filters separated by a comma. For example, this is how you would view all running PostgreSQL services that are hosted on AWS or Google Cloud::
+You can add multiple values to filters separated by a comma. For example, this is how you would view all running PostgreSQL® services that are hosted on AWS or Google Cloud::
 
     service:pg status:running provider:aws,google
 
-You can use these filters alongside keyword searches. For example, to see all powered off Kafka services with "production" in the name you could use::
+You can use these filters alongside keyword searches. For example, to see all powered off Kafka® services with "production" in the name you could use::
 
     production service:kafka status:poweroff 
 
@@ -65,7 +65,7 @@ To filter the services by service type, use the filter values in this table.
       - ``opensearch`` 
     * - PostgreSQL®
       - ``pg`` 
-    * - Redis®
+    * - Redis®*
       - ``redis``  
 
 

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -41,24 +41,24 @@ To filter the services by service type, use the filter values in this table.
 
     * - Service name
       - Filter value
-    * - Cassandra®
+    * - Apache Cassandra®
       - ``cassandra`` 
-    * - ClickHouse®
-      - ``clickhouse``
-    * - Flink®
+    * - Apache Flink®
       - ``flink``
+    * - Apache Kafka®
+      - ``kafka``
+    * - ClickHouse®
+      - ``clickhouse``  
     * - Grafana®
       - ``grafana``
     * - InfluxDB®
       - ``influxdb``
-    * - Kafka®
-      - ``kafka``
-    * - M3DB®
-      - ``m3db``
     * - M3 Aggregator®
       - ``m3aggregator`` 
     * - M3 Coordinator®
       - ``m3coordinator``
+    * - M3DB®
+      - ``m3db``
     * - MySQL®
       - ``mysql`` 
     * - OpenSearch®

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -6,31 +6,33 @@ On the **Current services** page in `Aiven Console <https://console.aiven.io/>`_
 Search by keyword
 ------------------
 
-When you search by keyword, Aiven Console will show all services that have the maching words in the service name, plan, cloud, and tags.
+When you search by keyword, Aiven Console will show all services that have the matching words in the service name, plan, cloud provider, and tags.
 
 Filter search results
 ----------------------
 
-You can narrow down your search results by clicking **Filter list** and selecting the services, statuses, and providers to filter.
+You can narrow down your search results by clicking **Filter list** and selecting the services, statuses, and providers to filter by.
 
-You can also add filters to the search box yourself. The supported filters are:
+You can also add filters to the search field yourself. The supported filters are:
 
 * ``service``
 * ``status``
 * ``provider``
 * ``region``
 
-For example, to filter the services to show all running PostgreSQL services that are hosted on AWS or Google Cloud::
+You can add multiple values to filters separated by a comma. For example, this is how you would view all running PostgreSQL services that are hosted on AWS or Google Cloud::
 
     service:pg status:running provider:aws,google
 
-You can use these filters alongside keywords. For example::
+You can use these filters alongside keyword searches. For example, to see all powered off Kafka services with "production" in the name you could use::
 
-    prod service:kafka status:poweroff provider:google,azure
+    production service:kafka status:poweroff 
 
 
 Filter by service type
 ~~~~~~~~~~~~~~~~~~~~~~~
+
+To filter the services by service type, use the filter values in this table.
 
 .. list-table::
     :align: left
@@ -39,47 +41,49 @@ Filter by service type
 
     * - Service name
       - Filter value
-    * - Cassandra
+    * - Cassandra®
       - cassandra 
-    * - ClickHouse
+    * - ClickHouse®
       - clickhouse
-    * - Flink
+    * - Flink®
       - flink
-    * - Grafana
+    * - Grafana®
       - grafana
-    * - InfluxDB
+    * - InfluxDB®
       - influxdb
-    * - Kafka
+    * - Kafka®
       - kafka   
-    * - M3DB
+    * - M3DB®
       - m3db
-    * - M3 Aggregator
+    * - M3 Aggregator®
       - m3aggregator 
-    * - M3 Coordinator
+    * - M3 Coordinator®
       - m3coordinator
-    * - MySQL
+    * - MySQL®
       - mysql 
-    * - OpenSearch
+    * - OpenSearch®
       - opensearch 
-    * - PostgreSQL
+    * - PostgreSQL®
       - pg 
-    * - Redis
+    * - Redis®
       - redis  
-
-
 
 
 Filter by status
 ~~~~~~~~~~~~~~~~~
-The values supported for the ``status`` filter are:
+You can filter the services to show only those that are running, powered off, rebuilding, or rebalancing. The values supported for the ``status`` filter are:
 
 * running
 * poweroff
 * rebuilding
 * rebalancing
 
+
 Filter by cloud provider
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+To filter the services by the cloud provider they are hosted on, use the filter values in this table.
+
 .. list-table::
     :align: left
     :widths: 50 25
@@ -102,11 +106,10 @@ Filter by cloud provider
     * - Vultr
       - vultr
 
+
 Filter by cloud region
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The supported values for the ``region`` filter are on the :doc:`List of available cloud regions </docs/platform/reference/list_of_clouds>` page. For example, to see all services in the AWS region eu-central-1 you would use this filter::
+The supported values for the ``region`` filter are in the **Cloud** column of the tables on the :doc:`List of available cloud regions </docs/platform/reference/list_of_clouds>` page. For example, to see all services in the AWS eu-central-1 region you would use this filter::
 
     region:aws-eu-central-1
-
-

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -99,12 +99,8 @@ To filter the services by the cloud provider they are hosted on, use the filter 
       - ``do``
     * - Google Cloud Provider (GCP)
       - ``google``
-    * - Exoscale
-      - ``exoscale``
     * - UpCloud
       - ``upcloud``
-    * - Vultr
-      - ``vultr``
 
 
 Filter by cloud region

--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -42,41 +42,41 @@ To filter the services by service type, use the filter values in this table.
     * - Service name
       - Filter value
     * - Cassandra®
-      - cassandra 
+      - ``cassandra`` 
     * - ClickHouse®
-      - clickhouse
+      - ``clickhouse``
     * - Flink®
-      - flink
+      - ``flink``
     * - Grafana®
-      - grafana
+      - ``grafana``
     * - InfluxDB®
-      - influxdb
+      - ``influxdb``
     * - Kafka®
-      - kafka   
+      - ``kafka``
     * - M3DB®
-      - m3db
+      - ``m3db``
     * - M3 Aggregator®
-      - m3aggregator 
+      - ``m3aggregator`` 
     * - M3 Coordinator®
-      - m3coordinator
+      - ``m3coordinator``
     * - MySQL®
-      - mysql 
+      - ``mysql`` 
     * - OpenSearch®
-      - opensearch 
+      - ``opensearch`` 
     * - PostgreSQL®
-      - pg 
+      - ``pg`` 
     * - Redis®
-      - redis  
+      - ``redis``  
 
 
 Filter by status
 ~~~~~~~~~~~~~~~~~
 You can filter the services to show only those that are running, powered off, rebuilding, or rebalancing. The values supported for the ``status`` filter are:
 
-* running
-* poweroff
-* rebuilding
-* rebalancing
+* ``running``
+* ``poweroff``
+* ``rebuilding``
+* ``rebalancing``
 
 
 Filter by cloud provider
@@ -92,24 +92,24 @@ To filter the services by the cloud provider they are hosted on, use the filter 
     * - Cloud provider
       - Filter value
     * - Amazon Web Services (AWS)
-      - aws 
+      - ``aws``
     * - Azure
-      - azure 
+      - ``azure``
     * - Digital Ocean
-      - do 
+      - ``do``
     * - Google Cloud Provider (GCP)
-      - google
+      - ``google``
     * - Exoscale
-      - exoscale 
+      - ``exoscale``
     * - UpCloud
-      - upcloud 
+      - ``upcloud``
     * - Vultr
-      - vultr
+      - ``vultr``
 
 
 Filter by cloud region
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The supported values for the ``region`` filter are in the **Cloud** column of the tables on the :doc:`List of available cloud regions </docs/platform/reference/list_of_clouds>` page. For example, to see all services in the AWS eu-central-1 region you would use this filter::
+The supported values for the ``region`` filter are in the **Cloud** column of the tables on the :doc:`List of available cloud regions </docs/platform/reference/list_of_clouds>` page. For example, to see all services in the AWS ``eu-central-1`` region you would use this filter::
 
     region:aws-eu-central-1


### PR DESCRIPTION
# What changed, and why it matters
Added a new article about how to search for and filter services in the Aiven Console. This includes some advanced search parameters that uses can manually enter into the search field.

Note: These filters are supported when manually entered, but the list of filters that can be selected is currently being worked on. This article can be published when that is released.

Resolves #1565 

