### PR TITLE
Remove requirement for psycopg2-binary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,6 @@ Install the dependencies::
 
     pip install -r requirements.txt
 
-**Note:** If that fails because it can't install ``psycopg2-binary``, run ``brew install postgresql@14`` to install PostgreSQL 14 (or a similar command for your package manager) and then try again.
-
 Start the HTML version with::
 
     make livehtml

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ sphinx_gitstamp==0.3.2
 beautifulsoup4==4.9.3
 opensearch-py==1.0.0
 requests==2.25.1
-psycopg2-binary==2.9.1
 sphinxext-opengraph==0.4.2
 sphinx-sitemap==2.2.0
 sphinx-notfound-page==0.8

--- a/scripts/create_feedback_table.py
+++ b/scripts/create_feedback_table.py
@@ -1,5 +1,13 @@
 import argparse
-import psycopg2
+try:
+    import psycopg2
+except ImportError as e:
+    print(e)
+    print('To run this script, install psycopg2-binary. For instance:')
+    print('    pip install psycopg2-binary')
+    print('On some platforms, you may need to install PostgreSQL using your system')
+    print('package manager to make that work')
+    exit(1)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--pg-url', help='PostgreSQL URL')


### PR DESCRIPTION
The `psycopg` module is only needed by one script, which is not expected to be used in normal use cases. Unfortunately, on current M1 macs, installing psycopg2-binary can be a problem. So move addressing the problem into the script.

Fixes https://github.com/aiven/devportal/issues/1507

**Note** also adds a newline to the end of the script - this should be there anyway.

