### PR TITLE
Clean up linkcheck workflow

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -24,15 +24,6 @@ jobs:
         id: run_tests
         run: |
           make linkcheck > logs.txt || echo "OUTPUT=$(grep -E "broken" logs.txt | tr '\n' '@' | sed 's/@/<br>/g' | sed 's/broken/*\*`broken`\*\*/g' | sed $'s/\e\\[[0-9;:]*[a-zA-Z]//g')" >> $GITHUB_ENV
-
-      - name: Create Issue
-        if: "${{ env.RES != '' }}"
-        uses: dblock/create-a-github-issue@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/ISSUE_TEMPLATE/linkcheck_report.md
-
       - name: Create Issue
         if: "${{ env.OUTPUT != '' }}"
         uses: dblock/create-a-github-issue@v3
@@ -40,5 +31,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/ISSUE_TEMPLATE/linkcheck_report.md
-
       - run: echo {{ env.OUTPUT }}


### PR DESCRIPTION
This is step is not needed and
it was added by mistake. Removig because
it is not needed and takes longer to run with
it.




