### PR TITLE
Bump pygments version to reflect heredoc fix.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ requests==2.25.1
 sphinxext-opengraph==0.4.2
 sphinx-sitemap==2.2.0
 sphinx-notfound-page==0.8
-pygments==2.12.0
+pygments==2.14.0
 python-dotenv==0.21.0


### PR DESCRIPTION
# What changed, and why it matters


Currently, we're using v2.12.0 of pygments. A fix for https://github.com/pygments/pygments/issues/2162 went in on v2.13.0. The current version of pygments is making PRs fail for the above Terraform lexer issue with heredoc. This PR proposed an update to pygments version and avoid that error.