### PR TITLE
Add instructions for getting tech notifications in Slack

### DIFF
--- a/.github/vale/dicts/aiven.dic
+++ b/.github/vale/dicts/aiven.dic
@@ -191,6 +191,7 @@ skyvia
 Snowflake
 Sphinx
 SLA/S
+Slackbot
 Splunk
 spring
 Sql

--- a/.github/vale/styles/Aiven/capitalization_headings.yml
+++ b/.github/vale/styles/Aiven/capitalization_headings.yml
@@ -101,6 +101,7 @@ exceptions:
   - Schema Registry
   - Simple Authentication and Security Layer
   - Skyvia
+  - Slack
   - Snowflake
   - Sphinx
   - Splunk

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -21,6 +21,9 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
 
 #. In Slack, `create an email address for a channel or DM <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WDZG8RTCTNAMR4KJ7D419V>`_.
 
+   .. note::
+       If you don't see the email integrations option, ask the owner or admin of the workspace or organization to `allow incoming emails <https://slack.com/help/articles/360053335433-Manage-incoming-emails-for-your-workspace-or-organization#manage-incoming-emails>`_.
+
 #. In the Aiven Console, go to the project that you want to get notifications for.
 
 #. Click **Settings**.

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -22,7 +22,7 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
 #. In Slack, `create an email address for a channel or DM <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WDZG8RTCTNAMR4KJ7D419V>`_.
 
    .. note::
-       If you don't see the email integrations option, ask the owner or admin of the workspace or organization to `allow incoming emails <https://slack.com/help/articles/360053335433-Manage-incoming-emails-for-your-workspace-or-organization#manage-incoming-emails>`_.
+       If you don't see the email integrations option, ask the owner or admin of the workspace or organization to `allow incoming emails <https://slack.com/help/articles/360053335433-Manage-incoming-emails-for-your-workspace-or-organization>`_.
 
 #. In the Aiven Console, go to the project that you want to get notifications for.
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,7 +1,7 @@
 Get technical notifications
 ============================
 
-To stay up to date with the latest news about the services in a project, you can set up email or Slack notifications for technical contacts for the project. 
+To stay up to date with the latest news about the services in a project, you can set up notifications for technical contacts for the project. 
 
 Notifications include information about plan sizes, performance, outages and scheduled maintenance. High priority notifications (for example, a plan running out of space) are also sent to project admin users.
 
@@ -25,7 +25,8 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
 
 #. Click **Settings**.
 
-#. In the **Technical Emails** section, add the email address of the Slack channel or  DM.
+#. In the **Technical Emails** section, add the email address that you created for the Slack channel or  DM.                
+
 
 #. Click **Save changes**. 
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,15 +1,32 @@
-Receive technical notifications
-===============================
+Get technical notifications
+============================
 
-After creating services on Aiven you will want to make sure you stay
-up to date with what's happening to them.
+To stay up to date with the latest news about the services in a project, you can set up email or Slack notifications for technical contacts for the project. 
 
-To add email addresses to technical notifications:
+Notifications include information about plan sizes, performance, outages and scheduled maintenance. High priority notifications (for example, a plan running out of space) are also sent to project admin users.
+
+Set up email notifications
+"""""""""""""""""""""""""""
 
 #. In the project, click **Settings**.
 
-#. In the **Technical Emails** section of the project settings, add the email addresses.
+#. In the **Technical Emails** section, add the email addresses.
 
 #. Click **Save changes**. 
 
-These users will receive notifications related to plan sizes, performance, outages and upcoming mandatory planned maintenance. If no emails are specified, we will still send some high-priority notifications (such as disks running out of space warnings) to project admin users.
+Set up Slack notifications
+"""""""""""""""""""""""""""
+
+To get notifications in Slack, you can add a Slack channel's or DM email address to the technical contacts for an Aiven project:
+
+#. In Slack, `create an email address for a channel or DM <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WDZG8RTCTNAMR4KJ7D419V>`_.
+
+#. In the Aiven Console, go to the project that you want to get notifications for.
+
+#. Click **Settings**.
+
+#. In the **Technical Emails** section, add the email address of the Slack channel or  DM.
+
+#. Click **Save changes**. 
+
+Alternatively, you can `set up a Slackbot forwarding address <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WE06MBF06BBHQNZ1G0H2K5>`_ and use that to automatically forward Aiven's email notifications from your email client.


### PR DESCRIPTION
# What changed, and why it matters
Update article on getting notifications for services and add instructions on how to get the email notifications in Slack. 

