### PR TITLE
Update CLI docs for orgs/units release

### DIFF
--- a/docs/tools/cli/account.rst
+++ b/docs/tools/cli/account.rst
@@ -1,27 +1,19 @@
 ``avn account``
-==================================
+================
 
-This article has the full list of commands for ``avn account``. An account is the same as an organization or organizational unit.
-
-
-Manage account details
--------------------------
-
-Commands for managing Aiven accounts via ``avn`` commands. 
+This article has the full list of commands for managing organization or organizational unit details using ``avn account``. An account is the same as an :doc:`organization or organizational unit </docs/platform/concepts/projects_accounts_access>`.
 
 Check out the full description of :doc:`Aiven's security model </docs/platform/concepts/cloud-security>` for more information.
-
 
 ``avn account authentication-method``
 '''''''''''''''''''''''''''''''''''''
 
-:doc:`See detailed command information <account/account-authentication-method>`
-
+A full list of commands is available in a :doc:`separate article for managing authentication methods in the CLI <account/account-authentication-method>`.
 
 ``avn account create``
 '''''''''''''''''''''''
 
-Creates a new account.
+Creates a new organization or organizational unit.
 
 .. list-table::
   :header-rows: 1
@@ -30,18 +22,29 @@ Creates a new account.
   * - Parameter
     - Information
   * - ``--name``
-    - The name of the account
+    - The name of the organization or unit
+  * - ``--parent-account-id``
+    - The ID of the organization
 
-**Example:** Create a new account for the  ``billing-analytics`` department.
+To create a new organizational unit, specify the parent organization using ``--parent-account-id``.
+
+**Example:** Create an organizational unit for production in an organization with the ID ``123456789123``. 
+
+::
+
+  avn account create --name "Production" --parent-account-id 123456789123
+
+**Example:** Create a new organization for the billing analytics department.
 
 ::
 
   avn account create --name "Billing Analytics"
 
+
 ``avn account delete``
 '''''''''''''''''''''''
 
-Deletes an existing account.
+Deletes an organization or organizational unit.
 
 .. list-table::
   :header-rows: 1
@@ -50,26 +53,21 @@ Deletes an existing account.
   * - Parameter
     - Information
   * - ``account_id``
-    - The id of the account
+    - The id of the organization or unit
 
-**Example:** Delete the account with id ``123456789123``.
+**Example:** Delete the organization with id ``123456789123``.
 
 ::
 
   avn account delete 123456789123
 
+
 ``avn account list``
-'''''''''''''''''''''''
+'''''''''''''''''''''
 
-Lists existing accounts information including account id, name, team owner id, created time, tenant id and update time.
+Lists the details of organizations and organizational units including ID (account ID), name, team owner ID, created time, tenant ID, and time last updated.
 
-**Example:** List existing accounts.
-
-::
-
-  avn account list
-
-An example of account list output:
+An example of the output:
 
 .. code:: text
 
@@ -77,15 +75,17 @@ An example of account list output:
     ============  ======================  =====================  ====================  ================  ========================  ============  ====================
     123456789123  Billing Analytics       45678910111213         2020-09-09T20:28:44Z  true              null                      my_tenant_id  2020-09-09T20:28:44Z
 
+
 ``avn account team``
 '''''''''''''''''''''''
 
-:doc:`See detailed command information <account/account-team>`
+A full list of commands is available in a :doc:`separate article for managing teams in the CLI <account/account-team>`.
+
 
 ``avn account update``
 '''''''''''''''''''''''
 
-Updates an existing account's name.
+Changes the name of an organization or organizational unit.
 
 .. list-table::
   :header-rows: 1
@@ -94,11 +94,11 @@ Updates an existing account's name.
   * - Parameter
     - Information
   * - ``account_id``
-    - The id of the account
+    - The ID of the organization or unit
   * - ``--name``
-    - The account new name
+    - The new name
 
-**Example:** Update the name of account with id ``123456789123`` to ``Billing Analytics Account``.
+**Example:** Change the name of organizational unit with the ID ``123456789123`` to ``Billing Analytics Account``.
 
 ::
 

--- a/docs/tools/cli/account.rst
+++ b/docs/tools/cli/account.rst
@@ -1,7 +1,7 @@
 ``avn account``
 ==================================
 
-Here you’ll find the full list of commands for ``avn account``.
+This article has the full list of commands for ``avn account``. An account is the same as an organization or organizational unit.
 
 
 Manage account details

--- a/docs/tools/cli/billing-group.rst
+++ b/docs/tools/cli/billing-group.rst
@@ -159,7 +159,7 @@ Deletes a billing group.
   * - ``id``
     - The billing group ID 
 
-**Example:** Delete the billing group with id ``55b0e547-58f9-48de-8808-807d385d1f95``:
+**Example:** Delete the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
 .. code:: shell
 

--- a/docs/tools/cli/billing-group.rst
+++ b/docs/tools/cli/billing-group.rst
@@ -1,7 +1,7 @@
 ``avn billing-group``
 =====================
 
-This article has the full list of commands for managing billing groups using ``avn billing-group``. An account is the same as an :doc:`organization or organizational unit </docs/platform/concepts/projects_accounts_access>`.
+This article has the full list of commands for managing billing groups assigned to organizations using ``avn billing-group``. An account is the same as an :doc:`organization </docs/platform/concepts/projects_accounts_access>`.
 
 ``avn billing-group assign-projects``
 '''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/billing-group.rst
+++ b/docs/tools/cli/billing-group.rst
@@ -1,19 +1,12 @@
 ``avn billing-group``
-==================================
+=====================
 
-Here you'll find the full list of commands for ``avn billing-group``.
-
-
-Work with billing groups
--------------------------
-
-Commands for managing billing groups and using them with ``avn`` commands.
-
+This article has the full list of commands for managing billing groups using ``avn billing-group``. An account is the same as an :doc:`organization or organizational unit </docs/platform/concepts/projects_accounts_access>`.
 
 ``avn billing-group assign-projects``
 '''''''''''''''''''''''''''''''''''''
 
-Adds the given projects to the given billing group
+Adds projects to a billing group.
 
 .. list-table::
   :header-rows: 1
@@ -24,11 +17,11 @@ Adds the given projects to the given billing group
   * - ``id``
     - The ID of your billing group
   * - ``projects``
-    - Name(s) of projects to assign (separated by spaces)
+    - Names of the projects to assign, separated by spaces
 
 **Example:** Add the project ``new-project`` to the existing billing group with id ``55b0e547-58f9-48de-8808-807d385d1f95``
 
-::
+.. code:: shell
 
   avn biling-group assign-projects 55b0e547-58f9-48de-8808-807d385d1f95 new-project
 
@@ -36,7 +29,7 @@ Adds the given projects to the given billing group
 ``avn billing-group create`` and ``avn billing-group update``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new billing group with ``create`` or amend it with ``update``
+Creates a new billing group with ``create`` or amends a billing group with ``update``.
 
 .. list-table::
   :header-rows: 1
@@ -49,15 +42,15 @@ Creates a new billing group with ``create`` or amend it with ``update``
   * - ``ID`` (required for ``update``)
     - Note: This is a positional argument, not a switch
   * - ``--account-id``
-    - The account ID to create the billing group in
+    - The ID of the organization or unit to create the billing group in
   * - ``--card-id``
     - The card ID (see ``avn card``)
   * - ``--vat-id``
     - VAT ID for this billing group
   * - ``--billing-currency``
-    - The currency to bill in. The choices are: "AUD" "CAD" "CHF" "DKK" "EUR" "GBP" "NOK" "SEK" "USD"
+    - The currency to bill in: ``AUD``, ``CAD``, ``CHF``, ``DKK``, ``EUR``, ``GBP``, ``NOK``, ``SEK``, or ``USD``
   * - ``--billing-extra-text``
-    - Information to include with an invoice such as a cost center number
+    - Information to include in an invoice (for example, a cost center number)
   * - ``--billing-email``
     - Email for the billing contact
   * - ``--company``
@@ -73,7 +66,7 @@ Creates a new billing group with ``create`` or amend it with ``update``
   * - ``--zip-code``
     - ZIP / Post Code
 
-**Example:** Create a billing-group named ``qa-dept`` under the account with ID ``c59dde4j9`` with the following properties:
+**Example:** Create a billing group named ``qa-dept`` in the organization that has the account ID ``c59dde4j9`` and give it the following properties:
 
 * currency: ``EUR``
 * e-mail address: ``billing@testers.dev``
@@ -82,7 +75,7 @@ Creates a new billing group with ``create`` or amend it with ``update``
 * country code: ``SE``
 * city: ``Stockholm``
 
-::
+.. code:: shell
 
   avn billing-group create qa-dept        \
     --account-id c59dde4j9                \
@@ -95,7 +88,7 @@ Creates a new billing group with ``create`` or amend it with ``update``
 
 **Example:** Rename your ``qa-dept`` billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95`` to ``qa-department``.
 
-::
+.. code:: shell
 
   avn billing-group update               \
     55b0e547-58f9-48de-8808-807d385d1f95 \
@@ -104,7 +97,7 @@ Creates a new billing group with ``create`` or amend it with ``update``
 ``avn billing-group credits-claim``
 ''''''''''''''''''''''''''''''''''''
 
-Claim a credit code within your biling-group
+Claims a credit code within your biling-group.
 
 .. list-table::
   :header-rows: 1
@@ -113,13 +106,13 @@ Claim a credit code within your biling-group
   * - Parameter
     - Information
   * - ``id``
-    - The ID of your billing group
+    - The billing group ID 
   * - ``code``
     - Credit Code
 
-**Example:** Claim the credit code ``sneaky-crab`` in the billing-group having ID ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** Claim the credit code ``sneaky-crab`` in the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group credits-claim 55b0e547-58f9-48de-8808-807d385d1f95 sneaky-crab
 
@@ -137,9 +130,9 @@ Lists all the credits redeemed in your billing-group
   * - ``id``
     - The ID of your billing group
 
-**Example:** List credits claimed in the billing-group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** List credits claimed in the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``
 
-::
+.. code:: shell
 
   avn billing-group credits-list 55b0e547-58f9-48de-8808-807d385d1f95
 
@@ -155,7 +148,7 @@ An example of ``avn billing-group credits-list`` output:
 ``avn billing-group delete``
 ''''''''''''''''''''''''''''''''''''
 
-Deletes a billing-group
+Deletes a billing group.
 
 .. list-table::
   :header-rows: 1
@@ -164,18 +157,18 @@ Deletes a billing-group
   * - Parameter
     - Information
   * - ``id``
-    - The ID of your billing group
+    - The billing group ID 
 
-**Example:** Delete your billing-group with id ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** Delete the billing group with id ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group delete 55b0e547-58f9-48de-8808-807d385d1f95
 
 ``avn billing-group events``
 '''''''''''''''''''''''''''''
 
-List the events that have occurred for a given billing-group 
+Lists the activity for a given billing group.
 
 .. list-table::
   :header-rows: 1
@@ -184,11 +177,11 @@ List the events that have occurred for a given billing-group
   * - Parameter
     - Information
   * - ``id``
-    - The ID of your billing group
+    - The billing group ID 
 
-**Example:** List events in the billing-group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** List activity for the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group events 55b0e547-58f9-48de-8808-807d385d1f95
 
@@ -216,7 +209,7 @@ An example of ``avn billing-group events`` output:
 ``avn billing-group get``
 ''''''''''''''''''''''''''
 
-Gets the details for a given billing-group
+Gets the details for a given billing group.
 
 .. list-table::
   :header-rows: 1
@@ -225,11 +218,11 @@ Gets the details for a given billing-group
   * - Parameter
     - Information
   * - ``id``
-    - The ID of your billing group
+    - The billing group ID
 
-**Example:** Get details for the billing-group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** Get details for the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group get 55b0e547-58f9-48de-8808-807d385d1f95
 
@@ -258,16 +251,16 @@ Retrieve the lines for a given invoice
   * -  ``invoice```
     - The number of the invoice
 
-**Example:** Retrieve lines from the invoice ``94885-2`` for the billing group with id ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** Retrieve lines from the invoice ``94885-2`` for the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group invoice-lines 55b0e547-58f9-48de-8808-807d385d1f95 94885-2
 
 ``avn billing-group invoice-list``
 ''''''''''''''''''''''''''''''''''''
 
-List all invoices for a given billing group
+Lists all invoices for a billing group:
 
 .. list-table::
   :header-rows: 1
@@ -278,9 +271,9 @@ List all invoices for a given billing group
   * - ``id``
     - The ID of your billing group
 
-**Example:** List invoices for billing-group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``
+**Example:** List all invoices for the billing group with ID ``55b0e547-58f9-48de-8808-807d385d1f95``:
 
-::
+.. code:: shell
 
   avn billing-group invoice-list 55b0e547-58f9-48de-8808-807d385d1f95
 
@@ -296,11 +289,11 @@ An example of ``avn billing-group invoice-list`` output:
 ``avn billing-group list``
 '''''''''''''''''''''''''''
 
-Lists all of your billing-groups
+Lists all of your billing-groups.
 
-**Example:** List all of your billing-groups
+**Example:** List all billing-groups:
 
-::
+.. code:: shell
 
   avn billing-group list
 

--- a/docs/tools/cli/card.rst
+++ b/docs/tools/cli/card.rst
@@ -1,19 +1,12 @@
 ``avn card``
 ===============================
 
-Here you’ll find the full list of commands for ``avn card``.
-
-
-Manage credit cards
--------------------
-
-Commands for managing credit card details associated to Aiven projects.
-
+This article has the full list of commands for managing credit card details using ``avn account``. 
 
 ``avn card add``
 ''''''''''''''''
 
-Adds a new credit card to the Aiven account.
+Adds a new credit card.
 
 .. list-table::
   :header-rows: 1
@@ -34,27 +27,25 @@ Adds a new credit card to the Aiven account.
   * - ``--update-project``
     - Assign card to a project
 
-**Example:** Add a credit card to a named project.
+**Example:** Add a credit card:
 
-::
+.. code:: shell
 
   avn card add --cvc 123         \
     --exp-month 01               \
     --exp-year 2031              \
     --name "Name Surname"        \
-    --number 4111111111111111    \
-    --update-project my-project
-
+    --number 4111111111111111
 
 ``avn card list``
 '''''''''''''''''
 
-Lists credit cards associated with this account.
+Lists all credit cards.
 
 
-**Example:** List all credit cards associated with this account.
+**Example:** List credit cards:
 
-::
+.. code:: shell
 
   avn card list
 
@@ -62,7 +53,7 @@ Lists credit cards associated with this account.
 ``avn card remove``
 '''''''''''''''''''
 
-Removes a credit card associated with the Aiven account.
+Removes a credit card.
 
 .. list-table::
   :header-rows: 1
@@ -74,16 +65,16 @@ Removes a credit card associated with the Aiven account.
     - The ID shown for this card in the ``list`` command output
 
 
-**Example:** Remove a credit card associated with the Aiven account.
+**Example:** Remove a credit card:
 
-::
+.. code:: shell
 
   avn card remove AAAAAAAA-BBBB-CCCC-DDDD-0123456789AB
 
 ``avn card update``
 '''''''''''''''''''
 
-Updates a credit card associated with the account.
+Updates a credit card.
 
 .. list-table::
     :header-rows: 1
@@ -96,14 +87,14 @@ Updates a credit card associated with the account.
     * - ``--exp-month``
       - Card expiration month (1-12)
     * - ``--exp-year``
-      - Card expiration year
+      - Card expiration year (YYYY)
     * - ``--name``
       - Name on the credit card
 
 
-**Example:** Update a credit card associated with the Aiven account.
+**Example:** Update a credit card:
 
-::
+.. code:: shell
 
     avn card update AAAAAAAA-BBBB-CCCC-DDDD-0123456789AB \
         --exp-month 01                                   \

--- a/docs/tools/cli/card.rst
+++ b/docs/tools/cli/card.rst
@@ -1,7 +1,7 @@
 ``avn card``
 ===============================
 
-This article has the full list of commands for managing credit card details using ``avn account``. 
+This article has the full list of commands for managing credit card details using ``avn card``. 
 
 ``avn card add``
 ''''''''''''''''
@@ -27,7 +27,7 @@ Adds a new credit card.
   * - ``--update-project``
     - Assign card to a project
 
-**Example:** Add a credit card:
+**Example:** 
 
 .. code:: shell
 
@@ -40,10 +40,7 @@ Adds a new credit card.
 ``avn card list``
 '''''''''''''''''
 
-Lists all credit cards.
-
-
-**Example:** List credit cards:
+Lists all credit cards:
 
 .. code:: shell
 
@@ -65,7 +62,7 @@ Removes a credit card.
     - The ID shown for this card in the ``list`` command output
 
 
-**Example:** Remove a credit card:
+**Example:** 
 
 .. code:: shell
 
@@ -92,7 +89,7 @@ Updates a credit card.
       - Name on the credit card
 
 
-**Example:** Update a credit card:
+**Example:** 
 
 .. code:: shell
 

--- a/docs/tools/cli/project.rst
+++ b/docs/tools/cli/project.rst
@@ -1,14 +1,10 @@
 ``avn project``
-==================================
+================
 
-Here you'll find the full list of commands for ``avn project``.
+This article has the full list of commands for managing projects in Aiven using ``avn project``. 
 
-
-Work with project details
--------------------------
-
-Commands for managing projects and using them with ``avn`` commands.
-
+Manage project details
+-----------------------
 
 ``avn project details``
 '''''''''''''''''''''''
@@ -24,16 +20,16 @@ Fetches project details.
   * - ``--project``
     - The project to fetch details for
 
-**Example:** Show the details of the currently selected project.
+**Example:** Show the details of the currently selected project:
 
-::
+.. code:: shell
 
   avn project details
 
 
-**Example:** Show the details of a named project.
+**Example:** Show the details of a project:
 
-::
+.. code :: shell
 
   avn project details --project my-project
 
@@ -41,7 +37,7 @@ Fetches project details.
 ``avn project switch``
 ''''''''''''''''''''''
 
-Sets the default project to use with ``avn``.
+Sets the default project to use when one is not specified in an ``avn`` command.
 
 .. list-table::
   :header-rows: 1
@@ -50,11 +46,11 @@ Sets the default project to use with ``avn``.
   * - Parameter
     - Information
   * - ``--project``
-    - The project to use when a project isn't specified for an ``avn`` command
+    - The project name
 
-**Example:** Change to use the project called ``my-project`` as default for all commands where the ``--project`` parameter isn't supplied.
+**Example:** Make the project named ``my-project`` the default for all commands where the ``--project`` parameter isn't supplied:
 
-::
+.. code:: shell
 
   avn project switch --project my-project
 
@@ -64,9 +60,9 @@ Sets the default project to use with ``avn``.
 
 Lists all the projects that you have access to.
 
-**Example:** List all the projects available to use with a ``--project`` command switch.
+**Example:** List all the projects available to use with a ``--project`` command switch:
 
-::
+.. code:: shell
 
   avn project list
 
@@ -75,7 +71,7 @@ Lists all the projects that you have access to.
 ``avn project create`` and ``avn project update``
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-Creates a new project with ``create`` or changes the settings with ``update``.
+Creates a new project with ``create`` or changes the settings with ``update``. An account is the same as an :doc:`organization or organizational unit </docs/platform/concepts/projects_accounts_access>`.
 
 .. list-table::
   :header-rows: 1
@@ -90,7 +86,7 @@ Creates a new project with ``create`` or changes the settings with ``update``.
   * - ``--name`` (``update`` only)
     - Supply a new name for the project
   * - ``--account-id``
-    - The account to create the project in
+    - The organization or unit to create the project in
   * - ``--billing-group-id``
     - Billing group ID to use
   * - ``--card-id``
@@ -116,15 +112,15 @@ Creates a new project with ``create`` or changes the settings with ``update``.
   * - ``--tech-email``
     - Email for the technical contact
 
-**Example:** Create a project named ``my-project``.
+**Example:** Create a project named ``my-project``:
 
-::
+.. code:: shell
 
   avn project create my-project
 
-**Example:** Create a project in a specific account using ``my-project`` as a template and set the email address for the technical contact.
+**Example:** Create a project in an organization using ``my-project`` as a template and set the email address for the technical contact:
 
-::
+.. code:: shell
 
   avn project create \
     --create-project-from my-project \
@@ -132,9 +128,9 @@ Creates a new project with ``create`` or changes the settings with ``update``.
     --tech-email geek@example.com \
     my-other-project
 
-**Example:** Rename a project.
+**Example:** Rename a project:
 
-::
+.. code:: shell
 
   avn project update
     --project my-project
@@ -143,16 +139,16 @@ Creates a new project with ``create`` or changes the settings with ``update``.
 .. _avn-delete-project:
 
 ``avn project delete``
-''''''''''''''''''''''
+'''''''''''''''''''''''
 
-Deletes an empty project. If the project isn't empty, it removes the services in it first.
+Deletes a project. If the project isn't empty, it removes the services in it first.
 
 .. Note::
     Aiven doesn't allow the deletion of non-empty projects as safeguard against accidental code execution.
 
-**Example:** Delete ``my-project``.
+**Example:** Delete ``my-project``:
 
-::
+.. code:: shell
 
   avn project delete my-project
 
@@ -180,9 +176,9 @@ Downloads the CA certificate for this project, the certificate is saved in the f
   * - ``--target-filepath``
     - File name, including path, to use
 
-**Example:** Download the CA certificate for the current project, and save it in a file in the current directory called ``ca.pem``.
+**Example:** Download the CA certificate for the current project, and save it in a file in the current directory called ``ca.pem``:
 
-::
+.. code:: shell
 
   avn project ca-get --target-filepath ca.pem
 
@@ -206,9 +202,9 @@ Lists the open invitations to the project.
   * - ``--project``
     - The project to show invitations for
 
-**Example:** List the invitations for the current project.
+**Example:** List the invitations for the current project:
 
-::
+.. code:: shell
 
   avn project invite-list
 
@@ -216,7 +212,7 @@ Lists the open invitations to the project.
 ``avn project user-list``
 '''''''''''''''''''''''''
 
-Lists the users with access to the project
+Lists the users with access to the project.
 
 .. list-table::
   :header-rows: 1
@@ -228,16 +224,16 @@ Lists the users with access to the project
     - The project to show users for
 
 
-**Example:** List the users with access to project ``my-project``.
+**Example:** List the users with access to project ``my-project``:
 
-::
+.. code:: shell
 
   avn project user-list --project my-project
 
 ``avn project user-invite``
 '''''''''''''''''''''''''''
 
-Sends an invitation to a user (by email) to join a project.
+Sends an email invitation to a user to join a project.
 
 .. list-table::
   :header-rows: 1
@@ -252,9 +248,9 @@ Sends an invitation to a user (by email) to join a project.
   * - ``--role``
     - Can be "operator", "developer" or "admin"
 
-**Example:** Invite an important person to be an admin on the currently-selected project.
+**Example:** Invite an important person to be an admin on the currently-selected project:
 
-::
+.. code:: shell
 
   avn project user-invite --role admin boss@example.com
 
@@ -275,8 +271,8 @@ Removes a user with the supplied email address from the project.
   * - ``--project``
     - The project to remove the user from
 
-**Example:** Remove the user with email ``alice@example.com`` from project ``my-project``.
+**Example:** Remove the user with email ``alice@example.com`` from project ``my-project``:
 
-::
+.. code:: shell
 
   avn project user-remove --project my-project alice@example.com


### PR DESCRIPTION
# What changed, and why it matters
With the organizations and units release, accounts will become organizations, but the CLI commands will mostly remain unchanged. There needs to be explanations on the relevant CLI pages about the terminology as well as a couple of new parameters for managing organizational units.

The release is planned for 16 February.

