### PR TITLE
Simple fix: typo in TOC

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -54,7 +54,7 @@ entries:
           - file: docs/platform/howto/reactivate-suspended-project
           - file: docs/platform/howto/disable-platform-authentication                     
       - file: docs/platform/howto/list-account
-        title: Acccount management
+        title: Account management
         entries: 
           - file: docs/tools/aiven-console/howto/create-accounts
       - file: docs/platform/howto/list-service


### PR DESCRIPTION
# What changed, and why it matters
Fixing typo in the name of the Account management section of the platform how-tos.

