### PR TITLE
SUP-431: Updated notes section regarding recreation of replication slots

### DIFF
--- a/docs/products/postgresql/concepts/upgrade-failover.rst
+++ b/docs/products/postgresql/concepts/upgrade-failover.rst
@@ -65,7 +65,7 @@ In case of failover or controlled switchover of an Aiven for PostgreSQL service,
 
 .. note::
 
-    The recreation of replication slots feature is enabled automatically and doesn't require restarting the nodes.
+    The recreation of replication slots feature is enabled automatically and doesn't require restarting the nodes for services that have been created or updated as of January 2023.  Additional details our outlined on `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_.
 
 .. important::
 

--- a/docs/products/postgresql/concepts/upgrade-failover.rst
+++ b/docs/products/postgresql/concepts/upgrade-failover.rst
@@ -65,7 +65,7 @@ In case of failover or controlled switchover of an Aiven for PostgreSQL service,
 
 .. note::
 
-    The recreation of replication slots feature is enabled automatically and doesn't require restarting the nodes for services that have been created or updated as of January 2023.  Additional details our outlined on `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_.
+    The recreation of replication slots feature is enabled automatically and doesn't require restarting the nodes for services that have been created or updated as of January 2023.  Additional details are outlined in `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_.
 
 .. important::
 

--- a/docs/products/postgresql/howto/setup-logical-replication.rst
+++ b/docs/products/postgresql/howto/setup-logical-replication.rst
@@ -175,6 +175,6 @@ For further information about WAL and checkpoints, read the `PostgreSQL document
 
 .. note::
 
-    The recreation of replication slots gets enabled automatically for services created or updated as of January 2023.  Additional details are outlined on `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_. 
+    The recreation of replication slots gets enabled automatically for services created or updated as of January 2023.  Additional details are outlined in `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_. 
     
-    Replication slots are recreated when a maintenance update is applied or a failover occurs, but they are not recovered after major version upgrades.
+    Replication slots are recreated when a maintenance update is applied or a failover occurs (for multi-node clusters), but they are not recovered after major version upgrades.

--- a/docs/products/postgresql/howto/setup-logical-replication.rst
+++ b/docs/products/postgresql/howto/setup-logical-replication.rst
@@ -175,4 +175,6 @@ For further information about WAL and checkpoints, read the `PostgreSQL document
 
 .. note::
 
-    The recreation of replication slots gets enabled automatically. Replication slots are recreated when a maintenance update is applied or a failover occurs, but they are not recovered after major version upgrades.
+    The recreation of replication slots gets enabled automatically for services created or updated as of January 2023.  Additional details are outlined on `our blog post <https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots>`_. 
+    
+    Replication slots are recreated when a maintenance update is applied or a failover occurs, but they are not recovered after major version upgrades.


### PR DESCRIPTION
# What changed, and why it matters

Since the release of this [January blog post about PG logical replication slots recreation upon failover](https://aiven.io/blog/aiven-for-pg-recreates-logical-replication-slots), we should update our documentation "Note" sections to mention that services that have been updated or deployed since January 2023 would have this feature available and doesn't require restarting nodes.

For PostgreSQL services that have not been updated from December 2022 and earlier, service nodes wouldn't have this feature and would still lose their logical replication slots per internal discussion.

- [Recreation of replication slots](https://docs.aiven.io/docs/products/postgresql/concepts/upgrade-failover#recreation-of-replication-slots)
- [Manage inactive or lagging replication slots](https://docs.aiven.io/docs/products/postgresql/howto/setup-logical-replication#manage-inactive-or-lagging-replication-slots)
