### PR TITLE
Add a terraform recipe for kafka and http sink

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -230,6 +230,8 @@ entries:
               title: Apache Kafka MongoDB Source Connector
             - file: docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source
               title: Debezium Source Connector across clouds
+            - file: docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+              title: Apache Kafka with topics and HTTP sink connector
             - file: docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
               title: Apache Kafka with custom configurations  
             - file: docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe

--- a/docs/tools/terraform/reference/cookbook.rst
+++ b/docs/tools/terraform/reference/cookbook.rst
@@ -70,6 +70,14 @@ Each "recipe" includes an architecture diagram and the terraform sample code you
         :shadow: md
         :margin: 2 2 0 0
 
+        :doc:`Apache Kafka with topics and HTTP sink connector <cookbook/kafka-topics-http-connector-recipe>`
+
+        |icon-kafka|
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
         :doc:`Apache Kafka MongoDB Source Connector <cookbook/kafka-mongodb-recipe>`
 
         |icon-kafka|

--- a/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
@@ -40,7 +40,7 @@ Configure common files
 	 required_providers {
 	   aiven = {
 	     source  = "aiven/aiven"
-	     version = "~> 3.9.0"
+	     version = "~> 3.10.0"
 	   }
 	 }
        }
@@ -51,7 +51,7 @@ Configure common files
 
   .. tip::
     
-    You can set environment variable ``AIVEN_TOKEN`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can set environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
 
   2. ``variables.tf`` file
 

--- a/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -43,7 +43,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-clickhouse-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-clickhouse-integration-recipe.rst
@@ -60,7 +60,7 @@ Configure common files
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.8.1"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -71,7 +71,7 @@ Configure common files
 
   .. tip::
 
-    You can set environment variable ``AIVEN_TOKEN`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can set environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
 
   2. ``variables.tf`` file
 

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -45,7 +45,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -40,7 +40,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -44,7 +44,7 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -53,7 +53,7 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -40,7 +40,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -49,7 +49,7 @@ For this, you'd like to run an Apache Flink job and write the filtered messages 
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
@@ -32,7 +32,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -41,7 +41,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -57,7 +57,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -66,7 +66,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -42,7 +42,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -51,7 +51,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
@@ -204,8 +204,8 @@ this is then sent over HTTP.
 You could use this setup for relaying payloads to platforms that don't have
 specific connectors available. The HTTP sink connector is also an excellent
 tool for integrating with webhook-ready platforms like functions-as-a-service
-(`Amazon Lambda<https://aws.amazon.com/lambda/>`_, `Cloudflare
-Workers<https://workers.cloudflare.com/>`_) or `Zapier<https://zapier.com/>`_.
+(`Amazon Lambda <https://aws.amazon.com/lambda/>`_, `Cloudflare
+Workers <https://workers.cloudflare.com/>`_) or `Zapier <https://zapier.com/>`_.
 
 
 Further resources

--- a/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
@@ -29,7 +29,7 @@ something like the diagram below:
 The Aiven for Apache Kafka and Kafka Connect services are connected with a
 service integration. The Kafka Connect service has the HTTP sink configured and
 this connects the topic to the HTTP destination. The HTTP destination is an
-external location defined by `http.url` in the HTTP sink connector
+external location defined by ``http.url`` in the HTTP sink connector
 configuration.
 
 Define the setup
@@ -166,11 +166,11 @@ are likely to need changing to suit your use case.
 This example creates two Aiven services: one Aiven for Apache Kafka service,
 and a Kafka Connect service. It adds a service integration so that the the
 connectors can access the data in the Kafka cluster. There is a topic defined
-`user_activity`, and this is referred to by the Kafka connector configuration
+``user_activity``, and this is referred to by the Kafka connector configuration
 as the source of the data to send over HTTP. The connector also defines where
-the HTTP requests should be sent to, using the `http.url` setting.
+the HTTP requests should be sent to, using the ``http.url`` setting.
 
-To avoid any race conditions in this setup, the `depends_on` clause makes sure
+To avoid any race conditions in this setup, the ``depends_on`` clause makes sure
 that the connector will only be configured when both the Kafka Connect service
 and its integration to Kafka are in place.
 
@@ -198,16 +198,21 @@ Go ahead and plan and then apply the Terraform configuration.
            
 Try out this recipe by defining an HTTP endpoint where you can receive and
 acknowledge HTTP requests in the connector configuration. Then produce some
-data to the `user_activity` topic (any JSON data is fine), and observe that
+data to the ``user_activity`` topic (any JSON data is fine), and observe that
 this is then sent over HTTP.
 
-You could use this setup for relaying payloads to platforms that don't have specific connectors available. The HTTP sink connector is also an excellent tool for integrating with webhook-ready platforms like functions-as-a-service ([Amazon Lambda](https://aws.amazon.com/lambda/), [Cloudflare Workers](https://workers.cloudflare.com/)) or [Zapier](https://zapier.com/).
+You could use this setup for relaying payloads to platforms that don't have
+specific connectors available. The HTTP sink connector is also an excellent
+tool for integrating with webhook-ready platforms like functions-as-a-service
+(`Amazon Lambda<https://aws.amazon.com/lambda/>`_, `Cloudflare
+Workers<https://workers.cloudflare.com/>`_) or `Zapier<https://zapier.com/>`_.
 
 
 Further resources
 -----------------
 
-Here are some resources with additional information, examples and documentation for working with the technologies in this recipe:
+Here are some resources with additional information, examples and documentation
+for working with the technologies in this recipe:
 
 - :doc:`Configuration options for Kafka </docs/products/kafka/reference/advanced-params>`
 - :doc:`HTTP sink documentation and examples </docs/products/kafka/kafka-connect/howto/http-sink>`

--- a/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
@@ -52,7 +52,7 @@ example, you'll need to declare the variables for ``project_name`` and
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -61,7 +61,7 @@ example, you'll need to declare the variables for ``project_name`` and
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
@@ -1,0 +1,213 @@
+Configure Apache Kafka® with topics and an HTTP sink connector using Terraform
+==============================================================================
+
+This article shows the Terraform configuration for setting up an Aiven for
+Apache Kafka®, configuring a topic, and adding a Kafka Connector to send the
+data from the topic over HTTP using the :doc:`HTTP sink connector
+</docs/products/kafka/kafka-connect/howto/http-sink>`. This is a great way to
+use webhooks or HTTP requests as a generic connector to send the data to
+another platform.
+
+The setup needs the Aiven for Apache Kafka service and the Kafka Connect
+service, plus a service integration to connect the two. The overall setup looks
+something like the diagram below:
+
+
+.. mermaid::
+
+    flowchart LR
+        subgraph k1 [Kafka cluster]
+        topic[Topic]
+        end
+        sikafka{{Service Integration}}
+        subgraph kc1 [Kafka Connect]
+        connector[HTTP sink connector]
+        end
+        webhook([HTTP destination])
+        topic-->sikafka-->connector-->webhook
+
+The Aiven for Apache Kafka and Kafka Connect services are connected with a
+service integration. The Kafka Connect service has the HTTP sink configured and
+this connects the topic to the HTTP destination. The HTTP destination is an
+external location defined by `http.url` in the HTTP sink connector
+configuration.
+
+Define the setup
+----------------
+
+Be sure to check out the :doc:`getting started guide <../../get-started>` to
+learn about the common files required to execute the following recipe. For
+example, you'll need to declare the variables for ``project_name`` and
+``api_token``.
+
+.. dropdown:: Expand to see the common files needed for this recipe.
+
+    Navigate to a new folder and add the following files.
+
+    1. Add the following to a new ``provider.tf`` file:
+
+    .. code:: terraform
+
+       terraform {
+         required_providers {
+           aiven = {
+             source  = "aiven/aiven"
+             version = "~> 3.9.0"
+           }
+         }
+       }
+   
+       provider "aiven" {
+         api_token = var.aiven_api_token
+       }
+   
+    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+ 
+    2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
+
+    The ``variables.tf`` file defines the API token, the project name to use, and the prefix for the service name:
+
+    .. code:: terraform
+
+       variable "aiven_api_token" {
+         description = "Aiven console API token"
+         type        = string
+       }
+   
+       variable "project_name" {
+         description = "Aiven console project name"
+         type        = string
+       }
+   
+    3. The ``var-values.tfvars`` file holds the actual values and is passed to Terraform using the ``-var-file=`` flag.
+
+    ``var-values.tfvars`` file:
+
+    .. code:: terraform
+
+       aiven_api_token     = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
+       project_name        = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
+
+
+
+The sample Terraform file to create and connect all the services is shown
+below. This file uses sample data; comments are added to indicate settings that
+are likely to need changing to suit your use case.
+
+``services.tf`` file:
+
+.. code:: terraform
+    
+    # Kafka service
+    resource "aiven_kafka" "project_kafka" {
+      project                 = var.project_name # from variables.tf and supplied at run time
+      cloud_name              = "google-europe-west1"
+      plan                    = "business-4"
+      service_name            = "my-kafka-demo"
+      kafka_user_config {
+        kafka_version = "3.2"
+        kafka_rest      = true
+        kafka {
+          auto_create_topics_enable = true
+        }
+      }
+    }
+
+    # Kafka topic, in the cluster defined above
+    resource "aiven_kafka_topic" "user_activity" {
+      project      = var.project_name
+      service_name = aiven_kafka.project_kafka.service_name
+      topic_name   = "user_activity"
+      partitions   = 3
+      replication  = 2
+    }
+
+    # Kafka Connect service
+    resource "aiven_kafka_connect" "data_connector" {
+      project                 = var.project_name
+      cloud_name              = "google-europe-west1"
+      plan                    = "business-4"
+      service_name            = "my-kafka-demo-connector"
+    }
+
+    # Integration between kafka and kafka connect
+    resource "aiven_service_integration" "kafka_to_data_connector" {
+      project                  = var.project_name
+      integration_type         = "kafka_connect"
+      source_service_name      = aiven_kafka.project_kafka.service_name
+      destination_service_name = aiven_kafka_connect.data_connector.service_name
+    }
+
+    # Kafka connector: this one is an HTTP sink
+    resource "aiven_kafka_connector" "kafka_webhook_sink" {
+      project        = var.project_name
+      service_name   = aiven_kafka_connect.data_connector.service_name
+      connector_name = "my-http-sink"
+      config = {
+        # Which topic (or topics) should the data come from?
+        "topics"                         = aiven_kafka_topic.user_activity.topic_name
+        "connector.class"                = "io.aiven.kafka.connect.http.HttpSinkConnector"
+        "name"                           = "my-http-sink"
+        # Edit where the HTTP data should be sent
+        "http.url"                       = "https://example.com/endpoint"
+        "http.authorization.type"        = "none"
+        "http.headers.content.type"      = "application/json"
+        "key.converter"                  = "org.apache.kafka.connect.storage.StringConverter"
+        "value.converter"                = "org.apache.kafka.connect.storage.StringConverter"
+      }
+
+      # Make sure that the connect service is ready before creating this
+      depends_on = [
+        aiven_kafka_connect.data_connector,
+        aiven_service_integration.kafka_to_data_connector
+      ]
+    }
+
+This example creates two Aiven services: one Aiven for Apache Kafka service,
+and a Kafka Connect service. It adds a service integration so that the the
+connectors can access the data in the Kafka cluster. There is a topic defined
+`user_activity`, and this is referred to by the Kafka connector configuration
+as the source of the data to send over HTTP. The connector also defines where
+the HTTP requests should be sent to, using the `http.url` setting.
+
+To avoid any race conditions in this setup, the `depends_on` clause makes sure
+that the connector will only be configured when both the Kafka Connect service
+and its integration to Kafka are in place.
+
+Go ahead and plan and then apply the Terraform configuration.
+
+.. dropdown:: Expand for how to execute the Terraform files
+
+    The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.
+    
+    .. code:: shell
+
+       terraform init
+
+    The ``plan`` command creates an execution plan and shows you the resources that will be created (or modified) for you. This command does not actually create any resource; this is more like a preview.
+
+    .. code:: bash
+
+       terraform plan -var-file=var-values.tfvars
+
+    If you're satisfied with the output of ``terraform plan``, go ahead and run the ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
+
+    .. code:: bash
+
+       terraform apply -var-file=var-values.tfvars
+           
+Try out this recipe by defining an HTTP endpoint where you can receive and
+acknowledge HTTP requests in the connector configuration. Then produce some
+data to the `user_activity` topic (any JSON data is fine), and observe that
+this is then sent over HTTP.
+
+You could use this setup for relaying payloads to platforms that don't have specific connectors available. The HTTP sink connector is also an excellent tool for integrating with webhook-ready platforms like functions-as-a-service ([Amazon Lambda](https://aws.amazon.com/lambda/), [Cloudflare Workers](https://workers.cloudflare.com/)) or [Zapier](https://zapier.com/).
+
+
+Further resources
+-----------------
+
+Here are some resources with additional information, examples and documentation for working with the technologies in this recipe:
+
+- :doc:`Configuration options for Kafka </docs/products/kafka/reference/advanced-params>`
+- :doc:`HTTP sink documentation and examples </docs/products/kafka/kafka-connect/howto/http-sink>`

--- a/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -45,7 +45,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -40,7 +40,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/postgres-clickhouse-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgres-clickhouse-integration-recipe.rst
@@ -41,7 +41,7 @@ Configure common files
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -52,7 +52,7 @@ Configure common files
 
   .. tip::
 
-    You can set environment variable ``AIVEN_TOKEN`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can set environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property so that you don't need to pass the ``-var-file`` flag when executing Terraform commands.
 
   2. ``variables.tf`` file
 

--- a/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -43,7 +43,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -48,7 +48,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.9.0"
+             version = "~> 3.10.0"
            }
          }
        }
@@ -57,7 +57,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          api_token = var.aiven_api_token
        }
    
-    You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+    You can also set the environment variable ``TF_VAR_aiven_api_token`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
  
     2. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
 


### PR DESCRIPTION
# What changed, and why it matters

I use this terraform setup with my webhooks demo, wondered if it might be useful as a recipe. It's quite similar to another connector one, but includes a few different bits and pieces, so I thought I'd add it. We'd also be able to link to it from the related blog post early next month if we had this.
