### PR TITLE
Enable anonymous session tracking

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -35,7 +35,7 @@ snowplow("newTracker", "at", "dc.aiven.io", {
   forceSecureTracker: true,
   discoverRootDomain: true,
   cookieSameSite: 'Lax',
-  anonymousTracking: { withServerAnonymisation: true },
+  anonymousTracking: { withSessionTracking: true, withServerAnonymisation: true },
   stateStorageStrategy: 'none',
   eventMethod: 'post',
   postPath: '/aiven/dc2',
@@ -62,7 +62,7 @@ function OptanonWrapper() {
     snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
   } else {
     // enable fully anonymous tracking
-    snowplow('clearUserData');
+    snowplow('clearUserData', { preserveSession: true, preserveUser: true });
   }
 
   if (window.firstTimeVisit) {


### PR DESCRIPTION
This changes the Snowplow tracking configuration
by enabling the anonymous session tracking option.
This allows identifying unique sessions of visitors and
sending those session IDs along with the Snowplow
events even with the anonymous tracking enabled.

Upon calling the `clearUserData` function from Snowplow,
we are including the parameters for preserving the user
data and session anonymously.

