### PR TITLE
fixed list of flink CLI commands

### DIFF
--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -224,7 +224,7 @@ More information on ``es-acl-add``, ``es-acl-del``, ``es-acl-disable``, ``es-acl
 
 Manages Aiven for Apache Flink® tables and jobs.
 
-More info on ``flink table create``, ``flink table delete``, ``flink table get``, ``flink table list``, ``flink job create``, ``flink job cancel``, ``flink job get`` and ``flink job list`` can be found in :doc:`the dedicated page <service/flink>`.
+More info on ``flink create-application``, ``flink list-applications``, ``flink get-application``, ``flink update-application``, ``flink delete-application``, ``flink create-application-version``, ``flink validate-application-version``, ``flink get-application-version``, ``flink delete-application-version``, ``flink list-application-deployments``, ``flink get-application-deployment``, ``flink create-application-deployment``, ``flink delete-application-deployment``, ``flink stop-application-deployment``, ``flink cancel-application-deployment`` can be found in :doc:`the dedicated page <service/flink>`.
 
 .. _avn_service_get:
 


### PR DESCRIPTION
# What changed, and why it matters

Fixed in the service page the list of CLI flink commands
