### PR TITLE
Add Python autoformatter

### DIFF
--- a/.github/workflows/python-run-autoformatter.yaml
+++ b/.github/workflows/python-run-autoformatter.yaml
@@ -1,7 +1,7 @@
 name: Python formatting - Run psf/black
 on:
   schedule:
-    - cron: "0 6 * * 2"
+    - cron: "0 7 * * 2"
   workflow_dispatch:
 jobs:
   linter_name:

--- a/.github/workflows/python-run-autoformatter.yaml
+++ b/.github/workflows/python-run-autoformatter.yaml
@@ -26,6 +26,5 @@ jobs:
           body: |
             Automation to format python code using [psf/black](https://github.com/psf/black)
           labels: Maintenance, automated-pr
-          reviewers: laysauchoa
           base: ${{ github.head_ref }}
           branch: format-python-code-with-black

--- a/.github/workflows/python-run-autoformatter.yaml
+++ b/.github/workflows/python-run-autoformatter.yaml
@@ -1,0 +1,31 @@
+name: Python formatting - Run psf/black
+on:
+  schedule:
+    - cron: "0 6 * * 2"
+  workflow_dispatch:
+jobs:
+  linter_name:
+    name: runner / black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
+        with:
+          black_args: "."
+      - name: Create Pull Request
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Python: use psf/black to format code 🐍"
+          commit-message: "Python: use psf/black to format code 🐍"
+          body: |
+            Automation to format python code using [psf/black](https://github.com/psf/black)
+          labels: Maintenance, automated-pr
+          reviewers: laysauchoa
+          base: ${{ github.head_ref }}
+          branch: format-python-code-with-black

--- a/code/products/cassandra/connect.py
+++ b/code/products/cassandra/connect.py
@@ -8,5 +8,6 @@ ssl_options = {"ca_certs": SSL_CERTFILE, "cert_reqs": ssl.CERT_REQUIRED}
 with Cluster([HOST], port=PORT, ssl_options=ssl_options, auth_provider=auth_provider, 
                     load_balancing_policy=DCAwareRoundRobinPolicy(local_dc='aiven')) as cluster:
         with cluster.connect() as session:
+            pass
         # Here you can now read from or write to the database
 


### PR DESCRIPTION
Use psf/black to format Python code. Run once per week seems fine, but we can also change some of the customizations parameters from the workflow. This can be triggered manually and on the schedule.

Fixes: https://github.com/aiven/devportal/issues/1226