### PR TITLE
adding credit card free details to the page

### DIFF
--- a/docs/platform/concepts/corporate-billing.rst
+++ b/docs/platform/concepts/corporate-billing.rst
@@ -10,6 +10,15 @@ The default billing method for all new Aiven customers is credit card. All costs
 
 Services are billed by the hour. The costs are automatically calculated based on the services running in a project. Each project is charged separately.
 
+Credit card fees
+""""""""""""""""""
+
+The prices listed of our website and in your invoices are inclusive of all credit card and processing fees related to the charges that are visible to us and payable by us. This includes transaction fees with our credit card processor (Stripe) and the fees various card issuers charge from merchants.
+
+Some credit card issuers may unfortunately add extra charges on top of the fees charged by us from your cards. The most common such fee is an "international transaction fee" charged by some issuers for all transactions where the native countries of the merchant (in case of us, Finland), processor (in case of us, United States), bank and card are different. The fee may be applied even if the card was charged in the card's default currency (USD).
+
+Such fees are not added by Aiven and are not visible to us or our credit card processor, and we're thus unable to include them in our prices or waive the fees.
+
 Invoice payments
 """""""""""""""""
 


### PR DESCRIPTION
Credit card fee details migrated from old intercom help archive.
Added to this page as per the suggestion from - https://github.com/aiven/devportal/pull/1676


