### PR TITLE
Added a blurb about max users for servics. (SUP-436)

### DIFF
--- a/docs/platform/howto/create_new_service_user.rst
+++ b/docs/platform/howto/create_new_service_user.rst
@@ -4,13 +4,11 @@
 Service users are users that only exist in the scope of the corresponding Aiven service. They are unique to this service and not shared with any other services, and can be granted restricted permissions compared to the default ``avnadmin`` user. You can add service users for all the Aiven services, with the exception of Aiven for Apache Flink® and Aiven for Grafana®.
 
 .. warning::
-   By default, the maximum amount of users allowed on a service is 50. If a service user is created that exceeds the max users, the following error will be produced.
+   By default, the maximum amount of users allowed on a service is 50. 
    
-   .. code-block:: python 
       
-      "Service user 'xxx' cannot be created, maximum number of users for this plan exceeded"
 
-   If you would like to increase the maximum amount of users on a service, please reach out to the Aiven support team to request an increase.
+   If you would like to increase the maximum number of users allowed for a service, :doc:`create a support ticket </docs/platform/howto/project-support-center>` to request an increase.
 
 1. Log in to the `Aiven console <https://console.aiven.io/>`_.
 

--- a/docs/platform/howto/create_new_service_user.rst
+++ b/docs/platform/howto/create_new_service_user.rst
@@ -3,6 +3,15 @@
 
 Service users are users that only exist in the scope of the corresponding Aiven service. They are unique to this service and not shared with any other services, and can be granted restricted permissions compared to the default ``avnadmin`` user. You can add service users for all the Aiven services, with the exception of Aiven for Apache Flink® and Aiven for Grafana®.
 
+.. warning::
+   By default, the maximum amount of users allowed on a service is 50. If a service user is created that exceeds the max users, the following error will be produced.
+   
+   .. code-block:: python 
+      
+      "Service user 'xxx' cannot be created, maximum number of users for this plan exceeded"
+
+   If you would like to increase the maximum amount of users on a service, please reach out to the Aiven support team to request an increase.
+
 1. Log in to the `Aiven console <https://console.aiven.io/>`_.
 
 2. On the **Services** page, click on the service name.


### PR DESCRIPTION
# What changed, and why it matters
Added a blurb to platform/howto/create_new_service_user to inform customers of the default max user limit, and provide guidance if they want to increase their limit.

