### PR TITLE
clickhouse: add link to the  comparison of service plans

### DIFF
--- a/docs/products/clickhouse/reference/plans-pricing.rst
+++ b/docs/products/clickhouse/reference/plans-pricing.rst
@@ -13,7 +13,9 @@ Aiven for ClickHouse is packaged into four tiers, each including a range of plan
 * Business - high-availability plan for business-focused apps and internal services
 * Premium - high-availability plan with multiple shards for mission-critical apps, handling high query rates and big data amounts. 
 
-To compare the plans and learn their pricing details, see `Plan comparison <https://aiven.io/pricing?tab=plan-comparison&product=clickhouse>`_ and `Plan pricing <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_, respectively.
+.. seealso::
+
+    To compare the plans and learn their pricing details, see `Plan comparison <https://aiven.io/pricing?tab=plan-comparison&product=clickhouse>`_ and `Plan pricing <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_, respectively.
 
 Custom plans
 ------------

--- a/docs/products/clickhouse/reference/plans-pricing.rst
+++ b/docs/products/clickhouse/reference/plans-pricing.rst
@@ -13,7 +13,7 @@ Aiven for ClickHouse is packaged into four tiers, each including a range of plan
 * Business - high-availability plan for business-focused apps and internal services
 * Premium - high-availability plan with multiple shards for mission-critical apps, handling high query rates and big data amounts. 
 
-.. To learn more, check out the `plan comparison <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_.
+To comapre the plans and learn their pricing details, see `Plan comparison <https://aiven.io/pricing?tab=plan-comparison&product=clickhouse>`_ and `Plan pricing <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_, respectively.
 
 Custom plans
 ------------

--- a/docs/products/clickhouse/reference/plans-pricing.rst
+++ b/docs/products/clickhouse/reference/plans-pricing.rst
@@ -13,7 +13,7 @@ Aiven for ClickHouse is packaged into four tiers, each including a range of plan
 * Business - high-availability plan for business-focused apps and internal services
 * Premium - high-availability plan with multiple shards for mission-critical apps, handling high query rates and big data amounts. 
 
-To comapre the plans and learn their pricing details, see `Plan comparison <https://aiven.io/pricing?tab=plan-comparison&product=clickhouse>`_ and `Plan pricing <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_, respectively.
+To compare the plans and learn their pricing details, see `Plan comparison <https://aiven.io/pricing?tab=plan-comparison&product=clickhouse>`_ and `Plan pricing <https://aiven.io/pricing?tab=plan-pricing&product=clickhouse>`_, respectively.
 
 Custom plans
 ------------


### PR DESCRIPTION
Adding a link to the site specifying ClickHouse plans' pricing and providing plans comparison

https://aiven.atlassian.net/browse/DOC-130

