### PR TITLE
Add workflow to check redirects for renamed files

### DIFF
--- a/.github/workflows/redirect_checks.yaml
+++ b/.github/workflows/redirect_checks.yaml
@@ -1,0 +1,57 @@
+name: "Redirects in renamed files"
+"on":
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  prose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files in the docs folder
+        id: changed-files
+        uses: tj-actions/changed-files@v34
+        with:
+          include_all_old_new_renamed_files: true
+          files: |
+            docs/**
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Check renamed files
+        id: missing_redirection
+        env:
+          ALL_OLD_AND_NEW_RENAMED_FILES: ${{ steps.changed-files.outputs.all_old_new_renamed_files }}
+        run: |
+          for file in ${{ steps.changed-files.outputs.renamed_files }};
+          do
+            if [ "${file: -4}" == ".rst" ]
+              file="$file" | sed -e 's/\.[^.]*$//'
+              then
+                var="$var $file"
+            fi
+          done
+          echo "$var"
+          if ! [ -z "$var" ];then
+            python "scripts/aiven/check_renamed_files.py" --renamed_files ${{ steps.changed-files.outputs.renamed_files }}
+          fi
+
+      - name: Check env
+        env:
+          MISSING_REDIRECTION: ${{ env.MISSING_REDIRECTION }}
+        if: "${{ env.MISSING_REDIRECTION != '' }}"
+        run: |
+          echo "::error::Files were renamed with missing _redirects. Add redirect to renamed files to fix it. Renamed: ${{env.MISSING_REDIRECTION}}"
+          echo "::error::For full report, check logs on the step above."
+          exit 1

--- a/.github/workflows/redirect_checks.yaml
+++ b/.github/workflows/redirect_checks.yaml
@@ -44,7 +44,7 @@ jobs:
           done
           echo "$var"
           if ! [ -z "$var" ];then
-            python "scripts/aiven/check_renamed_files.py" --renamed_files ${{ steps.changed-files.outputs.renamed_files }}
+            python "scripts/check_renamed_files.py" --renamed_files ${{ steps.changed-files.outputs.renamed_files }}
           fi
 
       - name: Check env

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 ultimate-sitemap-parser==0.5
+coloredlogs==15.0.1

--- a/scripts/check_renamed_files.py
+++ b/scripts/check_renamed_files.py
@@ -1,0 +1,123 @@
+"""
+This script checks if a renamed file is added for proper redirection on redirects_ file.
+"""
+import os, sys, argparse
+import coloredlogs, logging
+from typing import Dict, List
+
+p = os.path.abspath(os.path.join(__file__, "../../.."))
+os.chdir(p)
+
+REDIRECTED_FILE = "_redirects"
+
+logger = logging.getLogger("check_renamed_files")
+logging.basicConfig(format="%(asctime)s - [%(levelname)s] - %(message)s")
+
+
+FIELD_STYLES = dict(asctime=dict(color="yellow"), levelname=dict(color="magenta"))
+LEVEL_STYLES = dict(
+    debug=dict(color="green"),
+    info=dict(color="cyan"),
+    verbose=dict(color="blue"),
+    warning=dict(color="yellow"),
+    error=dict(color="red"),
+    critical=dict(color="red"),
+)
+
+coloredlogs.install(
+    level="DEBUG",
+    logger=logger,
+    isatty=True,
+    level_styles=LEVEL_STYLES,
+    field_styles=FIELD_STYLES,
+)
+
+
+def find_redirected() -> Dict:
+    """Creates a dict with the redirected files
+    on the _redirects file.
+
+    { previous : redirected}
+
+    :returns: set with redirected files
+    :rtype: set
+    """
+    all_redirected_links = {}
+    with open(REDIRECTED_FILE) as f:
+        lines = f.readlines()
+    for line in lines:
+        if line.startswith("/docs/") and not line.startswith("/docs/:"):
+            previous, redirected = [x.lstrip("/") for x in line.split()]
+            # avoid repetitions of `html`
+            if not previous.endswith(".html"):
+                all_redirected_links[previous] = redirected
+
+    return all_redirected_links
+
+
+def check_missing_redirects(renamed_files: List[str]):
+    """
+    Creates a dict with all missing redirects.
+
+    { previous_link: current_link }
+
+    :returns: missing redirects
+    :rtype: dict
+    """
+
+    INPUT = os.environ["ALL_OLD_AND_NEW_RENAMED_FILES"]
+    all_new_and_renamed_files = dict([x.split(",")[::-1] for x in INPUT.split(" ")])
+
+    missing_redirects = {}
+    all_redirected_links = find_redirected()
+    for renamed in renamed_files:
+        try:
+            previous_link = all_new_and_renamed_files[renamed].rstrip(".rst")
+            logger.debug(previous_link)
+        except KeyError:
+            logger.error("Missing renamed files on all new and renamed files.")
+            exit(0)
+        current_link = renamed.rstrip(".rst")
+        if all_redirected_links.get(previous_link) != current_link:
+            missing_redirects[previous_link] = current_link
+    return missing_redirects
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Script to find missing redirects.")
+    parser.add_argument(
+        "--renamed_files",
+        help="delimited list input",
+        type=str,
+        nargs="*",
+        default=" ",
+    )
+    parser.add_argument(
+        "--path_file", help="path to a file", type=str, default=os.getenv("GITHUB_ENV")
+    )
+
+    renamed_files = parser.parse_args().renamed_files
+    env_file = parser.parse_args().path_file
+
+    if not renamed_files:
+        logger.info("No files are renamed.")
+        sys.exit()
+
+    missing_redirects = check_missing_redirects(renamed_files)
+    if not missing_redirects:
+        logger.info("Files renamed and redirects are added to _redirects.")
+        sys.exit()
+
+    res = ""
+    h = ["Previous Name", "Current Name"]
+    logger.error("{:<40s} {:<40s}".format(*h))
+    for k, v in missing_redirects.items():
+        logger.error("/{:<40s} /{:<40s}".format(k, v))
+
+    logger.info("🚨 Seems like you forgot to add redirects for the renamed files. 🚨")
+    logger.info(
+        "ℹ️ More info: https://docs.aiven.io/docs/community/documentation/tips-tricks/renaming-files.html"
+    )
+
+    with open(env_file, "a") as myfile:
+        myfile.write(f"MISSING_REDIRECTION={missing_redirects}")

--- a/scripts/check_renamed_files.py
+++ b/scripts/check_renamed_files.py
@@ -5,10 +5,9 @@ import os, sys, argparse
 import coloredlogs, logging
 from typing import Dict, List
 
-p = os.path.abspath(os.path.join(__file__, "../../.."))
-os.chdir(p)
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + "/../../")
 
-REDIRECTED_FILE = "_redirects"
 
 logger = logging.getLogger("check_renamed_files")
 logging.basicConfig(format="%(asctime)s - [%(levelname)s] - %(message)s")
@@ -42,6 +41,7 @@ def find_redirected() -> Dict:
     :returns: set with redirected files
     :rtype: set
     """
+    REDIRECTED_FILE = "_redirects"
     all_redirected_links = {}
     with open(REDIRECTED_FILE) as f:
         lines = f.readlines()
@@ -109,10 +109,10 @@ if __name__ == "__main__":
         sys.exit()
 
     res = ""
-    h = ["Previous Name", "Current Name"]
-    logger.error("{:<40s} {:<40s}".format(*h))
+    h = ["Previous Name", " Current Name"]
+    logger.error("{:<45s} {:<45s}".format(*h))
     for k, v in missing_redirects.items():
-        logger.error("/{:<40s} /{:<40s}".format(k, v))
+        logger.error("/{:<45s} /{:<45s}".format(k, v))
 
     logger.info("🚨 Seems like you forgot to add redirects for the renamed files. 🚨")
     logger.info(

--- a/scripts/tests/test_renamed_files.py
+++ b/scripts/tests/test_renamed_files.py
@@ -1,0 +1,58 @@
+import sys, os
+import mock, pytest
+
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + "/../../")
+from scripts.check_renamed_files import check_missing_redirects
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "ALL_OLD_AND_NEW_RENAMED_FILES": "docs/tools.rst,docs/renamed_tools_file.rst docs/community.rst,docs/renamed_community_file.rst docs/integrations.rst,docs/renamed_integration_file.rst docs/platform.rst,docs/platform2.rst docs/products/opensearch/howto/connect-with-python.rst,docs/products/opensearch/howto/renamed_opensearch_file.rst"
+    },
+)
+def test_check_missing_redirects_with_missing_links():
+    renamed_files = [
+        "docs/renamed_community_file.rst",
+        "docs/renamed_integration_file.rst",
+        "docs/renamed_tools_file.rst",
+        "docs/products/opensearch/howto/renamed_opensearch_file.rst",
+    ]
+    missing_redirects = check_missing_redirects(renamed_files)
+    assert missing_redirects == {
+        "docs/community": "docs/renamed_community_file",
+        "docs/integration": "docs/renamed_integration_file",
+        "docs/tool": "docs/renamed_tools_file",
+        "docs/products/opensearch/howto/connect-with-python": "docs/products/opensearch/howto/renamed_opensearch_file",
+    }
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "ALL_OLD_AND_NEW_RENAMED_FILES": "docs/tools.rst,docs/renamed_tools_file.rst docs/community.rst,docs/renamed_community_file.rst docs/integrations.rst,docs/renamed_integration_file.rst docs/platform.rst,docs/platform2.rst docs/products/opensearch/howto/connect-with-python.rst,docs/products/opensearch/howto/renamed_opensearch_file.rst"
+    },
+)
+def test_check_missing_redirects_with_no_renamed_files():
+    """
+    Test when there were previous changes in all old and new renamed file,
+    without renamed files in current commit. No missind redirects should be
+    reported
+    """
+    renamed_files = []
+    missing_redirects = check_missing_redirects(renamed_files)
+    assert missing_redirects == {}
+
+
+@mock.patch.dict(
+    os.environ,
+    {"ALL_OLD_AND_NEW_RENAMED_FILES": ""},
+)
+def test_check_missing_redirects_no_files_changed_and_no_renamed_files():
+    """
+    Function should raise an error if no files changed and this function is called
+    """
+    with pytest.raises(ValueError):
+        renamed_files = []
+        check_missing_redirects(renamed_files)


### PR DESCRIPTION
If a file is renamed, a redirect should
be added. This workflow helps to check and
report whether a renamed file is missing
redirects.

The redirect process is done manually by the contributor, so we need to make sure during the review that we do not merge renamed files without proper redirects. This workflow helps with that.

Running time: ~14 seconds

More info about the redirects process:
https://docs.aiven.io/docs/community/documentation/tips-tricks/renaming-files.html

Fixes: https://github.com/aiven/devportal/issues/1602

How to test it? Fork the repo, bring those changes to your main and open pull requests changing name of the files with/without redirects, for example. For the individual functions, you can find some tests you can run yourself with pytest.
