### PR TITLE
Custom canonical ul without html extension

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -11,42 +11,42 @@
 /grafana            /docs/products/grafana
 
 /api                /docs/tools/api
-/cli                /docs/tools/cli.html
+/cli                /docs/tools/cli
 /terraform          /docs/tools/terraform
 
 # Renamed/deleted files
-/docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution.html
+/docs/products/flink/howto/real-time-alerting-solution-cli.html       /docs/products/flink/howto/real-time-alerting-solution
 /docs/products/flink/howto/real-time-alerting-solution-cli            /docs/products/flink/howto/real-time-alerting-solution
-/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa.html
+/docs/platform/howto/disable-user-2fa.html                            /docs/platform/howto/user-2fa
 /docs/platform/howto/disable-user-2fa                                 /docs/platform/howto/user-2fa
-/docs/tools/terraform/upgrade-provider-v1-v2.html                     /docs/tools/terraform/howto/upgrade-provider-v1-v2.html
+/docs/tools/terraform/upgrade-provider-v1-v2.html                     /docs/tools/terraform/howto/upgrade-provider-v1-v2
 /docs/tools/terraform/upgrade-provider-v1-v2                          /docs/tools/terraform/howto/upgrade-provider-v1-v2
-/docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections.html
+/docs/products/mysql/howto/max-number-of-connections.html             /docs/products/mysql/concepts/max-number-of-connections
 /docs/products/mysql/howto/max-number-of-connections                  /docs/products/mysql/concepts/max-number-of-connections
-/docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability.html
+/docs/products/postgresql/reference/plan-iops.html                    /docs/products/postgresql/reference/resource-capability
 /docs/products/postgresql/reference/plan-iops                         /docs/products/postgresql/reference/resource-capability
-/docs/products/kafka/howto/enable-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/enable-schema-registry-authorization.html
+/docs/products/kafka/howto/enable-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/enable-schema-registry-authorization
 /docs/products/kafka/howto/enable-schema-registry-authorization       /docs/products/kafka/karapace/howto/enable-schema-registry-authorization
-/docs/products/kafka/howto/manage-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/manage-schema-registry-authorization.html
+/docs/products/kafka/howto/manage-schema-registry-authorization.html  /docs/products/kafka/karapace/howto/manage-schema-registry-authorization
 /docs/products/kafka/howto/manage-schema-registry-authorization       /docs/products/kafka/karapace/howto/manage-schema-registry-authorization
-/docs/platform/howto/renaming-a-service.html                          /docs/platform/howto/rename-a-service.html
+/docs/platform/howto/renaming-a-service.html                          /docs/platform/howto/rename-a-service
 /docs/platform/howto/renaming-a-service                               /docs/platform/howto/rename-a-service
-/docs/platform/howto/recovering-a-deleted-service.html                /docs/platform/howto/recover-a-deleted-service.html
+/docs/platform/howto/recovering-a-deleted-service.html                /docs/platform/howto/recover-a-deleted-service
 /docs/platform/howto/recovering-a-deleted-service                     /docs/platform/howto/recover-a-deleted-service
-/docs/products/opensearch/howto/upgrade-to-opensearch-with-terraform.html /docs/tools/terraform/howto/upgrade-to-opensearch.html
+/docs/products/opensearch/howto/upgrade-to-opensearch-with-terraform.html /docs/tools/terraform/howto/upgrade-to-opensearch
 /docs/products/opensearch/howto/upgrade-to-opensearch-with-terraform      /docs/tools/terraform/howto/upgrade-to-opensearch
 /docs/platform/howto/migrate-services                                 /docs/platform/howto/migrate-services-cloud-region
 /docs/products/clickhouse/howto/use-cli                                /docs/products/clickhouse/howto/connect-with-clickhouse-cli
-/docs/products/clickhouse/howto/use-cli.html                           /docs/products/clickhouse/howto/connect-with-clickhouse-cli.html
+/docs/products/clickhouse/howto/use-cli.html                           /docs/products/clickhouse/howto/connect-with-clickhouse-cli
 /docs/products/clickhouse/howto/grant-privilege                        /docs/products/clickhouse/howto/manage-users-roles
-/docs/products/clickhouse/howto/grant-privilege.html                   /docs/products/clickhouse/howto/manage-users-roles.html
+/docs/products/clickhouse/howto/grant-privilege.html                   /docs/products/clickhouse/howto/manage-users-roles
 /docs/products/clickhouse/howto/use-play                               /docs/products/clickhouse/howto/query-databases
-/docs/products/clickhouse/howto/use-play.html                          /docs/products/clickhouse/howto/query-databases.html
+/docs/products/clickhouse/howto/use-play.html                          /docs/products/clickhouse/howto/query-databases
 /docs/products/clickhouse/howto/use-query-editor                       /docs/products/clickhouse/howto/query-databases
-/docs/products/clickhouse/howto/use-query-editor.html                  /docs/products/clickhouse/howto/query-databases.html
+/docs/products/clickhouse/howto/use-query-editor.html                  /docs/products/clickhouse/howto/query-databases
 /docs/products/clickhouse/howto/add-service-users                      /docs/products/clickhouse/howto/manage-users-roles
-/docs/products/clickhouse/howto/add-service-users.html                 /docs/products/clickhouse/howto/manage-users-roles.html
-/docs/products/clickhouse/sample-dataset.html                          /docs/products/clickhouse/howto/load-dataset.html
+/docs/products/clickhouse/howto/add-service-users.html                 /docs/products/clickhouse/howto/manage-users-roles
+/docs/products/clickhouse/sample-dataset.html                          /docs/products/clickhouse/howto/load-dataset
 
 # Redirect from .index.html to specific page names for landing
 

--- a/_templates/base.html
+++ b/_templates/base.html
@@ -3,7 +3,7 @@
 {%- block extrahead %}
 {{ super() }}
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
-<link rel="canonical" href="https://docs.aiven.io/{{ pagename }}" />
+<link rel="canonical" href="https://docs.aiven.io/{{ pagename|replace("index", '') }}" />
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">

--- a/_templates/base.html
+++ b/_templates/base.html
@@ -2,8 +2,8 @@
 
 {%- block extrahead %}
 {{ super() }}
-
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
+<link rel="canonical" href="https://docs.aiven.io/{{ pagename }}" />
 
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">

--- a/conf.py
+++ b/conf.py
@@ -69,7 +69,8 @@ exclude_patterns = [
 gitstamp_fmt = "%B %Y"
 
 # sitemap config
-html_baseurl = 'https://docs.aiven.io'
+# No base url as we don't want to have .html extension in the canonical url. Custom set canonical tag in _template/base.html instead.
+html_baseurl = ''
 # Since we have `language='en'` set (further down) the URLs in the sitemap will
 # default to "{version}{lang}{link}", producing things like
 #    <url><loc>https://docs.aiven.io/en/docs/platform/howto/create_authentication_token.html</loc></url>


### PR DESCRIPTION
# What changed, and why it matters
In all pages, the canonical tags of [docs.aiven.io](http://docs.aiven.io/) are pointing to redirected URL versions ending with .html. For example, https://docs.aiven.io/docs/tools/api has a canonical to https://docs.aiven.io/docs/tools/api.html. This creates a redirect-canonical loop and makes the pages non-indexable. The canonical tags need to be the version without .html. So the canonical in the example should be https://docs.aiven.io/docs/tools/api

Resolving this [issue](https://github.com/aiven/devportal/issues/1691)

# Solution
Instead of using default [html_baseurl](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl), set custom canonical tag in base template to have control of the `pagename`.

# Demo
https://b0372b27.devportal.pages.dev/docs/tools/api
<img width="612" alt="Screenshot 2023-01-16 at 12 11 07" src="https://user-images.githubusercontent.com/3796599/212653274-c3d4b713-bddf-4466-9dc8-e5da0c08dcfb.png">



