### PR TITLE
Fix bugs on mobile screen [STORM-617]

### DIFF
--- a/_static/css/aiven.css
+++ b/_static/css/aiven.css
@@ -275,7 +275,7 @@ a {
 }
 
 .sidebar-search-container::before {
-  z-index: 99;
+  z-index: 11;
 }
 
 .card {
@@ -419,6 +419,7 @@ h3 > code > .pre {
     gap: var(--sidebar-item-spacing-vertical);
     padding: var(--sidebar-item-spacing-vertical)
       var(--sidebar-item-spacing-horizontal);
+    margin-bottom: 200px;
   }
 
   .mobile-sidebar-actions .topnavbar-button-large {


### PR DESCRIPTION
- main page content search bars icon was visible through sidebar
- user was not able to scroll the mobile sidebar all the way so they could actually click the bottom buttons
