### PR TITLE
Add missing comma to Auth0 SAML field mappings

### DIFF
--- a/docs/platform/howto/saml/setup-saml-auth0.rst
+++ b/docs/platform/howto/saml/setup-saml-auth0.rst
@@ -50,7 +50,7 @@ Setup on Auth0
      "email": "email",
      "first_name": "first_name",
      "identity": "email",
-     "last_name": "last_name"
+     "last_name": "last_name",
      "mapUnknownClaimsAsIs": true
    }
 


### PR DESCRIPTION
# What changed, and why it matters

Fixes the content for Auth0 SAML docs field mappings so that it's a valid configuration.
