### PR TITLE
Make links descriptive

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -222,7 +222,7 @@ Interfaces
             :color: primary
             :outline:
 
-            Aiven Console Overview
+            Aiven Console overview
     
     .. grid-item-card::
         :shadow: md
@@ -237,7 +237,7 @@ Interfaces
             :color: primary
             :outline:
 
-            Aiven CLI Quickstart
+            Aiven CLI quickstart
 
 
 Automation
@@ -257,7 +257,7 @@ Automation
             :color: primary
             :outline:
 
-            API Quickstart
+            API quickstart
 
     .. grid-item-card::
         :shadow: md

--- a/index.rst
+++ b/index.rst
@@ -1,16 +1,8 @@
 Aiven documentation
 ===================
 
-Aiven is a database-as-a-service for open source data solutions including
-PostgreSQL®,
-M3,
-Apache Kafka®,
-Apache Flink®,
-OpenSearch®,
-Apache Cassandra®,
-Redis®*,
-MySQL,
-InfluxDB® and Grafana®.
+Aiven is a database-as-a-service platform for open source data solutions including Apache Kafka®, Apache Flink®, Apache Cassandra®, ClickHouse®, Grafana®, InfluxDB®, M3DB, MySQL, OpenSearch®, PostgreSQL®, and Redis®*.
+
 
 ----------------
 
@@ -19,7 +11,7 @@ What can we help you with today?
 .. raw:: html
 
     <form class="sidebar-search-container" method="get" action="search.html">
-      <input class="sidebar-search" placeholder=Search name="q">
+      <input class="sidebar-search" placeholder='Try "VPC"' name="q">
       <input type="hidden" name="check_keywords" value="yes">
       <input type="hidden" name="area" value="default">
     </form>
@@ -27,10 +19,10 @@ What can we help you with today?
 
 ----------------
 
-Explore
--------
+Explore Aiven services
+-----------------------
 
-Learn about the Aiven platform
+Get started with Aiven's fully-managed services.
 
 
 .. grid:: 1 2 2 2
@@ -49,7 +41,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about Kafka
 
 
     .. grid-item-card::
@@ -65,7 +57,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about Flink
 
     .. grid-item-card::
         :shadow: md
@@ -80,7 +72,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about Cassandra
     
 
     .. grid-item-card::
@@ -96,7 +88,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about ClickHouse
 
     .. grid-item-card::
         :shadow: md
@@ -111,7 +103,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about Grafana
     
 
     .. grid-item-card::
@@ -127,7 +119,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about InfluxDB
 
     .. grid-item-card::
         :shadow: md
@@ -142,7 +134,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about M3
     
 
     .. grid-item-card::
@@ -158,7 +150,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about MySQL
     
     .. grid-item-card::
         :shadow: md
@@ -173,7 +165,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about OpenSearch
     
 
     .. grid-item-card::
@@ -189,7 +181,7 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about PostgreSQL
     
     .. grid-item-card::
         :shadow: md
@@ -204,45 +196,53 @@ Learn about the Aiven platform
             :color: primary
             :outline:
 
-            Read more
+            Learn about Redis
     
 
 Tools
 -----
 
-You can use the Aiven platform in the way that best fits your workflow with our set of tools:
+Use your preferred tool with the Aiven platform in the way that best fits your workflow.
 
-.. grid:: 1 2 2 2
+Interfaces
+""""""""""""
+
+.. grid:: 2
 
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        **Aiven Web Console** 
+        **Aiven Console** 
         
-        Manage your Aiven services from a convenient and friendly web-based experience.
+        Web-based graphical interface for creating and managing your services.
 
-        .. button-link:: https://console.aiven.io
-            :align: right
+        .. button-link:: docs/tools/aiven-console
+            :align: center
             :color: primary
             :outline:
 
-            Read more
+            Aiven Console Overview
     
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        ``avn`` **command-line** 
+        **Aiven CLI** 
         
-        Work with Aiven features from your command line using Aiven CLI tool.
+        Command line client for the Aiven platform.
 
         .. button-link:: docs/tools/cli
-            :align: right
+            :align: center
             :color: primary
             :outline:
 
-            Read more
+            Aiven CLI Quickstart
+
+
+Automation
+""""""""""""
+.. grid:: 1 1 1 1
 
     .. grid-item-card::
         :shadow: md
@@ -250,30 +250,29 @@ You can use the Aiven platform in the way that best fits your workflow with our 
 
         **Aiven API** 
         
-        An interface you can use for programmatic integrations that also powers our own web interface.
-
+        A public API you can use for programmatic integrations.
 
         .. button-link:: docs/tools/api
             :align: right
             :color: primary
             :outline:
 
-            Read more
-    
+            API Quickstart
+
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
         **Aiven Terraform Provider** 
         
-        An infrastructure-as-code tool to manage cloud infrastructure.
+        An infrastructure-as-code tool for lifecycle management of your Aiven resources. 
 
         .. button-link:: docs/tools/terraform
             :align: right
             :color: primary
             :outline:
 
-            Read more
+            Start using Terraform
 
     .. grid-item-card::
         :shadow: md
@@ -281,14 +280,14 @@ You can use the Aiven platform in the way that best fits your workflow with our 
 
         **Aiven Operator for Kubernetes®** 
         
-        Tool for orchestration of your Aiven services to your existing Kubernetes® cluster.
+        Provision and manage Aiven services from your Kubernetes cluster.
 
         .. button-link:: https://docs.aiven.io/docs/tools/kubernetes.html
             :align: right
             :color: primary
             :outline:
 
-            Read more
+            Start using Aiven Operator
 ..
   docs/tools/kubernetes failed on linkcheck for unknown reason,
   so using external links instead.


### PR DESCRIPTION
# What changed, and why it matters
Made links on the docs homepage descriptive for better accessibility and SEO. Some other minor changes to tool descriptions and other microcopy. 

Resolves: #1276 