### PR TITLE
Update eol for OS 1.x

### DIFF
--- a/docs/platform/reference/eol-for-major-versions.rst
+++ b/docs/platform/reference/eol-for-major-versions.rst
@@ -51,7 +51,7 @@ Aiven for OpenSearch® is the open source continuation of the original Elasticse
 
    =========== ============= ==================
    **Version** **Aiven EOL** **Upstream EOL**
-   1.x         20??-??-??    20??-??-??
+   1.x         2023-12-31    2023-12-31
    2.x         20??-??-??    20??-??-??
    =========== ============= ==================
 


### PR DESCRIPTION
# What changed, and why it matters

EOL date is introduced in upstream OpenSearch. https://opensearch.org/releases.html

We follow the same eol for Aiven for opensearch