### PR TITLE
Kafka cluster configuration backup 

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -278,6 +278,7 @@ entries:
           - file: docs/products/kafka/concepts/partition-segments
           - file: docs/products/kafka/concepts/auth-types
           - file: docs/products/kafka/concepts/non-leader-for-partition
+          - file: docs/products/kafka/concepts/configuration-backup
       - file: docs/products/kafka/howto
         title: HowTo
         entries:

--- a/docs/products/kafka/concepts/configuration-backup.rst
+++ b/docs/products/kafka/concepts/configuration-backup.rst
@@ -1,0 +1,35 @@
+Configuration backups for Apache Kafka®
+=======================================
+
+Aiven for Apache Kafka® includes **configuration backups** that automatically back up key Apache Kafka® service configurations for you without any additional costs. 
+
+Suppose the Apache Kafka® service is powered off/on or an incident causes the Apache Kafka cluster to stop functioning. In that case, the configuration backup enables the restoration of your Apache Kafka® service to its previous state.
+
+.. note:: 
+    The configuration backups feature is currently available for all new projects within Aiven and for newly added Aiven for Apache Kafka® services.
+
+Whats included in configuration backups
+----------------------------------------
+
+The following data are backed up in the configuration backups:
+
+* Apache Kafka® topic-related configurations.
+* Everything related to Schema Registry (schemas, ids, subjects, compatibility levels).
+* Apache Kafka® Connect configurations.
+
+Benefits of configuration backups
+-------------------------------------
+Some of the key benefits of configuration backups include the following: 
+
+* Configuration backups are automatically enabled and stored in the Cloud storage.
+* Configurations are backed up in 3 hours intervals.
+* It helps with speedy disaster recovery in certain situations. 
+.. note:: 
+    In a rare scenario where all the nodes are lost, the configurations are lost and not accessible anymore.
+* It helps application users with a quick re-creation of Apache Kafka® services, allowing them to focus on development tasks rather than re-configuring the platform.
+
+Limitations
+-----------
+Configuration backups do not back up the actual data stored in topics, consumer groups, and their offsets. Only the Apache Kafka® cluster configurations are backed up. 
+
+For additional support with configuration backups for your Aiven for Apache Kafka® services, contact support@Aiven.io. 

--- a/docs/products/kafka/concepts/configuration-backup.rst
+++ b/docs/products/kafka/concepts/configuration-backup.rst
@@ -24,8 +24,10 @@ Some of the key benefits of configuration backups include the following:
 * Configuration backups are automatically enabled and stored in the Cloud storage.
 * Configurations are backed up in 3 hours intervals.
 * It helps with speedy disaster recovery in certain situations. 
+
 .. note:: 
     In a rare scenario where all the nodes are lost, the configurations are lost and not accessible anymore.
+
 * It helps application users with a quick re-creation of Apache Kafka® services, allowing them to focus on development tasks rather than re-configuring the platform.
 
 Limitations


### PR DESCRIPTION
# What changed, and why it matters

Kafka cluster configuration backup allows the restoration of a Kafka cluster to the previous state after a power off/ on cycle or an incident that has caused the cluster to stop working.

For more info - https://aiven.atlassian.net/browse/HH-1164

Note: This pull request has been recreated from an older version (https://github.com/aiven/devportal/pull/1486) which was closed due to a merge conflict.