### PR TITLE
Migrated credit card fee information from intercom help articles

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -103,6 +103,7 @@ entries:
         entries:
           - file: docs/platform/howto/manage-payment-card
           - file: docs/platform/howto/use-billing-groups
+          - file: docs/platform/howto/credit-card-fee
           - file: docs/platform/howto/change-billing-contact
           - file: docs/platform/howto/payment-issues-plan-upgrades
           - file: docs/platform/howto/custom-plans

--- a/docs/platform/howto/credit-card-fee.rst
+++ b/docs/platform/howto/credit-card-fee.rst
@@ -1,0 +1,7 @@
+## Credit card fees
+
+The prices listed of our website and in your invoices are inclusive of all credit card and processing fees related to the charges that are visible to us and payable by us. This includes transaction fees with our credit card processor (Stripe) and the fees various card issuers charge from merchants.
+
+Some credit card issuers may unfortunately add extra charges on top of the fees charged by us from your cards. The most common such fee is an "international transaction fee" charged by some issuers for all transactions where the native countries of the merchant (in case of us, Finland), processor (in case of us, United States), bank and card are different. The fee may be applied even if the card was charged in the card's default currency (USD).
+
+Such fees are not added by Aiven and are not visible to us or our credit card processor, and we're thus unable to include them in our prices or waive the fees.

--- a/docs/platform/howto/credit-card-fee.rst
+++ b/docs/platform/howto/credit-card-fee.rst
@@ -1,4 +1,5 @@
-## Credit card fees
+Credit card fees
+=================
 
 The prices listed of our website and in your invoices are inclusive of all credit card and processing fees related to the charges that are visible to us and payable by us. This includes transaction fees with our credit card processor (Stripe) and the fees various card issuers charge from merchants.
 


### PR DESCRIPTION
Credit card fee details migrated from old [help archive](https://app.intercom.com/a/apps/reo7593q/articles/articles/913806/show?request=%7B%22conditions%22%3A%7B%22languages%22%3A%5B%5D%2C%22status%22%3A%22published%22%2C%22collection_ids%22%3A%5B%22%22%2C%22341167%22%2C%22341199%22%5D%2C%22sync%22%3Anull%7D%2C%22order%22%3A%7B%22direction%22%3A%22desc%22%2C%22key%22%3A%22updated_at%22%7D%7D). 

Added to : docs -> platform -> howto -> billing


