### PR TITLE
Add instructions on moving projects

### DIFF
--- a/docs/platform/howto/manage-project.rst
+++ b/docs/platform/howto/manage-project.rst
@@ -59,11 +59,15 @@ To move a project from one organization or organizational unit to another:
 Delete a project
 ----------------
 
-In order to delete a project, you need to removes the services in it first. Once all the services are removed:
+To delete a project, you first need to delete all of the services in it. Once the services are deleted:
 
-1. Select the project from the **Project** drop down.
-2. Click on **Settings**.
-3. Click on **Remove project**. 
+#. Select the project from the **Projects** drop down.
+
+#. Click **Settings**.
+
+#. Click **Delete project**. 
+
+#. Click **Confirm**.
 
 .. note::
-    You can :ref:`delete a project using the Aiven CLI <avn-delete-project>` as well.
+    You can also :ref:`delete a project using the Aiven CLI <avn-delete-project>`.

--- a/docs/platform/howto/manage-project.rst
+++ b/docs/platform/howto/manage-project.rst
@@ -39,11 +39,15 @@ Renaming a project is possible **only** when all the services in the project are
 Move a project
 ---------------
 
-#. In the organization, click **Admin**.
+To move a project from one organization or organizational unit to another:
 
-#. In the organization details section, select the **Projects** tab.
+#. Open the organization or organizational unit that has the project using the drop-down menu in the top right.
 
-#. For the project you want to move, click **Move project**.
+#. Click **Admin**.
+
+#. Select the **Projects** tab.
+
+#. Find the project you want to move and click **Move project**.
 
 #. Select the organization or organizational unit that you want to move the project to.
 

--- a/docs/platform/howto/manage-project.rst
+++ b/docs/platform/howto/manage-project.rst
@@ -36,6 +36,22 @@ Renaming a project is possible **only** when all the services in the project are
 .. note::
     You can :ref:`rename a project using the Aiven CLI <avn-create-update-project>` as well.
 
+Move a project
+---------------
+
+#. In the organization, click **Admin**.
+
+#. In the organization details section, select the **Projects** tab.
+
+#. For the project you want to move, click **Move project**.
+
+#. Select the organization or organizational unit that you want to move the project to.
+
+#. Choose a billing group.
+
+#. Click **Move project**.
+
+
 Delete a project
 ----------------
 


### PR DESCRIPTION
# What changed, and why it matters
Added instructions on how to move projects between organizations/organizational units.

This will be published as part of the release of organizations/org units features in Q1.

