### PR TITLE
bugfix: Correct grammar/style  in VPC headings

### DIFF
--- a/docs/platform/howto/attach-vpc-aws-tgw.rst
+++ b/docs/platform/howto/attach-vpc-aws-tgw.rst
@@ -1,5 +1,5 @@
-﻿Attach VPC to AWS Transit Gateway
-=================================
+﻿Attach a VPC to an AWS Transit Gateway
+=======================================
 
 `AWS Transit Gateway (TGW) <https://aws.amazon.com/transit-gateway/>`_ enables transitive routing from on-premises networks through VPN and from other VPC. 
 By creating a Transit Gateway VPC attachment, services in an Aiven Project VPC can route traffic to all other networks attached - directly or indirectly - to the Transit Gateway.

--- a/docs/platform/howto/use-aws-privatelinks.rst
+++ b/docs/platform/howto/use-aws-privatelinks.rst
@@ -1,4 +1,4 @@
-Using AWS PrivateLink with Aiven services
+Use AWS PrivateLink with Aiven services
 =========================================
 
 AWS `PrivateLink <https://aws.amazon.com/privatelink/>`__ brings Aiven

--- a/docs/platform/howto/vnet-peering-azure.rst
+++ b/docs/platform/howto/vnet-peering-azure.rst
@@ -1,5 +1,5 @@
-Azure virtual network peering
-=============================
+Set up Azure virtual network peering
+====================================
 
 This help article contains step-by-step instructions for setting up
 peering in Azure. See the `Using VPC

--- a/docs/platform/howto/vpc-peering-aws.rst
+++ b/docs/platform/howto/vpc-peering-aws.rst
@@ -1,5 +1,5 @@
-Set Virtual Private Cloud (VPC) peering on AWS
-==============================================
+Set up Virtual Private Cloud (VPC) peering on AWS
+==================================================
 
 Once you've created a :doc:`VPC on the Aiven platform <manage-vpc-peering>`, you can follow this instruction to set up VPC peering on AWS.
 


### PR DESCRIPTION
# What changed, and why it matters

Small nonbreaking changes: normalizing the grammar and verbs in the titles of the Platform > HowTo > VPC related topics.

