### PR TITLE
Fixing build warnings and errors.

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -625,7 +625,7 @@ entries:
                 title: Connect to Grafana
               - file: docs/products/clickhouse/howto/integrate-kafka
                 title: Connect to Apache Kafka
-              - file: docs/products/clickhouse/howto/integrate-karka-terraform
+              - file: docs/products/clickhouse/howto/integrate-kafka-terraform
                 title: Connect to Kafka with Terraform
               - file: docs/products/clickhouse/howto/integrate-postgresql
                 title: Connect to PostgreSQL

--- a/docs/platform/howto/disable-platform-authentication.rst
+++ b/docs/platform/howto/disable-platform-authentication.rst
@@ -5,13 +5,13 @@ If you have already :doc:`set up a SAML authentication <saml/saml-authentication
 
 Here are the steps to follow to disable platform authentication:
 
-1. Log in to the `Aiven Console<https://console.aiven.io/>`_ using your alternative authentication (for example, SAML) method. 
+1. Log in to the `Aiven Console <https://console.aiven.io/>`_ using your alternative authentication (for example, SAML) method. 
 
 .. warning::
 
    You must not be logged in with any open sessions using the password-based platform authentication.
    
-2. From the top-right corner of the `Aiven Console<https://console.aiven.io/>`_, click on **User information** and then click **Authentication** tab.
+2. From the top-right corner of the `Aiven Console <https://console.aiven.io/>`_, click on **User information** and then click **Authentication** tab.
 
 3. Use the toggle switch under the *Authentication methods* section to turn off platform authentication for the **Aiven Password** method.
 


### PR DESCRIPTION
# What changed, and why it matters

This PR addresses some final naming and referencing issues that were causing the `make linkcheck` to show warnings.

Hi @harshini-rangaswamy the other changes on the PR is not related to you but I'm tagging you for your input on the following file:

```
/Users/dewan.ahmed/code/github.com/devportal/docs/products/clickhouse/howto/integrate-kafka.rst:186: WARNING: duplicate label reference, other instance in /Users/dewan.ahmed/code/github.com/devportal/docs/tools/terraform/reference.rst
/Users/dewan.ahmed/code/github.com/devportal/docs/products/kafka/howto/kafka-klaw.rst:2: WARNING: Duplicate explicit target name: "klaw documentation".
```

I think this results when an anchor tag is used within reST/Sphinx and Sphinx gets confused on the reference i.e. it's thinking **Klaw documentation** on lines 54 and 139 as duplicates. What's your thought?

