### PR TITLE
Replace AWS with Aiven reference.

### DIFF
--- a/docs/tools/terraform.rst
+++ b/docs/tools/terraform.rst
@@ -40,10 +40,10 @@ Check out the :doc:`getting started guide </docs/tools/terraform/get-started>` f
 
 Learn more
 ----------
-Check out these resources to learn more about Terraform and our Provider:
+Check out these resources to learn more:
 
-* Terraform page `Get Started - AWS <https://developer.hashicorp.com/terraform/tutorials/aws-get-started>`_
 * `Aiven Terraform Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_
+* `Terraform scripts and code samples on GitHub <https://github.com/aiven/aiven-examples/tree/main/terraform>`_
 
 Get involved
 ------------

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -34,7 +34,7 @@ Add the following to a new ``provider.tf`` file:
      required_providers {
        aiven = {
          source  = "aiven/aiven"
-         version = "~> 3.9.0"
+         version = "~> 3.11.0"
        }
      }
    }


### PR DESCRIPTION
# What changed, and why it matters

This PR replaces an AWS docs reference with Aiven GitHub code samples. At this point, Aiven has enough Terraform related docs to refer to without needing to send our reader to other sites.

This PR also updates the Terraform provider version on a page. 
