### PR TITLE
Updating provider and service versions.

### DIFF
--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -34,7 +34,7 @@ Add the following to a new ``provider.tf`` file:
      required_providers {
        aiven = {
          source  = "aiven/aiven"
-         version = ">= 3.1"
+         version = "~> 3.8.1"
        }
      }
    }

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -34,7 +34,7 @@ Add the following to a new ``provider.tf`` file:
      required_providers {
        aiven = {
          source  = "aiven/aiven"
-         version = "~> 3.8.1"
+         version = "~> 3.9.0"
        }
      }
    }

--- a/docs/tools/terraform/howto/config-postgresql-provider.rst
+++ b/docs/tools/terraform/howto/config-postgresql-provider.rst
@@ -18,7 +18,7 @@ The new provider must be added to the ``required_providers`` block in the Terraf
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = ">= 3.1"
+          version = "~> 3.8.1"
         }
         postgresql = {
           source  = "cyrilgdn/postgresql"

--- a/docs/tools/terraform/howto/config-postgresql-provider.rst
+++ b/docs/tools/terraform/howto/config-postgresql-provider.rst
@@ -18,7 +18,7 @@ The new provider must be added to the ``required_providers`` block in the Terraf
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = "~> 3.8.1"
+          version = "~> 3.9.0"
         }
         postgresql = {
           source  = "cyrilgdn/postgresql"

--- a/docs/tools/terraform/howto/upgrade-provider-v2-v3.rst
+++ b/docs/tools/terraform/howto/upgrade-provider-v2-v3.rst
@@ -25,7 +25,7 @@ the Aiven Terraform Provider (v3.8.1 at the time of writing):
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = ">= 3.8.1"
+          version = ">= 3.9.0"
         }
       }
     }

--- a/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
@@ -40,7 +40,7 @@ Configure common files
 	 required_providers {
 	   aiven = {
 	     source  = "aiven/aiven"
-	     version = ">= 3.8"
+	     version = "~> 3.8.1"
 	   }
 	 }
        }

--- a/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
@@ -88,7 +88,7 @@ Configure the ``services.tf`` file as follows:
   resource "aiven_clickhouse" "clickhouse" {
     project                 = var.project_name
     cloud_name              = "google-europe-west1"
-    plan                    = "startup-16"
+    plan                    = "startup-beta-16" // A special plan name for the product being in beta
     service_name            = "clickhouse-gcp-eu"
     maintenance_window_dow  = "monday"
     maintenance_window_time = "10:00:00"

--- a/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
@@ -40,7 +40,7 @@ Configure common files
 	 required_providers {
 	   aiven = {
 	     source  = "aiven/aiven"
-	     version = "~> 3.8.1"
+	     version = "~> 3.9.0"
 	   }
 	 }
        }

--- a/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -105,7 +105,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     maintenance_window_time = "10:00:00"
   
     m3db_user_config {
-      m3db_version = 1.1
+      m3db_version = 1.5
   
       namespaces {
         name = "my_ns1"

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -89,7 +89,7 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
       kafka_user_config {
         kafka_connect = true
         kafka_rest    = true
-        kafka_version = "3.0"
+        kafka_version = "3.2"
         kafka {
           group_max_session_timeout_ms = 70000
           log_retention_bytes          = 1000000000
@@ -169,7 +169,7 @@ Here is the sample Terraform file to stand-up and connect all the services. Keep
       maintenance_window_dow  = "monday"
       maintenance_window_time = "10:00:00"
       opensearch_user_config {
-        opensearch_version = "1"
+        opensearch_version = "2"
       }
     }
     

--- a/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -44,7 +44,7 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -44,7 +44,7 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -121,7 +121,7 @@ The ``services.tf`` file for the provisioning of these three services, service i
   resource "aiven_kafka_connect" "demo-kafka-connect" {
     project                 = var.project_name
     cloud_name              = "google-europe-north1"
-    project_vpc_id          = "proj1-demo/01a413b4-36df-4b1b-a697-fd7f87833494"
+    project_vpc_id          = "PROJECT_NAME/ABCD1234-AB12-AB12-AB12-ABCDEF123456"
     plan                    = "startup-4"
     service_name            = "demo-kafka-connect"
     maintenance_window_dow  = "monday"

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -40,7 +40,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -92,6 +92,17 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     cloud_name   = "google-europe-west1"
     plan         = "business-8"
     service_name = "demo-kafka"
+  
+    kafka_user_config {
+        kafka_connect = true
+        kafka_rest    = true
+        kafka_version = "3.2"
+        kafka {
+          group_max_session_timeout_ms = 70000
+          log_retention_bytes          = 1000000000
+        }
+      }
+  
   }
   
   resource "aiven_service_integration" "flink_to_kafka" {

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -94,8 +94,8 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
     service_name = "demo-kafka"
   
     kafka_user_config {
-        kafka_connect = true
-        kafka_rest    = true
+        kafka_connect = false
+        kafka_rest    = false
         kafka_version = "3.2"
         kafka {
           group_max_session_timeout_ms = 70000

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -40,7 +40,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
@@ -32,7 +32,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -82,7 +82,7 @@ Here is the sample Terraform file to stand-up a single Apache Kafka server and c
      maintenance_window_dow  = "monday"
      maintenance_window_time = "10:00:00"
      kafka_user_config {
-       kafka_version = "3.1"
+       kafka_version = "3.2"
        // Enables Karapace Schema Registry and REST
        schema_registry = true
        kafka_rest      = true

--- a/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
@@ -32,7 +32,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -57,7 +57,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -57,7 +57,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -165,7 +165,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     maintenance_window_time = "10:00:00"
   
     kafka_user_config {
-      kafka_version = "3.1"
+      kafka_version = "3.2"
       kafka {
         group_max_session_timeout_ms = 70000
         log_retention_bytes          = 1000000000
@@ -190,7 +190,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     maintenance_window_time = "10:00:00"
   
     kafka_user_config {
-      kafka_version = "3.1"
+      kafka_version = "3.2"
       kafka {
         group_max_session_timeout_ms = 70000
         log_retention_bytes          = 1000000000

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -42,7 +42,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }
@@ -104,7 +104,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
     kafka_user_config {
       kafka_connect = true
       kafka_rest    = true
-      kafka_version = "3.1"
+      kafka_version = "3.2"
       kafka {
         auto_create_topics_enable = true
       }

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -42,7 +42,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -48,7 +48,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = ">= 3.7"
+             version = "~> 3.8.1"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -48,7 +48,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.9.0"
            }
          }
        }


### PR DESCRIPTION
# What changed, and why it matters


This PR updates Aiven Terraform Provider and Aiven product versions. The new versioning practice for the provider is `~> X.Y.Z` rather than `>= X.Y.Z` which allows the patch version to be greater than Z but requires the major and minor versions (X.Y) to match the version that the configuration specifies. 

The product versions are updated to their latest available versions.