### PR TITLE
Update title for ClickHouse JDBC

### DIFF
--- a/docs/products/clickhouse/howto/connect-with-jdbc.rst
+++ b/docs/products/clickhouse/howto/connect-with-jdbc.rst
@@ -1,7 +1,7 @@
-Connect Aiven for ClickHouse® to external databases via JDBC
+Connect to Aiven for ClickHouse® using JDBC
 ===============================================================
 
-You can use `ClickHouse JDBC driver <https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-jdbc>`_ to connect external sources to your Aiven for ClickHouse database.
+You can use `ClickHouse JDBC driver <https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-jdbc>`_ to connect to your Aiven for ClickHouse database.
 
 You will need Aiven for ClickHouse® service, accessible by HTTPS. The connection values you'll need can be found in your Aiven for ClickHouse® service page in the connection information for *HTTPS endpoint*.
 


### PR DESCRIPTION
## What changed, and why it matters

I think we should change the title, the current one look like it's about connecting from ClickHouse to something else, over JDBC.

The ClickHouse JDBC driver is the opposite, it's to connect from a Java app to ClickHouse (and the Java app is not really a source).

Though, since we have the "Connect with Java" article maybe this article is now redundant ?



