### PR TITLE
Reorganized the product lists

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -502,97 +502,6 @@ entries:
             - file: docs/products/kafka/karapace/howto/manage-schema-registry-authorization
             - file: docs/products/kafka/karapace/howto/manage-kafka-rest-proxy-authorization
 
-  - file: docs/products/postgresql
-    title: PostgreSQL
-    entries:
-      - file: docs/products/postgresql/getting-started
-        title: Get started
-      - file: docs/products/postgresql/howto/pagila
-        title: "Sample dataset: Pagila"
-      - file: docs/products/postgresql/concepts
-        title: Concepts
-        entries:
-          - glob: docs/products/postgresql/concepts/*
-      - file: docs/products/postgresql/howto
-        title: HowTo
-        entries:
-          - file: docs/products/postgresql/howto/list-code-samples
-            entries:
-              - file: docs/products/postgresql/howto/connect-go
-              - file: docs/products/postgresql/howto/connect-java
-              - file: docs/products/postgresql/howto/connect-node
-              - file: docs/products/postgresql/howto/connect-php
-              - file: docs/products/postgresql/howto/connect-python
-          - file: docs/products/postgresql/howto/list-dba-tasks
-            entries:
-              - file: docs/products/postgresql/howto/create-database
-              - file: docs/products/postgresql/howto/upgrade
-              - file: docs/products/postgresql/howto/manage-extensions
-              - file: docs/products/postgresql/howto/create-manual-backups
-              - file: docs/products/postgresql/howto/restore-backup
-              - file: docs/products/postgresql/howto/migrate-cloud-region
-              - file: docs/products/postgresql/howto/claim-public-schema-ownership
-              - file: docs/products/postgresql/howto/manage-pool
-              - file: docs/products/postgresql/howto/pgbouncer-stats
-              - file: docs/products/postgresql/howto/use-dblink-extension
-              - file: docs/products/postgresql/howto/use-pg-repack-extension
-              - file: docs/products/postgresql/howto/enable-jit
-              - file: docs/products/postgresql/howto/repair-pg-index
-              - file: docs/products/postgresql/howto/identify-pg-slow-queries
-              - file: docs/products/postgresql/howto/pg-long-running-queries
-              - file: docs/products/postgresql/howto/optimize-pg-slow-queries
-              - file: docs/products/postgresql/howto/check-avoid-transaction-id-wraparound
-              - file: docs/products/postgresql/howto/prevent-full-disk
-              
-          - file: docs/products/postgresql/howto/list-replication-migration
-            entries:
-              - file: docs/products/postgresql/howto/create-read-replica
-              - file: docs/products/postgresql/howto/setup-logical-replication
-              - file: docs/products/postgresql/howto/migrate-aiven-db-migrate
-                entries:
-                - file: docs/products/postgresql/howto/logical-replication-aws-aurora
-                - file: docs/products/postgresql/howto/logical-replication-aws-rds
-                - file: docs/products/postgresql/howto/logical-replication-gcp-cloudsql
-              - file: docs/products/postgresql/howto/migrate-pg-dump-restore
-              - file: docs/products/postgresql/howto/migrate-using-bucardo
-              - file: docs/products/postgresql/howto/run-aiven-db-migrate-python
-          - file: docs/products/postgresql/howto/list-integrations
-            entries:
-              - file: docs/products/postgresql/howto/connect-psql
-              - file: docs/products/postgresql/howto/connect-pgadmin
-              - file: docs/products/postgresql/howto/connect-rivery
-              - file: docs/products/postgresql/howto/connect-skyvia
-              - file: docs/products/postgresql/howto/connect-zapier
-              - file: docs/products/postgresql/howto/monitor-database-with-datadog
-              - file: docs/products/postgresql/howto/visualize-grafana
-              - file: docs/products/postgresql/howto/report-metrics-grafana
-              - file: docs/products/postgresql/howto/monitor-with-pgwatch2
-              - file: docs/products/postgresql/howto/datasource-integration
-              - file: docs/products/postgresql/howto/analyze-with-google-data-studio
-      - file: docs/products/postgresql/reference
-        title: Reference
-        entries:
-          - file: docs/products/postgresql/reference/high-cpu-load-of-pgbouncer
-            title: High CPU load
-          - file: docs/products/postgresql/reference/list-of-advanced-params
-            title: Advanced parameters
-          - file: docs/products/postgresql/reference/list-of-extensions
-            title: Extensions
-          - file: docs/products/postgresql/reference/pg-metrics
-            title: Metrics exposed to Grafana
-          - file: docs/products/postgresql/reference/pg-connection-limits
-            title: Connection limits per plan
-          - file: docs/products/postgresql/reference/resource-capability
-            title: Resource capability per plan
-          - file: docs/products/postgresql/reference/terminology
-            title: Terminology
-          - file: docs/products/postgresql/reference/idle-connections
-            title: Idle connections
-          - file: docs/products/postgresql/reference/use-of-deprecated-tls-versions
-            title: Use of deprecated TLS Versions
-          - file: docs/products/postgresql/reference/log-formats-supported
-            title: Supported log formats
-
   - file: docs/products/flink
     title: Apache Flink
     entries:
@@ -627,9 +536,6 @@ entries:
           - file: docs/products/flink/concepts/kafka-connectors
             title: Stardand and upsert connectors
           - file: docs/products/flink/concepts/kafka-connector-requirements
-          
-          
-          
       - file: docs/products/flink/howto
         title: HowTo
         entries:
@@ -668,6 +574,31 @@ entries:
         title: Reference
         entries:
           - file: docs/products/flink/reference/advanced-params
+            title: Advanced parameters
+
+  - file: docs/products/cassandra
+    title: Apache Cassandra
+    entries:
+      - file: docs/products/cassandra/get-started
+        title: Get started
+      - file: docs/products/cassandra/concepts
+        title: Concepts
+        entries:
+          - glob: docs/products/cassandra/concepts/*
+      - file: docs/products/cassandra/howto
+        title: HowTo
+        entries:
+          - file: docs/products/cassandra/howto/list-code-samples
+            entries:
+              - file: docs/products/cassandra/howto/connect-python
+              - file: docs/products/cassandra/howto/connect-go
+          - file: docs/products/cassandra/howto/connect-cqlsh-cli
+          - file: docs/products/cassandra/howto/use-nosqlbench-with-cassandra
+          - file: docs/products/cassandra/howto/use-dsbulk-with-cassandra
+      - file: docs/products/cassandra/reference
+        title: Reference
+        entries:
+          - file: docs/products/cassandra/reference/advanced-params
             title: Advanced parameters
 
   - file: docs/products/clickhouse
@@ -765,6 +696,104 @@ entries:
           - file: docs/products/clickhouse/reference/advanced-params
             title: Advanced parameters
 
+  - file: docs/products/grafana
+    title: Grafana
+    entries:
+      - file: docs/products/grafana/get-started
+        title: Get started
+      - file: docs/products/grafana/howto
+        title: HowTo
+        entries:
+          - glob: docs/products/grafana/howto/*
+      - file: docs/products/grafana/reference
+        title: Reference
+        entries:
+          - file: docs/products/grafana/reference/advanced-params
+            title: Advanced parameters
+          - file: docs/products/grafana/reference/plugins
+            title: Plugins
+
+  - file: docs/products/influxdb
+    title: InfluxDB 
+    entries: 
+      - file: docs/products/influxdb/get-started
+        title: Get started
+      - file: docs/products/influxdb/concepts
+        title: Concepts
+        entries:
+          - file: docs/products/influxdb/concepts/continuous-queries
+          - file: docs/products/influxdb/concepts/influxdb-retention-policy
+      - file: docs/products/influxdb/howto
+        title: HowTo
+        entries:
+          - file: docs/products/influxdb/howto/migrate-data-self-hosted-influxdb-aiven
+      - file: docs/products/influxdb/reference
+        title: Reference
+        entries:
+          - glob: docs/products/influxdb/reference/*
+
+  - file: docs/products/m3db
+    title: M3DB
+    entries:
+      - file: docs/products/m3db/getting-started
+        title: Get started
+      - file: docs/products/m3db/concepts
+        title: Concepts
+        entries:
+          - glob: docs/products/m3db/concepts/*
+      - file: docs/products/m3db/howto
+        title: HowTo
+        entries:
+          - glob: docs/products/m3db/howto/*
+      - file: docs/products/m3db/reference
+        title: Reference
+        entries:
+          - file: docs/products/m3db/reference/terminology
+            title: Terminology
+          - file: docs/products/m3db/reference/advanced-params
+            title: Advanced parameters
+          - file: docs/products/m3db/reference/advanced-params-m3aggregator
+            title: Advanced parameters M3Aggregator
+
+  - file: docs/products/mysql
+    title: MySQL
+    entries:
+      - file: docs/products/mysql/get-started
+        title: Get started
+      - file: docs/products/mysql/concepts                   
+        title: Concepts                           
+        entries:                                  
+          - glob: docs/products/mysql/concepts/*
+      - file: docs/products/mysql/howto
+        title: HowTo
+        entries:
+          - file: docs/products/mysql/howto/list-code-samples
+            entries:
+              - file: docs/products/mysql/howto/connect-from-cli
+              - file: docs/products/mysql/howto/connect-with-python
+              - file: docs/products/mysql/howto/connect-using-mysqlx-with-python
+              - file: docs/products/mysql/howto/connect-with-java
+              - file: docs/products/mysql/howto/connect-with-php
+          - file: docs/products/mysql/howto/create-database
+          - file: docs/products/mysql/howto/connect-from-mysql-workbench
+          - file: docs/products/mysql/howto/migrate-from-external-mysql
+          - file: docs/products/mysql/howto/do-check-service-migration
+          - file: docs/products/mysql/howto/prevent-disk-full
+          - file: docs/products/mysql/howto/reclaim-disk-space
+          - file: docs/products/mysql/howto/identify-disk-usage-issues
+          - file: docs/products/mysql/howto/disable-foreign-key-checks
+          - file: docs/products/mysql/howto/enable-slow-queries
+          - file: docs/products/mysql/howto/migrate-database-mysqldump
+          - file: docs/products/mysql/howto/create-tables-without-primary-keys
+          - file: docs/products/mysql/howto/create-missing-primary-keys
+      - file: docs/products/mysql/reference
+        title: Reference
+        entries:
+          - file: docs/products/mysql/reference/advanced-params
+            title: Advanced parameters
+          - file: docs/products/mysql/reference/resource-capability
+            title: Resource capability per plan
+
   - file: docs/products/opensearch
     title: OpenSearch
     entries:
@@ -830,68 +859,96 @@ entries:
           - file: docs/products/opensearch/reference/restapi-limited-access
           - file: docs/products/opensearch/reference/low-space-watermarks
 
-  - file: docs/products/m3db
-    title: M3DB
+  - file: docs/products/postgresql
+    title: PostgreSQL
     entries:
-      - file: docs/products/m3db/getting-started
+      - file: docs/products/postgresql/getting-started
         title: Get started
-      - file: docs/products/m3db/concepts
+      - file: docs/products/postgresql/howto/pagila
+        title: "Sample dataset: Pagila"
+      - file: docs/products/postgresql/concepts
         title: Concepts
         entries:
-          - glob: docs/products/m3db/concepts/*
-      - file: docs/products/m3db/howto
+          - glob: docs/products/postgresql/concepts/*
+      - file: docs/products/postgresql/howto
         title: HowTo
         entries:
-          - glob: docs/products/m3db/howto/*
-      - file: docs/products/m3db/reference
-        title: Reference
-        entries:
-          - file: docs/products/m3db/reference/terminology
-            title: Terminology
-          - file: docs/products/m3db/reference/advanced-params
-            title: Advanced parameters
-          - file: docs/products/m3db/reference/advanced-params-m3aggregator
-            title: Advanced parameters M3Aggregator
-
-  - file: docs/products/mysql
-    title: MySQL
-    entries:
-      - file: docs/products/mysql/get-started
-        title: Get started
-      - file: docs/products/mysql/concepts                   
-        title: Concepts                           
-        entries:                                  
-          - glob: docs/products/mysql/concepts/*
-      - file: docs/products/mysql/howto
-        title: HowTo
-        entries:
-          - file: docs/products/mysql/howto/list-code-samples
+          - file: docs/products/postgresql/howto/list-code-samples
             entries:
-              - file: docs/products/mysql/howto/connect-from-cli
-              - file: docs/products/mysql/howto/connect-with-python
-              - file: docs/products/mysql/howto/connect-using-mysqlx-with-python
-              - file: docs/products/mysql/howto/connect-with-java
-              - file: docs/products/mysql/howto/connect-with-php
-          - file: docs/products/mysql/howto/create-database
-          - file: docs/products/mysql/howto/connect-from-mysql-workbench
-          - file: docs/products/mysql/howto/migrate-from-external-mysql
-          - file: docs/products/mysql/howto/do-check-service-migration
-          - file: docs/products/mysql/howto/prevent-disk-full
-          - file: docs/products/mysql/howto/reclaim-disk-space
-          - file: docs/products/mysql/howto/identify-disk-usage-issues
-          - file: docs/products/mysql/howto/disable-foreign-key-checks
-          - file: docs/products/mysql/howto/enable-slow-queries
-          - file: docs/products/mysql/howto/migrate-database-mysqldump
-          - file: docs/products/mysql/howto/create-tables-without-primary-keys
-          - file: docs/products/mysql/howto/create-missing-primary-keys
-      - file: docs/products/mysql/reference
+              - file: docs/products/postgresql/howto/connect-go
+              - file: docs/products/postgresql/howto/connect-java
+              - file: docs/products/postgresql/howto/connect-node
+              - file: docs/products/postgresql/howto/connect-php
+              - file: docs/products/postgresql/howto/connect-python
+          - file: docs/products/postgresql/howto/list-dba-tasks
+            entries:
+              - file: docs/products/postgresql/howto/create-database
+              - file: docs/products/postgresql/howto/upgrade
+              - file: docs/products/postgresql/howto/manage-extensions
+              - file: docs/products/postgresql/howto/create-manual-backups
+              - file: docs/products/postgresql/howto/restore-backup
+              - file: docs/products/postgresql/howto/migrate-cloud-region
+              - file: docs/products/postgresql/howto/claim-public-schema-ownership
+              - file: docs/products/postgresql/howto/manage-pool
+              - file: docs/products/postgresql/howto/pgbouncer-stats
+              - file: docs/products/postgresql/howto/use-dblink-extension
+              - file: docs/products/postgresql/howto/use-pg-repack-extension
+              - file: docs/products/postgresql/howto/enable-jit
+              - file: docs/products/postgresql/howto/repair-pg-index
+              - file: docs/products/postgresql/howto/identify-pg-slow-queries
+              - file: docs/products/postgresql/howto/pg-long-running-queries
+              - file: docs/products/postgresql/howto/optimize-pg-slow-queries
+              - file: docs/products/postgresql/howto/check-avoid-transaction-id-wraparound
+              - file: docs/products/postgresql/howto/prevent-full-disk
+              
+          - file: docs/products/postgresql/howto/list-replication-migration
+            entries:
+              - file: docs/products/postgresql/howto/create-read-replica
+              - file: docs/products/postgresql/howto/setup-logical-replication
+              - file: docs/products/postgresql/howto/migrate-aiven-db-migrate
+                entries:
+                - file: docs/products/postgresql/howto/logical-replication-aws-aurora
+                - file: docs/products/postgresql/howto/logical-replication-aws-rds
+                - file: docs/products/postgresql/howto/logical-replication-gcp-cloudsql
+              - file: docs/products/postgresql/howto/migrate-pg-dump-restore
+              - file: docs/products/postgresql/howto/migrate-using-bucardo
+              - file: docs/products/postgresql/howto/run-aiven-db-migrate-python
+          - file: docs/products/postgresql/howto/list-integrations
+            entries:
+              - file: docs/products/postgresql/howto/connect-psql
+              - file: docs/products/postgresql/howto/connect-pgadmin
+              - file: docs/products/postgresql/howto/connect-rivery
+              - file: docs/products/postgresql/howto/connect-skyvia
+              - file: docs/products/postgresql/howto/connect-zapier
+              - file: docs/products/postgresql/howto/monitor-database-with-datadog
+              - file: docs/products/postgresql/howto/visualize-grafana
+              - file: docs/products/postgresql/howto/report-metrics-grafana
+              - file: docs/products/postgresql/howto/monitor-with-pgwatch2
+              - file: docs/products/postgresql/howto/datasource-integration
+              - file: docs/products/postgresql/howto/analyze-with-google-data-studio
+      - file: docs/products/postgresql/reference
         title: Reference
         entries:
-          - file: docs/products/mysql/reference/advanced-params
+          - file: docs/products/postgresql/reference/high-cpu-load-of-pgbouncer
+            title: High CPU load
+          - file: docs/products/postgresql/reference/list-of-advanced-params
             title: Advanced parameters
-          - file: docs/products/mysql/reference/resource-capability
+          - file: docs/products/postgresql/reference/list-of-extensions
+            title: Extensions
+          - file: docs/products/postgresql/reference/pg-metrics
+            title: Metrics exposed to Grafana
+          - file: docs/products/postgresql/reference/pg-connection-limits
+            title: Connection limits per plan
+          - file: docs/products/postgresql/reference/resource-capability
             title: Resource capability per plan
-
+          - file: docs/products/postgresql/reference/terminology
+            title: Terminology
+          - file: docs/products/postgresql/reference/idle-connections
+            title: Idle connections
+          - file: docs/products/postgresql/reference/use-of-deprecated-tls-versions
+            title: Use of deprecated TLS Versions
+          - file: docs/products/postgresql/reference/log-formats-supported
+            title: Supported log formats
 
   - file: docs/products/redis
     title: Redis
@@ -926,67 +983,6 @@ entries:
         entries:
           - file: docs/products/redis/reference/advanced-params
             title: Advanced parameters
-
-  - file: docs/products/cassandra
-    title: Apache Cassandra
-    entries:
-      - file: docs/products/cassandra/get-started
-        title: Get started
-      - file: docs/products/cassandra/concepts
-        title: Concepts
-        entries:
-          - glob: docs/products/cassandra/concepts/*
-      - file: docs/products/cassandra/howto
-        title: HowTo
-        entries:
-          - file: docs/products/cassandra/howto/list-code-samples
-            entries:
-              - file: docs/products/cassandra/howto/connect-python
-              - file: docs/products/cassandra/howto/connect-go
-          - file: docs/products/cassandra/howto/connect-cqlsh-cli
-          - file: docs/products/cassandra/howto/use-nosqlbench-with-cassandra
-          - file: docs/products/cassandra/howto/use-dsbulk-with-cassandra
-      - file: docs/products/cassandra/reference
-        title: Reference
-        entries:
-          - file: docs/products/cassandra/reference/advanced-params
-            title: Advanced parameters
-
-  - file: docs/products/grafana
-    title: Grafana
-    entries:
-      - file: docs/products/grafana/get-started
-        title: Get started
-      - file: docs/products/grafana/howto
-        title: HowTo
-        entries:
-          - glob: docs/products/grafana/howto/*
-      - file: docs/products/grafana/reference
-        title: Reference
-        entries:
-          - file: docs/products/grafana/reference/advanced-params
-            title: Advanced parameters
-          - file: docs/products/grafana/reference/plugins
-            title: Plugins
-
-  - file: docs/products/influxdb
-    title: InfluxDB 
-    entries: 
-      - file: docs/products/influxdb/get-started
-        title: Get started
-      - file: docs/products/influxdb/concepts
-        title: Concepts
-        entries:
-          - file: docs/products/influxdb/concepts/continuous-queries
-          - file: docs/products/influxdb/concepts/influxdb-retention-policy
-      - file: docs/products/influxdb/howto
-        title: HowTo
-        entries:
-          - file: docs/products/influxdb/howto/migrate-data-self-hosted-influxdb-aiven
-      - file: docs/products/influxdb/reference
-        title: Reference
-        entries:
-          - glob: docs/products/influxdb/reference/*
 
   # -------- AUXILIARY
   - file: docs/community

--- a/index.rst
+++ b/index.rst
@@ -32,40 +32,16 @@ Explore
 
 Learn about the Aiven platform
 
+
 .. grid:: 1 2 2 2
 
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        |icon-postgres| **PostgreSQL®** Powerful relational database platform. We have the latest versions, and an excellent selection of extensions.
-
-        .. button-link:: docs/products/postgresql
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
-    
-
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-m3db| **M3** Distributed time-series database for scalable solutions, with M3 Coordinator included, and M3 Aggregator also available.
-
-        .. button-link:: docs/products/m3db
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
-    
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-kafka| **Apache Kafka®** Streaming data pipelines for the modern enterprise. Apache MirrorMaker2 and Kafka Connect also available.
+        |icon-kafka| **Apache Kafka®** 
+        
+        Streaming data pipelines for the modern enterprise. Apache MirrorMaker2 and Kafka Connect also available.
 
 
         .. button-link:: docs/products/kafka
@@ -74,15 +50,110 @@ Learn about the Aiven platform
             :outline:
 
             Read more
+
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-flink| **Apache Flink®** 
+        
+        Framework for definining powerful transformations of batch and streaming data sets. 
+
+        .. button-link:: docs/products/flink
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-cassandra| **Apache Cassandra®** 
+        
+        High performance storage solution for large data quantities. This specialist data solution is a partitioned row store.
+
+        .. button-link:: docs/products/cassandra
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
     
 
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        |icon-flink| **Apache Flink®** Framework for definining powerful transformations of batch and streaming data sets. 
+        |icon-clickhouse| **ClickHouse** 
+        
+        A highly scalable, open source database that uses a column-oriented structure.
 
-        .. button-link:: docs/products/flink
+        .. button-link:: docs/products/clickhouse
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-grafana| **Grafana®** 
+        
+        The visualization tool you need to explore and understand your data. Grafana integrates with the other services in just a few clicks.
+
+        .. button-link:: docs/products/grafana
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
+    
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-influxdb| **InfluxDB®** 
+        
+        Specialist time series database, with good tooling support.
+
+        .. button-link:: docs/products/influxdb
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-m3db| **M3** 
+        
+        Distributed time-series database for scalable solutions, with M3 Coordinator included, and M3 Aggregator also available.
+
+        .. button-link:: docs/products/m3db
+            :align: right
+            :color: primary
+            :outline:
+
+            Read more
+    
+
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
+
+        |icon-mysql| **MySQL** 
+        
+        Popular and much-loved relational database platform.
+
+        .. button-link:: docs/products/mysql
             :align: right
             :color: primary
             :outline:
@@ -93,7 +164,9 @@ Learn about the Aiven platform
         :shadow: md
         :margin: 2 2 0 0
 
-        |icon-opensearch| **OpenSearch®** Document database with specialist search features, bring your freeform documents, logs or metrics, and make sense of them here.
+        |icon-opensearch| **OpenSearch®** 
+        
+        Document database with specialist search features, bring your freeform documents, logs or metrics, and make sense of them here.
 
         .. button-link:: docs/products/opensearch
             :align: right
@@ -107,9 +180,11 @@ Learn about the Aiven platform
         :shadow: md
         :margin: 2 2 0 0
 
-        |icon-cassandra| **Apache Cassandra®** High performance storage solution for large data quantities. This specialist data solution is a partitioned row store.
+        |icon-postgres| **PostgreSQL®** 
+        
+        Powerful relational database platform. We have the latest versions, and an excellent selection of extensions.
 
-        .. button-link:: docs/products/cassandra
+        .. button-link:: docs/products/postgresql
             :align: right
             :color: primary
             :outline:
@@ -120,7 +195,9 @@ Learn about the Aiven platform
         :shadow: md
         :margin: 2 2 0 0
 
-        |icon-redis| **Redis®\*** In-memory data store for all your high-peformance short-term storage and caching needs.
+        |icon-redis| **Redis®**
+        
+        In-memory data store for all your high-peformance short-term storage and caching needs.
 
         .. button-link:: docs/products/redis
             :align: right
@@ -129,58 +206,6 @@ Learn about the Aiven platform
 
             Read more
     
-
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-mysql| **MySQL** Popular and much-loved relational database platform.
-
-        .. button-link:: docs/products/mysql
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
-    
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-influxdb| **InfluxDB®** Specialist time series database, with good tooling support.
-
-        .. button-link:: docs/products/influxdb
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
-
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-grafana| **Grafana®** The visualization tool you need to explore and understand your data. Grafana integrates with the other services in just a few clicks.
-
-        .. button-link:: docs/products/grafana
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
-    
-    .. grid-item-card::
-        :shadow: md
-        :margin: 2 2 0 0
-
-        |icon-clickhouse| **ClickHouse** A highly scalable, open source database that uses a column-oriented structure.
-
-        .. button-link:: docs/products/clickhouse
-            :align: right
-            :color: primary
-            :outline:
-
-            Read more
 
 Tools
 -----


### PR DESCRIPTION
# What changed, and why it matters

 Reorganized the product lists in the left navigation and documentation landing page.  The ordering is a combination of alphabetical and strategic placement. 
- The Platform section remains at the top of the list due to its importance and relevance in the product suite.
- The Apache product suite(Kafka, Flink, Cassandra). Within the Apache suite, Kafka is prioritized first as a key product from Aiven, followed by Flink and Cassandra.
- The remaining products are listed in alphabetical order.

Fixes: #1597 