### PR TITLE
Flink create kafka based flink table

### DIFF
--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -15,7 +15,7 @@ Create Apache Flink® table with Aiven Console
 To create a Apache Flink® table based on an Aiven for Apache Kafka® topic via the `Aiven Console <https://console.aiven.io/>`_:
 
 1. In the Aiven for Apache Flink service page, open the **Application** tab.
-2. :doc:`Create a new application <../howto/create-flink-applications>` or select an existing one with Aiven for Apache Kafka integration. 
+2. Create a new application or select an existing one with Aiven for Apache Kafka integration. 
 
 .. note:: 
     If editing an existing application, create a new version to make changes to the source or sink tables.

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -1,7 +1,7 @@
 Create an Apache Kafka®-based Apache Flink® table
 ==================================================
 
-To build data pipelines, Apache Flink® requires you to map source and target data structures as `Flink tables <https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/create/#create-table>`_ within an application. You can accomplish this through the Aiven console or Aiven CLI. 
+To build data pipelines, Apache Flink® requires you to map source and target data structures as `Flink tables <https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/create/#create-table>`_ within an application. You can accomplish this through the `Aiven Console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`. 
 
 When creating an application to manage streaming data, you can create a Flink table that connects to an existing or new Aiven for Apache Kafka® topic to source or sink streaming data. To define a table over an Apache Kafka® topic, you need to specify the topic name, clearly define the columns' data format, and choose the appropriate connector type. Additionally, enter a clear and meaningful name to the table for reference when building data pipelines.
 
@@ -9,43 +9,46 @@ When creating an application to manage streaming data, you can create a Flink ta
 
     In order to define Flink's tables an :doc:`existing integration <create-integration>` needs to be available between the Aiven for Flink service and one or more Aiven for Apache Kafka services.
 
-Create an Apache Kafka-based Apache Flink table with Aiven Console
-------------------------------------------------------------------
+Create Apache Flink® table with Aiven Console
+------------------------------------------------
 
-To create a Flink table based on an Aiven for Apache Kafka topic via Aiven console:
+To create a Apache Flink® table based on an Aiven for Apache Kafka® topic via the `Aiven Console <https://console.aiven.io/>`_:
 
-1. Navigate to the Aiven for Apache Flink service page, and open the **Jobs and Data** tab.
+1. In the Aiven for Apache Flink service page, open the **Application** tab.
+2. :doc:`Create a new application <../howto/create-flink-applications>` or select an existing one with Aiven for Apache Kafka integration. 
 
-2. Select the **Data Tables** sub-tab and select the Aiven for Apache Kafka integration to use
+.. note:: 
+    If editing an existing application, create a new version to make changes to the source or sink tables.
 
-3. Select the Aiven for Apache Kafka service and the **topic** to be used as source or target for the data pipeline. If you want to use a new topic not yet existing, write the topic name.
+3. In the **Create new version** screen, click **Add source tables**.
+4. Click **Add new table** or click **Edit** if you want to edit an existing source table. 
+5. In the **Add new source table** or **Edit source table** screen, select the Aiven for Apache Kafka service as the integrated service. 
+6. In the **Table SQL** section, enter the SQL statement to create the Apache Kafka-based Apache Flink table with the following details: 
 
-.. Warning::
+   * The topic to be used as a source for the data pipeline. If you want to use a new topic that does not yet exist, write the topic name.
 
-    By default Flink will not be able to automatically create Apache Kafka topics while pushing the first record. To change this behaviour, enable in the Aiven for Apache Kafka target service the ``kafka.auto_create_topics_enable`` option in **Advanced configuration** section.
+    .. Warning::
+        By default, Flink will not be able to create Apache Kafka topics while pushing the first record automatically. To change this behavior, enable in the Aiven for Apache Kafka target service the ``kafka.auto_create_topics_enable`` option in **Advanced configuration** section.
 
-4. Select the **Kafka connector type**, between the **Apache Kafka SQL Connector** for standard topic reads/writes and the **Upsert Kafka SQL Connector** for changelog type of integration based on message key.
-
-.. Note::   
-   For more information on the connector types and the requirements for each of them, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka-connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka-connector-requirements>`.
-
-5. Select the **Key Data Format**, if a value other than **Key not used** is selected, specify the fields from the SQL schema to be used as key. This setting is specifically needed to set message keys for topics acting as target of data pipelines.
-
-6. Select the **Value Data Format** based on the message format in the Apache Kafka topic.
-
-.. Note::
-
-    For Key and Value data format the following options are available
+   * Specify the **Kafka connector type**, between the **Apache Kafka SQL Connector** for standard topic reads/writes and the **Upsert Kafka SQL Connector** for changelog type of integration based on message key. 
+   
+    .. note::
+        For more information on the connector types and the requirements for each, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka-connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka-connector-requirements>`.
     
-    * `JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/json/>`_
-    * `Apache Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/avro/>`_
-    * `Confluent Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/avro-confluent/>`_
-    * `Debezium Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
-    * `Debezium JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
+   * Specify the **Key Data Format**. If a value other than **Key not used** is selected, specify the fields from the SQL schema to be used as key. This setting is specifically needed to set message keys for topics acting as target of data pipelines.
+   * Specify the **Value Data Format**. Based on the message format in the Apache Kafka topic. 
 
-7. Define the **Flink table name**; this name will represents the Flink reference to the topic and will be used during the data pipeline definition
+    .. note:: 
+        For Key and Value data format, the following options are available:  
 
-8. Define the **SQL schema**: the SQL schema defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`
+        * `JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/json/>`_
+        * `Apache Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/avro/>`_
+        * `Confluent Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/avro-confluent/>`_
+        * `Debezium Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
+        * `Debezium JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
+7. To create a sink table, click **Add sink tables** and repeat steps 4-6 for sink tables.
+8. Create a statement that defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`. 
+
 
 Example: Define a Flink table using the standard connector over topic in JSON format   
 ------------------------------------------------------------------------------------

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -32,18 +32,18 @@ To create a Apache Flink® table based on an Aiven for Apache Kafka® topic via 
 
    * The topic to be used as a source for the data pipeline. If you want to use a new topic that does not yet exist, write the topic name.
 
-    .. Warning::
+     .. Warning::
         By default, Flink will not be able to create Apache Kafka topics while pushing the first record automatically. To change this behavior, enable in the Aiven for Apache Kafka target service the ``kafka.auto_create_topics_enable`` option in **Advanced configuration** section.
 
    * Specify the **Kafka connector type**, between the **Apache Kafka SQL Connector** for standard topic reads/writes and the **Upsert Kafka SQL Connector** for changelog type of integration based on message key. 
    
-    .. note::
+     .. note::
         For more information on the connector types and the requirements for each, see the articles on :doc:`Kafka connector types </docs/products/flink/concepts/kafka-connectors>` and :doc:`the requirements for each connector type </docs/products/flink/concepts/kafka-connector-requirements>`.
     
    * Specify the **Key Data Format**. If a value other than **Key not used** is selected, specify the fields from the SQL schema to be used as key. This setting is specifically needed to set message keys for topics acting as target of data pipelines.
    * Specify the **Value Data Format**. Based on the message format in the Apache Kafka topic. 
 
-    .. note:: 
+     .. note:: 
         For Key and Value data format, the following options are available:  
 
         * `JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/json/>`_
@@ -52,7 +52,7 @@ To create a Apache Flink® table based on an Aiven for Apache Kafka® topic via 
         * `Debezium Avro <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
         * `Debezium JSON <https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/table/formats/debezium/>`_
 7. To create a sink table, click **Add sink tables** and repeat steps 4-6 for sink tables.
-8. Create a statement that defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`. 
+8. In the **Create statement** section, create a statement that defines the fields retrieved from each message in a topic, additional transformations such as format casting or timestamp extraction, and :doc:`watermark settings <../concepts/watermarks>`. 
 
 
 Example: Define a Flink table using the standard connector over topic in JSON format   

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -1,9 +1,9 @@
 Create an Apache Kafka®-based Apache Flink® table
 ==================================================
 
-To build data pipelines, Apache Flink® requires source and target data structures to `be mapped as Flink tables <https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/dev/table/sql/create/#create-table>`_. This functionality can be achieved via the `Aiven console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`.
+To build data pipelines, Apache Flink® requires you to map source and target data structures as `Flink tables <https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/create/#create-table>`_ within an application. You can accomplish this through the Aiven console or Aiven CLI. 
 
-A Flink table can be defined over an existing or new Aiven for Apache Kafka® topic to be able to source or sink streaming data. To define a table over an Apache Kafka® topic, the topic name, columns data format and connector type need to be defined, together with the Flink table name to use as reference when building data pipelines.
+When creating an application to manage streaming data, you can create a Flink table that connects to an existing or new Aiven for Apache Kafka® topic to source or sink streaming data. To define a table over an Apache Kafka® topic, you need to specify the topic name, clearly define the columns' data format, and choose the appropriate connector type. Additionally, enter a clear and meaningful name to the table for reference when building data pipelines.
 
 .. Warning::
 

--- a/docs/products/flink/howto/connect-kafka.rst
+++ b/docs/products/flink/howto/connect-kafka.rst
@@ -1,6 +1,11 @@
 Create an Apache Kafka®-based Apache Flink® table
 ==================================================
 
+.. warning:: 
+    As with many beta products, the Aiven for Apache Flink® experience, APIs and CLI calls are currently being redesigned, you might get error messages if using the currently documented ones.
+    
+    We will be working to update all the examples in the documentation.
+
 To build data pipelines, Apache Flink® requires you to map source and target data structures as `Flink tables <https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/create/#create-table>`_ within an application. You can accomplish this through the `Aiven Console <https://console.aiven.io/>`_ or :doc:`Aiven CLI </docs/tools/cli/service/flink>`. 
 
 When creating an application to manage streaming data, you can create a Flink table that connects to an existing or new Aiven for Apache Kafka® topic to source or sink streaming data. To define a table over an Apache Kafka® topic, you need to specify the topic name, clearly define the columns' data format, and choose the appropriate connector type. Additionally, enter a clear and meaningful name to the table for reference when building data pipelines.


### PR DESCRIPTION
# What changed, and why it matters

Edited the topic "Create an Apache Kafka®-based Apache Flink® table"  to include updated steps and changes to flow based on the Flink application.