### PR TITLE
Remove reference to unnecessary help article on old service deletion

### DIFF
--- a/docs/platform/concepts/service-power-cycle.rst
+++ b/docs/platform/concepts/service-power-cycle.rst
@@ -20,7 +20,7 @@ Whenever an Aiven service is powered off:
 
 .. Warning:: 
 
-    Aiven does `periodic cleanup of powered-off services <https://help.aiven.io/en/articles/4578430-periodic-cleanup-of-powered-off-services>`_ on services powered off for longer than **180** consecutive days. Notification emails will be sent before actions are taken.
+    Aiven does periodic cleanup of powered-off services on services powered off for longer than **180** consecutive days. Notification emails will be sent before actions are taken.
 
 * The message in the **Power Off Confirmation** window will give some hints on the consequence of the power off. Below is an example of powering off an Aiven for Redis®* service whose data since the latest backup will be lost because the service only has time-based but not PITR backups. 
 


### PR DESCRIPTION
The help article on deleting old services didn't actually add any new information, so the simplest thing is just to stop that text from being a link.

