### PR TITLE
Uploaded rst for hourly billing model and updated toc

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -18,6 +18,7 @@ entries:
           - file: docs/platform/concepts/tax-information
           - file: docs/platform/concepts/billing-groups
           - file: docs/platform/concepts/corporate-billing
+          - file: docs/platform/concepts/hourly-billing-model
       - file: docs/platform/concepts/beta_services
       - file: docs/platform/concepts/cloud-security
       - file: docs/platform/concepts/logs-metrics-alerts

--- a/docs/platform/concepts/hourly-billing-model.rst
+++ b/docs/platform/concepts/hourly-billing-model.rst
@@ -11,6 +11,8 @@ The prices as shown in the Aiven console are all-inclusive, meaning that all of 
 .. note::
     While network traffic is not charged separately, your application cloud service provider may charge you for the network traffic going to or from their services.
 
+    Use of PrivateLink and/or additional storage will incur additional costs on top of the hourly service usage rate.
+
 The minimum hourly charge unit is one hour.  For example, when you launch an Aiven service and terminate it after 40 minutes, you will be charged for one full hour.  Likewise, if you terminate a service after 40.5 hours, you will be charged for 41 hours.
 
 :doc:`Terminating or pausing a service <../howto/pause-from-cli>` will stop the accumulation of new charges immediately.  However, please note that the minimum hourly charge unit still applies prior to terminating or pausing a service.

--- a/docs/platform/concepts/hourly-billing-model.rst
+++ b/docs/platform/concepts/hourly-billing-model.rst
@@ -1,7 +1,7 @@
 Hourly billing model for all services
 =====================================
 
-The prices as shown in the Aiven console are all inclusive where all of the following are included in the hourly service price:
+The prices as shown in the Aiven console are all-inclusive, meaning that all of the following are included in the hourly service price:
 
 * Virtual machine costs
 * Network costs
@@ -11,8 +11,8 @@ The prices as shown in the Aiven console are all inclusive where all of the foll
 .. note::
     While network traffic is not charged separately, your application cloud service provider may charge you for the network traffic going to or from their services.
 
-The minimum hourly charge unit is one hour.  For example, when you launch an Aiven service and terminate it after 40 minutes - you will be charged for one full hour.  Likewise, if you terminate a service after 40.5 hours, you will be charged for 41 hours.
+The minimum hourly charge unit is one hour.  For example, when you launch an Aiven service and terminate it after 40 minutes, you will be charged for one full hour.  Likewise, if you terminate a service after 40.5 hours, you will be charged for 41 hours.
 
 :doc:`Terminating or pausing a service <../howto/pause-from-cli>` will stop the accumulation of new charges immediately.  However, please note that the minimum hourly charge unit still applies prior to terminating or pausing a service.
 
-Upgrading or changing to different service plan levels (e.g. **Startup-4** to **Business-8**) will not incur any additional cost.  Additionally, migrating a service to another cloud region or to a different cloud provider does not incur any additional costs.
+Upgrading or changing to different service plan levels (e.g., from **Startup-4** to **Business-8**) will not incur any additional cost.  Additionally, migrating a service to another cloud region or to a different cloud provider does not incur any additional costs.

--- a/docs/platform/concepts/hourly-billing-model.rst
+++ b/docs/platform/concepts/hourly-billing-model.rst
@@ -1,0 +1,18 @@
+Hourly billing model for all services
+=====================================
+
+The prices as shown in the Aiven console are all inclusive where all of the following are included in the hourly service price:
+
+* Virtual machine costs
+* Network costs
+* Backup costs
+* Setup costs
+
+.. note::
+    While network traffic is not charged separately, your application cloud service provider may charge you for the network traffic going to or from their services.
+
+The minimum hourly charge unit is one hour.  For example, when you launch an Aiven service and terminate it after 40 minutes - you will be charged for one full hour.  Likewise, if you terminate a service after 40.5 hours, you will be charged for 41 hours.
+
+:doc:`Terminating or pausing a service <../howto/pause-from-cli>` will stop the accumulation of new charges immediately.  However, please note that the minimum hourly charge unit still applies prior to terminating or pausing a service.
+
+Upgrading or changing to different service plan levels (e.g. **Startup-4** to **Business-8**) will not incur any additional cost.  Additionally, migrating a service to another cloud region or to a different cloud provider does not incur any additional costs.


### PR DESCRIPTION
An overview of the hourly billing model for all services doesn't appear to have been migrated over from this [original help article](http://help.aiven.io/en/articles/495327-hourly-billing-model-for-all-services). 

Transferring over that content from intercom (with some edits) and added under the section:

**Platform > Concepts > Billing > Hourly billing model for all services**

Includes updating the `toc` file along with the new `rst` file.


