### PR TITLE
Add links to cluster management

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -605,6 +605,8 @@ entries:
           - file: docs/products/flink/howto/real-time-alerting-solution
           - file: docs/products/flink/howto/manage-flink-tables
           - file: docs/products/flink/howto/slack-connector
+          - file: docs/products/flink/howto/list-manage-cluster
+            title: Manage cluster
       - file: docs/products/flink/reference
         title: Reference
         entries:

--- a/docs/products/flink/howto/list-manage-cluster.rst
+++ b/docs/products/flink/howto/list-manage-cluster.rst
@@ -1,0 +1,16 @@
+Manage your Aiven for Apache Flink® cluster
+===========================================
+
+This section provides the resources needed to manage your Aiven for Apache Flink® cluster effectively. You will learn to monitor, configure, scale, and your cluster to ensure optimal performance and efficiency. 
+
+:doc:`Monitor a managed service </docs/platform/howto/monitoring-services>`
+
+:doc:`Tag a managed service </docs/platform/howto/tag-resources>`
+
+:doc:`Schedule maintenance updates </docs/platform/howto/prepare-for-high-load>`
+
+:doc:`Resize a managed service </docs/platform/howto/scale-services>`
+
+:doc:`Migrate a managed service </docs/platform/howto/migrate-services-cloud-region>`
+
+:doc:`Power off & delete a managed service </docs/platform/howto/pause-from-cli>`


### PR DESCRIPTION
# What changed, and why it matters

Added Manage cluster section for Flink.
