### PR TITLE
(very minor) Fix the link to the page about links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ External links are used for external hyperlinks::
 
     `ReStructuredText <https://docutils.sourceforge.io/rst.html>`_
 
-If you get the warning ``Duplicate target name``, because of multiple links with the same label, see :doc:`Create anonymous links <docs/documentation/anonymus-links>`.
+If you get the warning ``Duplicate target name``, because of multiple links with the same label, `use an anonymous link <https://docs.aiven.io/docs/community/documentation/tips-tricks/anonymous-links.html>`.
 
 To link to another page on the site, use the `:doc: <https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-documents>`_ role::
 

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ External links are used for external hyperlinks::
 
     `ReStructuredText <https://docutils.sourceforge.io/rst.html>`_
 
-If you get the warning ``Duplicate target name``, because of multiple links with the same label, `use an anonymous link <https://docs.aiven.io/docs/community/documentation/tips-tricks/anonymous-links.html>`.
+If you get the warning ``Duplicate target name``, because of multiple links with the same label, `use an anonymous link <https://docs.aiven.io/docs/community/documentation/tips-tricks/anonymous-links.html>`_ .
 
 To link to another page on the site, use the `:doc: <https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-documents>`_ role::
 


### PR DESCRIPTION
# What changed, and why it matters

I noticed when discussing on #1619 that we had somehow mangled the link to the tips on link formatting, so I fixed it.