### PR TITLE
task: Match title to nav title

### DIFF
--- a/docs/platform/howto/list-network.rst
+++ b/docs/platform/howto/list-network.rst
@@ -1,5 +1,5 @@
-Network tasks
-=============
+Network management
+==================
 
 Browse through instructions for common Aiven platform tasks related to managing services networking configurations.
 


### PR DESCRIPTION
Rename page title to match nav title (there's no meaningful reason for the two to differ)


