### PR TITLE
Fixing invalid boolean value based on testing.

### DIFF
--- a/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization.rst
+++ b/docs/products/kafka/karapace/howto/enable-kafka-rest-proxy-authorization.rst
@@ -5,11 +5,11 @@ Aiven for Apache Kafka® services have :doc:`Apache Kafka® REST proxy authoriza
 
 1. To enable Apache Kafka REST proxy authorization for a service, replace the ``SERVICE_NAME`` placeholder with the name of the Aiven for Apache Kafka® service in the Aiven CLI::
 
-    avn service update -c kafka_rest_authorization=True SERVICE_NAME
+    avn service update -c kafka_rest_authorization=true SERVICE_NAME
 
 2. You can similarly disable the Apache Kafka® REST proxy authorization using::
 
-    avn service update -c kafka_rest_authorization=False SERVICE_NAME
+    avn service update -c kafka_rest_authorization=false SERVICE_NAME
 
 .. warning:: 
     Enabling Apache Kafka REST proxy authorization can disrupt access for users if the Kafka access control rules have not been configured properly. For more information, see :doc:`Manage Apache Kafka® REST proxy authorization <../howto/manage-kafka-rest-proxy-authorization>`.


### PR DESCRIPTION
# What changed, and why it matters

This PR updates the Karapace docs to update the boolean values with the correct format.

From my testing:

```
dewan.ahmed@Dewans-MacBook-Pro opa % avn service update -c kafka_rest_authorization=True demo-kafka
ERROR	command failed: UserError: Invalid boolean value 'True': expected one of 1, 0, true, false
dewan.ahmed@Dewans-MacBook-Pro opa % avn service update -c kafka_rest_authorization=true demo-kafka
```

Using `True` or `False`, the user will get an error. This PR updates the command with `true` and `false` which are the expected boolean values.
