### PR TITLE
SUP-416: Postgresql log formats

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -556,7 +556,7 @@ entries:
           - file: docs/products/postgresql/reference/use-of-deprecated-tls-versions
             title: Use of deprecated TLS Versions
           - file: docs/products/postgresql/reference/log-formats-supported
-            title: Log formats supported
+            title: Supported log formats
 
   - file: docs/products/flink
     title: Apache Flink

--- a/_toc.yml
+++ b/_toc.yml
@@ -555,6 +555,8 @@ entries:
             title: Idle connections
           - file: docs/products/postgresql/reference/use-of-deprecated-tls-versions
             title: Use of deprecated TLS Versions
+          - file: docs/products/postgresql/reference/log-formats-supported
+            title: Log formats supported
 
   - file: docs/products/flink
     title: Apache Flink

--- a/docs/products/postgresql/reference/log-formats-supported.rst
+++ b/docs/products/postgresql/reference/log-formats-supported.rst
@@ -1,0 +1,18 @@
+Log formats supported
+=====================
+
+Aiven for PostgreSQL® supports setting different log formats which are compatible with popular log analysis tools like ``pgbadger`` or ``pganalyze``.
+
+You can use this functionality by navigating to your PostgreSQL® service on the `Aiven console <https://console.aiven.io/>`_.  
+
+Scroll down to the end of the overview page under ``Advanced configuration`` and select the ``Change`` button.  You can then select the ``pg.log_line_prefix`` parameter where there is a set of formats available that can be viewed from the drop down menu:  
+
+* ``'pid=%p,user=%u,db=%d,app=%a,client=%h '``
+* ``'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '``
+* ``'%m [%p] %q[user=%u,db=%d,app=%a] '``
+
+After selecting one of the available log formats from the drop down menu, you can click the ``Save advanced configuration`` button to have the change take effect.  Once the setting has been enabled, you can navigate to the logs tab on your service page to check if the log format has been successfully changed.
+
+At the moment, the formats available are known to be compatible with majority of the log analysis tools.
+
+For additional information on how to check the service logs, you can visit our :doc:`access service logs <../../../platform/howto/access-service-logs>` documentation.

--- a/docs/products/postgresql/reference/log-formats-supported.rst
+++ b/docs/products/postgresql/reference/log-formats-supported.rst
@@ -3,15 +3,32 @@ Log formats supported
 
 Aiven for PostgreSQL® supports setting different log formats which are compatible with popular log analysis tools like ``pgbadger`` or ``pganalyze``.
 
-You can use this functionality by navigating to your PostgreSQL® service on the `Aiven console <https://console.aiven.io/>`_.  
+You can use this functionality by navigating to your PostgreSQL® service on the `Aiven Console <https://console.aiven.io/>`_.  
 
-Scroll down to the end of the overview page under ``Advanced configuration`` and select the ``Change`` button.  You can then select the ``pg.log_line_prefix`` parameter where there is a set of formats available that can be viewed from the drop down menu:  
+Scroll down to the end of the overview page under **Advanced configuration** and select the **Change** button.  You can then select the ``pg.log_line_prefix`` parameter where there is a set of formats available that can be viewed from the drop down menu.  A sample of the log line outputs for each option is provided below:  
 
 * ``'pid=%p,user=%u,db=%d,app=%a,client=%h '``
+
+.. code-block::
+
+    [pg-user-test-1]2023-01-11T23:58:46.010530[postgresql-14][14-1] pid=625,user=postgres,db=defaultdb,app=[unknown],client=[local] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
+    [pg-user-test-1]2023-01-11T23:58:46.019705[postgresql-14][15-1] pid=625,user=postgres,db=defaultdb,app=aiven-pruned,client=[local] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]
+
 * ``'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '``
+
+.. code-block::
+
+    [pg-user-test-1]2023-01-11T23:59:46.592609[postgresql-14][16-1] 2023-01-11 23:59:46 GMT [949]: [2-1] user=postgres,db=defaultdb,app=[unknown],client=[local] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
+    [pg-user-test-1]2023-01-11T23:59:46.602035[postgresql-14][17-1] 2023-01-11 23:59:46 GMT [949]: [3-1] user=postgres,db=defaultdb,app=aiven-pruned,client=[local] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]
+
 * ``'%m [%p] %q[user=%u,db=%d,app=%a] '``
 
-After selecting one of the available log formats from the drop down menu, you can click the ``Save advanced configuration`` button to have the change take effect.  Once the setting has been enabled, you can navigate to the logs tab on your service page to check if the log format has been successfully changed.
+.. code-block::
+
+    [pg-user-test-1]2023-01-12T00:00:57.839867[postgresql-14][18-1] 2023-01-12 00:00:57.839 GMT [1323] [user=postgres,db=defaultdb,app=[unknown]] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
+    [pg-user-test-1]2023-01-12T00:00:57.849223[postgresql-14][19-1] 2023-01-12 00:00:57.849 GMT [1323] [user=postgres,db=defaultdb,app=aiven-pruned] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]
+
+After selecting one of the available log formats from the drop down menu, you can click the **Save advanced configuration** button to have the change take effect.  Once the setting has been enabled, you can navigate to the logs tab on your service page to check if the log format has been successfully changed.
 
 At the moment, the formats available are known to be compatible with majority of the log analysis tools.
 

--- a/docs/products/postgresql/reference/log-formats-supported.rst
+++ b/docs/products/postgresql/reference/log-formats-supported.rst
@@ -1,29 +1,31 @@
-Log formats supported
+Supported log formats
 =====================
 
 Aiven for PostgreSQL® supports setting different log formats which are compatible with popular log analysis tools like ``pgbadger`` or ``pganalyze``.
 
-You can use this functionality by navigating to your PostgreSQL® service on the `Aiven Console <https://console.aiven.io/>`_.  
+You can customise this functionality by navigating to your PostgreSQL® service on the `Aiven Console <https://console.aiven.io/>`_.  
 
-Scroll down to the end of the overview page under **Advanced configuration** and select the **Change** button.  You can then select the ``pg.log_line_prefix`` parameter where there is a set of formats available that can be viewed from the drop down menu.  A sample of the log line outputs for each option is provided below:  
+Scroll down to the end of the **Overview** page under **Advanced configuration** and select the **Change** button.  You can then select the ``pg.log_line_prefix`` parameter and select the needed format based on a pre-fixed list.  
+
+The supported log formats are available below with an example of the output:  
 
 * ``'pid=%p,user=%u,db=%d,app=%a,client=%h '``
 
-.. code-block::
+  .. code-block::
 
     [pg-user-test-1]2023-01-11T23:58:46.010530[postgresql-14][14-1] pid=625,user=postgres,db=defaultdb,app=[unknown],client=[local] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
     [pg-user-test-1]2023-01-11T23:58:46.019705[postgresql-14][15-1] pid=625,user=postgres,db=defaultdb,app=aiven-pruned,client=[local] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]
 
 * ``'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '``
 
-.. code-block::
+  .. code-block::
 
     [pg-user-test-1]2023-01-11T23:59:46.592609[postgresql-14][16-1] 2023-01-11 23:59:46 GMT [949]: [2-1] user=postgres,db=defaultdb,app=[unknown],client=[local] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
     [pg-user-test-1]2023-01-11T23:59:46.602035[postgresql-14][17-1] 2023-01-11 23:59:46 GMT [949]: [3-1] user=postgres,db=defaultdb,app=aiven-pruned,client=[local] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]
 
 * ``'%m [%p] %q[user=%u,db=%d,app=%a] '``
 
-.. code-block::
+  .. code-block::
 
     [pg-user-test-1]2023-01-12T00:00:57.839867[postgresql-14][18-1] 2023-01-12 00:00:57.839 GMT [1323] [user=postgres,db=defaultdb,app=[unknown]] LOG: connection authorized: user=postgres database=defaultdb application_name=aiven-pruned
     [pg-user-test-1]2023-01-12T00:00:57.849223[postgresql-14][19-1] 2023-01-12 00:00:57.849 GMT [1323] [user=postgres,db=defaultdb,app=aiven-pruned] LOG: disconnection: session time: 0:00:00.010 user=postgres database=defaultdb host=[local]


### PR DESCRIPTION
Migrated content for log formats supported on PostgreSQL under the Reference section of PostgreSQL.

Migrated from this [help article](https://app.intercom.com/a/apps/reo7593q/articles/articles/5187126/show?request=%7B%22conditions%22%3A%7B%22languages%22%3A%5B%5D%2C%22status%22%3A%22published%22%2C%22collection_ids%22%3A%5B%22%22%2C%22341167%22%2C%22341199%22%5D%2C%22sync%22%3Anull%7D%2C%22order%22%3A%7B%22direction%22%3A%22desc%22%2C%22key%22%3A%22updated_at%22%7D%7D) and updated the title to match the content of the article.  This article appears to be still valid in terms of selections of formats.

Uploaded the content under **PostgreSQL > Reference > Log formats supported**
