### PR TITLE
Fix various `make spell` issues, and make the dictionary a little cleverer

### DIFF
--- a/.github/vale/dicts/aiven.aff
+++ b/.github/vale/dicts/aiven.aff
@@ -1,0 +1,30 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'
+ICONV 1
+ICONV ’ '
+NOSUGGEST !
+
+# ordinal numbers
+COMPOUNDMIN 1
+# only in compounds: 1th, 2th, 3th
+ONLYINCOMPOUND c
+# compound rules:
+# 1. [0-9]*1[0-9]th (10th, 11th, 12th, 56714th, etc.)
+# 2. [0-9]*[02-9](1st|2nd|3rd|[4-9]th) (21st, 22nd, 123rd, 1234th, etc.)
+COMPOUNDRULE 2
+COMPOUNDRULE n*1t
+COMPOUNDRULE n*mp
+WORDCHARS 0123456789
+
+# Gradually copying over rules from the Vale en_US dictionary at
+#   https://github.com/errata-ai/en_US-web
+# as necessary.
+
+SFX S Y 4
+SFX S   y     ies        [^aeiou]y
+SFX S   0     s          [aeiou]y
+SFX S   0     es         [sxzh]
+SFX S   0     s          [^sxzhy]
+
+SFX M Y 1
+SFX M   0     's         .

--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -32,7 +32,7 @@ Conduktor
 Coralogix
 connect
 Couchbase
-CPU
+CPU/MS
 CRD
 cyber
 datacenter
@@ -52,6 +52,7 @@ dockerized
 downsampled
 downsampling
 DSBulk
+DZone
 Elasticsearch
 Epicurious
 etcd
@@ -69,8 +70,8 @@ GitHub
 go
 Google Cloud Platform
 Gradle
-Grafana
-Grafana's
+Grafana/M
+GSuite
 hardcoded
 HashiCorp
 Homebrew
@@ -92,7 +93,7 @@ IPsec
 Java
 JMX
 Jolokia
-Kaggle
+Kaggle/M
 Kafdrop
 Kafka
 Karapace
@@ -118,11 +119,11 @@ MirrorMaker
 MongoDB
 MySQL
 myhoard
-namespace
-namespaces
+namespace/MS
 NodeJS
 nosqlbench
 npm
+NVMe
 OAuth
 Okta
 onboarding
@@ -140,8 +141,11 @@ Percona
 performant
 pgAdmin
 PgBouncer
+PGHoard
+pglookout
 plaintext
 plc
+PNG/S
 Plotly
 Podman
 pooler
@@ -179,9 +183,11 @@ Singlestat
 skyvia
 Snowflake
 Sphinx
+SLA/S
 Splunk
 spring
 Sql
+SSD/S
 Stackdriver
 Statusmap
 Stunnel
@@ -214,6 +220,7 @@ VNet
 wget
 Workbench
 Worldmap
+worldPing
 Zabbix
 zapier
 Zipkin

--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -209,7 +209,7 @@ UpCloud
 upsert
 VM
 VMs
-VPC
+VPC/MS
 VNet
 wget
 Workbench

--- a/docs/community/documentation/tips-tricks/renaming-files.rst
+++ b/docs/community/documentation/tips-tricks/renaming-files.rst
@@ -1,7 +1,7 @@
 Rename files and adding redirects
 ===================================
 
-The project supports a redirects file, named `_redirects`; the format is `source` and `destination` as paths relative to the root of the project. Here's an example::
+The project supports a redirects file, named ``_redirects``; the format is `source` and `destination` as paths relative to the root of the project. Here's an example::
 
     /docs/products/flink/howto/real-time-alerting-solution-cli.html    /docs/products/flink/howto/real-time-alerting-solution.html
 

--- a/docs/integrations/datadog/datadog-logs.rst
+++ b/docs/integrations/datadog/datadog-logs.rst
@@ -46,7 +46,7 @@ This is the format to use, replacing the variables listed. Don't edit the values
 
    DATADOG_API_KEY <%pri%>1 %timestamp:::date-rfc3339% %HOSTNAME%.AIVEN_PROJECT_NAME %app-name% - - - %msg%
 
-An example of the correct format, using an example API key and "my_project" as the project name:
+An example of the correct format, using an example API key and ``my_project`` as the project name:
 
 ``01234567890123456789abcdefabcdef <%pri%>1 %timestamp:::date-rfc3339% %HOSTNAME%.my_project %app-name% - - - %msg%``
 

--- a/docs/platform/howto/public-access-in-vpc.rst
+++ b/docs/platform/howto/public-access-in-vpc.rst
@@ -11,4 +11,4 @@ To enable public access for a service which is running within a virtual private 
 
 The connection with the **Dynamic** option is not possible outside the VPC, while the connection with the **Public** option is accessible over the public internet. *The IP allow list* applies to all connection types (Dynamic and Public, in this example).
 
-.. note:: You can change the **public_access** settings without any service downtime.
+.. note:: You can change the ``public_access`` settings without any service downtime.

--- a/docs/products/grafana/reference/plugins.rst
+++ b/docs/products/grafana/reference/plugins.rst
@@ -178,7 +178,7 @@ Prometheus - `Grafana <https://grafana.com/grafana/plugins/prometheus/>`__ | `Gr
     Work with the open-source service monitoring system and time series database.
 
 Prometheus AlertManager - `GitHub <https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource>`__
-    Allows you to use the Alertmanager's API of Prometheus to create dashboards in Grafana.
+    Allows you to use the AlertManager API of Prometheus to create dashboards in Grafana.
 
 SimpleJson - `Grafana <https://grafana.com/grafana/plugins/grafana-simple-json-datasource/>`__ | `GitHub <https://github.com/grafana/simple-json-datasource>`__
 

--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -83,7 +83,7 @@ Preview connectors
 ------------------
 
 .. image:: /images/products/kafka/kafka-connect/preview-kafka-connect-connectors.png
-   :alt: Preview icon next to a OpenSearch Apache Kafka Connect connector
+   :alt: Preview icon next to an OpenSearch® Apache Kafka® Connect connector
 
 Some of the available connectors have the |preview| tag next to the name. **Preview connectors do not come under our SLA**, consider this before using them for production purposes. 
 Bugs should be reported to the code owner directly.

--- a/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-iam-assume-role.rst
@@ -89,4 +89,4 @@ The connector configurations in a file (we'll refer to it with the name ``s3_sin
         "aws.s3.region": "<AWS_S3_REGION>"
     }
 
-To check all the Apache Kafka Connect® S3 sink connector by Aiven parameters and configuration options, browse the :doc:`dedicated document <s3-sink-connector-aiven>`.
+To check all the Apache Kafka® Connect S3 sink connector by Aiven parameters and configuration options, browse the :doc:`dedicated document <s3-sink-connector-aiven>`.

--- a/docs/products/opensearch/howto/opensearch-aggregations-and-nodejs.rst
+++ b/docs/products/opensearch/howto/opensearch-aggregations-and-nodejs.rst
@@ -377,7 +377,7 @@ However, our method is narrowed down to a specific scenario. We want to refactor
 * move aggregation field and bucket ranges to the list of method parameters
 * use the rest parameter syntax to collect range values
 * transform the list of range values into ``ranges`` object in a format `from X` / `to Y` expected by OpenSearch API
-* use logAggs function, which we already created, to log the results
+* use the ``logAggs`` function, which we already created, to log the results
 * separate ``body`` into a variable for better readability
 
 
@@ -729,7 +729,7 @@ The returned  data for every year including a value ``moving_average``::
 
 Pay attention to the values of ``count`` and ``moving_average``. To understand better how those numbers were calculated, we can compute first several values on our own:
 
-.. list-table:: Making sense of moving_average result
+.. list-table:: Making sense of the ``moving_average`` result
    :header-rows: 1
 
    * - Year

--- a/docs/products/opensearch/howto/sample-dataset.rst
+++ b/docs/products/opensearch/howto/sample-dataset.rst
@@ -113,7 +113,7 @@ When no data structure is specified, which is our case as shown on :ref:`load th
     pprint(fields)
     pprint(schema)
 
-You should be able to see the fields's output:
+You should be able to see the fields' output:
 
 .. code-block:: bash
 

--- a/docs/products/postgresql/howto/logical-replication-gcp-cloudsql.rst
+++ b/docs/products/postgresql/howto/logical-replication-gcp-cloudsql.rst
@@ -1,14 +1,14 @@
 Enable logical replication on Google Cloud SQL
 ================================================
 
-If you have not enabled logical replication on Cloud SQL PostgreSQL® already, the following instructions shows how to set the ``cloudsql.logical_decoding`` parameter to ``On``.
+If you have not enabled logical replication on Google Cloud SQL PostgreSQL® already, the following instructions shows how to set the ``cloudsql.logical_decoding`` parameter to ``On``.
 
-1. Set logical replication parameter for your Cloud SQL PostgreSQL® database.
+1. Set the logical replication parameter for your Cloud SQL PostgreSQL® database.
 
     .. image:: /images/products/postgresql/migrate-cloudsql-flags.png
         :alt: Cloud SQL PostgreSQL flags
 
-2. Authorize Aiven PostgresSQL IP to Cloud SQL's allowed network CIDR.
+2. Authorize the Aiven for PostgresSQL® IP to connect to Cloud SQL, using the network CIDR.
 
     .. image:: /images/products/postgresql/migrate-cloudsql-network.png
         :alt: Cloud SQL PostgreSQL network

--- a/docs/products/postgresql/howto/use-pg-repack-extension.rst
+++ b/docs/products/postgresql/howto/use-pg-repack-extension.rst
@@ -4,7 +4,7 @@ Use the PostgreSQL® ``pg_repack`` extension
 ``pg_repack`` is a PostgreSQL® extension that allows you to efficiently reorganize tables to remove any excess bloat the tables have accumulated. Reorganizing a table may take some time, but ``pg_repack`` tries to minimize the locks required to continue online operations.
 
 .. note:: 
-  Before you install the ``pg_repack`` extension, verify the version of the extension is supported on the PostgreSQL version you are using. For information on supported versions, see `pg_repack <https://reorg.github.io/pg_repack/>`_ documentation.   
+  Before you install the ``pg_repack`` extension, verify the version of the extension is supported on the PostgreSQL version you are using. For information on supported versions, see the ``pg_repack`` `documentation <https://reorg.github.io/pg_repack/>`_.
 
 Variables
 ---------

--- a/docs/products/postgresql/reference/terminology.rst
+++ b/docs/products/postgresql/reference/terminology.rst
@@ -18,8 +18,8 @@ Write-Ahead Log (WAL)
 
 .. _Terminology PGLookout:
 
-PGLookout
-    `PGLookout <https://github.com/aiven/pglookout>`_ is a PostgreSQL replication monitoring and failover daemon.
+pglookout
+    `pglookout <https://github.com/aiven/pglookout>`_ is a PostgreSQL replication monitoring and failover daemon.
 
 .. _Terminology PGHoard:
 

--- a/docs/products/redis/howto/connect-redis-cli.rst
+++ b/docs/products/redis/howto/connect-redis-cli.rst
@@ -32,7 +32,7 @@ Execute the following from a terminal window:
     redis-cli -u REDIS_URI
 
 
-This code connects to the Redis database.
+This code connects to the Redis®* database.
 
 To check the connection is working, execute the following code::
 

--- a/docs/tools/cli/service/flink.rst
+++ b/docs/tools/cli/service/flink.rst
@@ -105,7 +105,7 @@ For the Aiven for OpenSearch® :doc:`index integration </docs/products/flink/how
     - The name of the  Aiven for OpenSearch® index to use
 
 
-**Example:** Create a Flink table named ``KAlert`` on top of an Aiven for Apache Kafka topic in **insert mode** with:
+**Example:** Create an Apache Flink® table named ``KAlert`` on top of an Aiven for Apache Kafka® topic in **insert mode** with:
 
 * ``alert`` as source Apache Kafka **topic**
 * ``kafka`` as connector type
@@ -131,7 +131,7 @@ For the Aiven for OpenSearch® :doc:`index integration </docs/products/flink/how
         \"schema_sql\":\"cpu FLOAT, node INT, cpu_percent INT, occurred_at TIMESTAMP_LTZ(3)\"    
     }"""
 
-**Example:** Create a Flink table named ``KAlert`` on top of an Aiven for Apache Kafka topic in **upsert mode** with:
+**Example:** Create an Apache Flink® table named ``KAlert`` on top of an Aiven for Apache Kafka® topic in **upsert mode** with:
 
 * ``alert`` as source Apache Kafka **topic**
 * ``upsert-kafka`` as connector type
@@ -155,9 +155,9 @@ For the Aiven for OpenSearch® :doc:`index integration </docs/products/flink/how
         \"schema_sql\":\"cpu FLOAT, node INT PRIMARY KEY, cpu_percent INT, occurred_at TIMESTAMP_LTZ(3)\"    
     }"""
 
-**Example:** Create a Flink table named ``KAlert`` on top of an Aiven for PostgreSQL table with:
+**Example:** Create an Apache Flink® table named ``KAlert`` on top of an Aiven for PostgreSQL® table with:
 
-* ``alert`` as source PostgreSQL **table**
+* ``alert`` as source PostgreSQL® **table**
 * ``jdbc`` as connector type
 * ``cpu FLOAT, node INT PRIMARY KEY, cpu_percent INT, occurred_at TIMESTAMP(3)`` as **SQL schema**
 * ``ab8dd446-c46e-4979-b6c0-1aad932440c9`` as integration ID
@@ -175,9 +175,9 @@ For the Aiven for OpenSearch® :doc:`index integration </docs/products/flink/how
         \"schema_sql\":\"cpu FLOAT, node INT PRIMARY KEY, cpu_percent INT, occurred_at TIMESTAMP(3)\"    
     }"""
 
-**Example:** Create a Flink table named ``KAlert`` on top of an Aiven for OpenSearch index with:
+**Example:** Create an Apache Flink® table named ``KAlert`` on top of an Aiven for OpenSearch® index with:
 
-* ``alert`` as source OpenSearch **index**
+* ``alert`` as source OpenSearch® **index**
 * ``opensearch`` as connector type
 * ``cpu FLOAT, node INT PRIMARY KEY, cpu_percent INT, occurred_at TIMESTAMP(3)`` as **SQL schema**
 * ``ab8dd446-c46e-4979-b6c0-1aad932440c9`` as integration ID
@@ -199,7 +199,7 @@ For the Aiven for OpenSearch® :doc:`index integration </docs/products/flink/how
 ``avn service flink table delete``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Deletes an existing Aiven for Apache Flink table.
+Deletes an existing Aiven for Apache Flink® table.
 
 .. list-table::
   :header-rows: 1
@@ -212,7 +212,7 @@ Deletes an existing Aiven for Apache Flink table.
   * - ``table_id``
     - The ID of the table to delete
 
-**Example:** Delete the Flink table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** Delete the Apache Flink® table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
@@ -221,7 +221,7 @@ Deletes an existing Aiven for Apache Flink table.
 ``avn service flink table get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the definition of an existing Aiven for Apache Flink table.
+Retrieves the definition of an existing Aiven for Apache Flink® table.
 
 .. list-table::
   :header-rows: 1
@@ -234,7 +234,7 @@ Retrieves the definition of an existing Aiven for Apache Flink table.
   * - ``table_id``
     - The ID of the table to retrieve
 
-**Example:** Retrieve the definition of the Flink table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** Retrieve the definition of the Apache Flink® table with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
@@ -283,7 +283,7 @@ An example of ``avn service flink table get`` output:
 ``avn service flink table list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists all the Aiven for Apache Flink tables in a selected service.
+Lists all the Aiven for Apache Flink® tables in a selected service.
 
 .. list-table::
   :header-rows: 1
@@ -294,7 +294,7 @@ Lists all the Aiven for Apache Flink tables in a selected service.
   * - ``service_name``
     - The name of the service
 
-**Example:** List all the Flink tables available in the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** List all the Apache Flink® tables available in the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
@@ -309,13 +309,13 @@ An example of ``avn service flink table list`` output:
   315fe8af-34d9-4d7e-8711-bc7b6841dc55  882ee0be-cb0b-4ccf-b4d1-89d2e4a34260  ttt5         "id INT,\nage int"
   77741d89-71f1-4de6-897a-fd83bce0ee62  f7bbe17b-ab47-46fd-83cb-2f5d23656018  testname445  "id INT,\nname string"
 
-Manage a Flink job
+Manage an Apache Flink® job
 --------------------------------------------------------
 
 ``avn service flink job create``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new Aiven for Apache Flink job.
+Creates a new Aiven for Apache Flink® job.
 
 .. list-table::
   :header-rows: 1
@@ -333,7 +333,7 @@ Creates a new Aiven for Apache Flink job.
     - Flink job SQL statement
  
 
-**Example:** Create a Flink job named ``JobExample`` with:
+**Example:** Create an Apache Flink® job named ``JobExample`` with:
 
 * ``KCpuIn`` (with id ``cac53785-d1b5-4856-90c8-7cbcc3efb2b6``) and ``KAlert`` (with id ``54c2f4e6-a446-4d62-8dc9-2b81179c6f43``) as source/sink **tables**
 * ``INSERT INTO KAlert SELECT * FROM KCpuIn WHERE cpu_percent > 70`` as **SQL statement**
@@ -348,7 +348,7 @@ Creates a new Aiven for Apache Flink job.
 ``avn service flink job cancel``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Cancels an existing Aiven for Apache Flink job.
+Cancels an existing Aiven for Apache Flink® job.
 
 .. list-table::
   :header-rows: 1
@@ -361,7 +361,7 @@ Cancels an existing Aiven for Apache Flink job.
   * - ``job_id``
     - The ID of the job to delete
 
-**Example:** Cancel the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** Cancel the Apache Flink® job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
@@ -370,7 +370,7 @@ Cancels an existing Aiven for Apache Flink job.
 ``avn service flink job get``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Retrieves the definition of an existing Aiven for Apache Flink job.
+Retrieves the definition of an existing Aiven for Apache Flink® job.
 
 .. list-table::
   :header-rows: 1
@@ -383,7 +383,7 @@ Retrieves the definition of an existing Aiven for Apache Flink job.
   * - ``job_id``
     - The ID of the job to retrieve
 
-**Example:** Retrieve the definition of the Flink job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** Retrieve the definition of the Apache Flink® job with ID ``8b8ac2fe-b6eb-46bc-b327-fb4b84d27276`` belonging to the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   
@@ -400,7 +400,7 @@ An example of ``avn service flink job get`` output:
 ``avn service flink job list``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Lists all the Aiven for Apache Flink jobs in a selected service.
+Lists all the Aiven for Apache Flink® jobs in a selected service.
 
 .. list-table::
   :header-rows: 1
@@ -411,7 +411,7 @@ Lists all the Aiven for Apache Flink jobs in a selected service.
   * - ``service_name``
     - The name of the service
 
-**Example:** List all the Flink jobs available in the Aiven for Flink service ``flink-devportal-demo``.
+**Example:** List all the Apache Flink® jobs available in the Aiven for Flink service ``flink-devportal-demo``.
 
 ::
   


### PR DESCRIPTION
Fix a cluster of errors revealed on my local machine by `make spell`.

Fix: https://github.com/aiven/devportal/issues/1697

In particular:
* Start using `/S` (plural) and `/M` (possessive) markers in the dictionary. This also means putting some rules into the `.aff` dictionary file. I haven't tried to find all the places where we might use `/S` in the dictionary - there are probably others.
* Fix some odd cases where Vale was complaining about not enough ® marks, even though they already appeared to be sufficient when just looking at the file. In particular, add extra ® marks to `docs/tools/cli/service/flink.rst` beyond what Vale required, so that the text is self-consistent in how it uses them.
* Fix some cases of incorrect reStructuredText

I was not quite sure whether to keep this as one PR, or whether to split out the dictionary-related changes. Please ask if you'd prefer it split up into two or more PRs.

