### PR TITLE
cassandra: restructure doc section

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -613,7 +613,7 @@ entries:
       - file: docs/products/cassandra/howto
         title: HowTo
         entries:
-          - file: docs/products/cassandra/get-started
+          - file: docs/products/cassandra/howto/setup
             title: Get started
           - file: docs/products/cassandra/howto/list-code-samples
             title: Connect to service

--- a/_toc.yml
+++ b/_toc.yml
@@ -613,13 +613,26 @@ entries:
       - file: docs/products/cassandra/howto
         title: HowTo
         entries:
+          - file: docs/products/cassandra/get-started
+            title: Get started
           - file: docs/products/cassandra/howto/list-code-samples
+            title: Connect to service
             entries:
+              - file: docs/products/cassandra/howto/connect-cqlsh-cli
+                title: Connect with cqlsh
               - file: docs/products/cassandra/howto/connect-python
+                title: Connect with Python
               - file: docs/products/cassandra/howto/connect-go
-          - file: docs/products/cassandra/howto/connect-cqlsh-cli
-          - file: docs/products/cassandra/howto/use-nosqlbench-with-cassandra
-          - file: docs/products/cassandra/howto/use-dsbulk-with-cassandra
+                title: Connect with Go
+          - file: docs/products/cassandra/howto/list-manage-service
+            title: Manage service
+            entries:
+              - file: docs/products/cassandra/howto/use-dsbulk-with-cassandra
+                title: Manage data with DSBULK
+              - file: docs/products/cassandra/howto/use-nosqlbench-with-cassandra
+                title: Stress test with nosqlbench
+          - file: docs/products/cassandra/howto/list-manage-cluster
+            title: Manage cluster
           - file: docs/products/cassandra/howto/list-cross-cluster-replication
             title: Cross-cluster replication
             entries:

--- a/_toc.yml
+++ b/_toc.yml
@@ -599,8 +599,10 @@ entries:
   - file: docs/products/cassandra
     title: Apache Cassandra
     entries:
+      - file: docs/products/cassandra/overview
+        title: Overview
       - file: docs/products/cassandra/get-started
-        title: Get started
+        title: Quickstart
       - file: docs/products/cassandra/concepts
         title: Concepts
         entries:

--- a/docs/products/cassandra.rst
+++ b/docs/products/cassandra.rst
@@ -1,51 +1,32 @@
 Aiven for Apache Cassandra®
 ===========================
 
-What is Apache Cassandra®?
---------------------------
-
 `Apache Cassandra® <https://cassandra.apache.org/_/index.html>`_ is an open source, NoSQL database. It is specifically designed to be highly available, performant, and scalable. It supports a distributed architecture with asynchronous replication and is highly fault tolerant.
 
-Apache Cassandra originated from Facebook, and since then has had a strong history with some of the most demanding data platforms around while being in the care of the Apache project. From this strong history comes a robust database with an emphasis on security, and the ability to scale up to meet the needs of even the largest data platforms.
-
-Aiven for Apache Cassandra builds on the open source offering, adding management features and updates so that you can rely on the database your organisation needs to succeed.
-
-Why Aiven for Apache Cassandra®?
---------------------------------
-
-Apache Cassandra® is designed to handle large volumes of writes to the database; this is one of the key reasons we see for adopting Apache Cassandra over some of the other options in a similar problem space.
-
-It is a truly distributed database where the individual nodes can communicate with one another without referencing any master node. This improves both its scalability and its fault tolerance, two key capabilities of Apache Cassandra.
-
-Get started with Aiven for Apache Cassandra
--------------------------------------------
-
-Take your first steps with Aiven for Apache Cassandra® by following our :doc:`/docs/products/cassandra/get-started` article, or browse through our full list of articles:
+-------------------
 
 .. grid:: 1 2 2 2
 
-    .. grid-item-card::
+    .. grid-item-card:: :doc:`Quickstart </docs/products/cassandra/get-started>`
         :shadow: md
         :margin: 2 2 0 0
 
-        📚 :doc:`Concepts </docs/products/cassandra/concepts>`
+        Create your first cluster and learn how to connect to Aiven for Apache Cassandra.
 
-    .. grid-item-card::
+    .. grid-item-card:: :doc:`Overview </docs/products/cassandra/overview>`
         :shadow: md
         :margin: 2 2 0 0
 
-        💻 :doc:`/docs/products/cassandra/howto`
+        Discover Aiven for Apache Cassandra's features and use cases. 
 
-    .. grid-item-card::
+    .. grid-item-card:: :doc:`How-Tos </docs/products/cassandra/howto>`
         :shadow: md
         :margin: 2 2 0 0
 
-        📖 :doc:`/docs/products/cassandra/reference`
+        Explore step-by-step instructions for common operations on Aiven for Apache Cassandra.
 
-    .. grid-item-card::
+    .. grid-item-card:: :doc:`Concepts </docs/products/cassandra/concepts>`
         :shadow: md
         :margin: 2 2 0 0
 
-        🧰 :doc:`Code samples </docs/products/cassandra/howto/list-code-samples>`
-
-
+        Get familiar with core concepts of Aiven for Apache Cassandra.

--- a/docs/products/cassandra.rst
+++ b/docs/products/cassandra.rst
@@ -30,3 +30,15 @@ Aiven for Apache Cassandra®
         :margin: 2 2 0 0
 
         Get familiar with core concepts of Aiven for Apache Cassandra.
+
+    .. grid-item-card:: :doc:`Reference </docs/products/cassandra/reference>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+        Look up parameters, metrics, or formats supported by Aiven for Apache Cassandra.
+
+    .. grid-item-card:: `What's new <https://aiven.io/changelog>`_
+        :shadow: md
+        :margin: 2 2 0 0
+
+        Check out new features or latest improvements introduced to Aiven for Apache Cassandra and other Aiven services.

--- a/docs/products/cassandra/concepts.rst
+++ b/docs/products/cassandra/concepts.rst
@@ -1,6 +1,12 @@
-Guides for Apache Cassandra®
-============================
+Aiven for Apache Cassandra® concepts
+====================================
 
-In this section you can find guides for working with Aiven for Apache Cassandra®.
+.. grid:: 1 2 2 2
 
-.. tableofcontents::
+    .. grid-item-card:: :doc:`Cross-cluster replication </docs/products/cassandra/concepts/cross-cluster-replication>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`Tombstones in Apache Cassandra </docs/products/cassandra/concepts/tombstones>`
+        :shadow: md
+        :margin: 2 2 0 0

--- a/docs/products/cassandra/get-started.rst
+++ b/docs/products/cassandra/get-started.rst
@@ -28,4 +28,5 @@ In order to launch a service, decide on the service plan, cloud provider, and re
          --project PROJECT_NAME 
 
 .. note::
-   See the full list of default flags with the following command: ``avn service create -h``. Additionally, there are some type specific options, which you can see executing the following command: ``avn service types -v``
+
+   See the full list of default flags using the ``avn service create -h`` command. Additionally, there are some type-specific options, which you can see executing the ``avn service types -v`` command.

--- a/docs/products/cassandra/howto.rst
+++ b/docs/products/cassandra/howto.rst
@@ -1,6 +1,31 @@
-HowTo
-=====
+Aiven for Apache Cassandra® how-tos
+===================================
 
-Check out the common tasks for working with Aiven for Apache Cassandra®.
+.. dropdown:: Getting started
 
-.. tableofcontents::
+    - :doc:`Create a managed Aiven for Apache Cassandra service </docs/platform/howto/create_new_service>`
+    - :doc:`Connect to Aiven for Apache Cassandra with cqlsh </docs/products/cassandra/howto/connect-cqlsh-cli>`
+    - :doc:`Connect to Aiven for Apache Cassandra with Python </docs/products/cassandra/howto/connect-python>`
+    - :doc:`Connect to Aiven for Apache Cassandra with Go </docs/products/cassandra/howto/connect-go>`
+
+.. dropdown:: Service management
+
+    - :doc:`Manage data in Aiven for Apache Cassandra with DSBULK </docs/products/cassandra/howto/use-dsbulk-with-cassandra>`
+    - :doc:`Perform a stress test with nosqlbench </docs/products/cassandra/howto/use-nosqlbench-with-cassandra>`
+
+.. dropdown:: Cluster management
+
+    - :doc:`Monitor a managed Aiven for Apache Cassandra service </docs/platform/howto/monitoring-services>`
+    - :doc:`Resize a managed Aiven for Apache Cassandra service </docs/platform/howto/scale-services>`
+    - :doc:`Schedule automatic maintenance updates </docs/platform/howto/prepare-for-high-load>`
+    - :doc:`Upgrade a managed Aiven for Apache Cassandra service </docs/platform/howto/scale-services>`
+    - :doc:`Tag a managed Aiven for Apache Cassandra service </docs/platform/howto/tag-resources>`
+    - :doc:`Power-off and delete a managed Aiven for Apache Cassandra service </docs/platform/howto/pause-from-cli>`
+    - :doc:`Migrate a managed Aiven for Apache Cassandra service </docs/platform/howto/migrate-services-cloud-region>`
+    - :doc:`Fork a managed Aiven for Apache Cassandra service </docs/platform/howto/console-fork-service>`
+
+.. dropdown:: Cross-cluster replication
+
+    - :doc:`Enable CCR on Aiven for Apache Cassandra </docs/products/cassandra/howto/enable-cross-cluster-replication>`
+    - :doc:`Manage CCR on Aiven for Apache Cassandra </docs/products/cassandra/howto/manage-cross-cluster-replication>`
+    - :doc:`Disable CCR on Aiven for Apache Cassandra </docs/products/cassandra/howto/disable-cross-cluster-replication>`

--- a/docs/products/cassandra/howto.rst
+++ b/docs/products/cassandra/howto.rst
@@ -1,5 +1,5 @@
-Aiven for Apache Cassandra® how-tos
-===================================
+Aiven for Apache Cassandra® HowTo
+=================================
 
 .. dropdown:: Getting started
 

--- a/docs/products/cassandra/howto/list-code-samples.rst
+++ b/docs/products/cassandra/howto/list-code-samples.rst
@@ -1,4 +1,4 @@
-Code samples
-============
+Connect to Aiven for Apache Cassandra®
+======================================
 
 .. tableofcontents::

--- a/docs/products/cassandra/howto/list-manage-cluster.rst
+++ b/docs/products/cassandra/howto/list-manage-cluster.rst
@@ -1,0 +1,16 @@
+Manage your Aiven for Apache Cassandra® cluster
+===============================================
+
+:doc:`Monitor a managed service </docs/platform/howto/monitoring-services>`
+
+:doc:`Tag a managed service </docs/platform/howto/tag-resources>`
+
+:doc:`Schedule maintenance updates </docs/platform/howto/prepare-for-high-load>`
+
+:doc:`Resize a managed service </docs/platform/howto/scale-services>`
+
+:doc:`Migrate a managed service </docs/platform/howto/migrate-services-cloud-region>`
+
+:doc:`Fork a managed service </docs/platform/howto/console-fork-service>`
+
+:doc:`Power off & delete a managed service </docs/platform/howto/pause-from-cli>`

--- a/docs/products/cassandra/howto/list-manage-service.rst
+++ b/docs/products/cassandra/howto/list-manage-service.rst
@@ -1,0 +1,12 @@
+Manage your Aiven for Apache Cassandra® service
+===============================================
+
+.. grid:: 1 2 2 2
+
+    .. grid-item-card:: :doc:`Manage data with DSBULK </docs/products/cassandra/howto/use-dsbulk-with-cassandra>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`Perform a stress test with nosqlbench </docs/products/cassandra/howto/use-nosqlbench-with-cassandra>`
+        :shadow: md
+        :margin: 2 2 0 0

--- a/docs/products/cassandra/howto/list-manage-service.rst
+++ b/docs/products/cassandra/howto/list-manage-service.rst
@@ -1,12 +1,5 @@
 Manage your Aiven for Apache Cassandra® service
 ===============================================
 
-.. grid:: 1 2 2 2
+.. tableofcontents::
 
-    .. grid-item-card:: :doc:`Manage data with DSBULK </docs/products/cassandra/howto/use-dsbulk-with-cassandra>`
-        :shadow: md
-        :margin: 2 2 0 0
-
-    .. grid-item-card:: :doc:`Perform a stress test with nosqlbench </docs/products/cassandra/howto/use-nosqlbench-with-cassandra>`
-        :shadow: md
-        :margin: 2 2 0 0

--- a/docs/products/cassandra/howto/setup.rst
+++ b/docs/products/cassandra/howto/setup.rst
@@ -1,0 +1,1 @@
+.. include:: /docs/products/cassandra/get-started.rst

--- a/docs/products/cassandra/overview.rst
+++ b/docs/products/cassandra/overview.rst
@@ -1,0 +1,23 @@
+Aiven for Apache Cassandra® overview
+====================================
+
+What is Apache Cassandra®?
+--------------------------
+
+`Apache Cassandra® <https://cassandra.apache.org/_/index.html>`_ is an open source, NoSQL database. It is specifically designed to be highly available, performant, and scalable. It supports a distributed architecture with asynchronous replication and is highly fault tolerant.
+
+Apache Cassandra originated from Facebook, and since then has had a strong history with some of the most demanding data platforms around while being in the care of the Apache project. From this strong history comes a robust database with an emphasis on security, and the ability to scale up to meet the needs of even the largest data platforms.
+
+Aiven for Apache Cassandra builds on the open source offering, adding management features and updates so that you can rely on the database your organisation needs to succeed.
+
+Why Aiven for Apache Cassandra®?
+--------------------------------
+
+Apache Cassandra® is designed to handle large volumes of writes to the database; this is one of the key reasons we see for adopting Apache Cassandra over some of the other options in a similar problem space.
+
+It is a truly distributed database where the individual nodes can communicate with one another without referencing any master node. This improves both its scalability and its fault tolerance, two key capabilities of Apache Cassandra.
+
+Get started with Aiven for Apache Cassandra
+-------------------------------------------
+
+Take your first steps with Aiven for Apache Cassandra® by following :doc:`Get started with Aiven for Apache Cassandra </docs/products/cassandra/get-started>`.

--- a/docs/products/cassandra/reference.rst
+++ b/docs/products/cassandra/reference.rst
@@ -1,6 +1,9 @@
-Reference
-=========
+Aiven for Apache Cassandra® reference
+=====================================
 
-Additional reference information for Aiven for Apache Cassandra®:
+.. grid:: 1 2 2 2
 
-.. tableofcontents::
+    .. grid-item-card:: :doc:`Advanced parameters for Aiven for Apache Cassandra </docs/products/cassandra/reference/advanced-params>`
+        :shadow: md
+        :margin: 2 2 0 0
+

--- a/docs/products/clickhouse.rst
+++ b/docs/products/clickhouse.rst
@@ -1,7 +1,7 @@
 Aiven for ClickHouse®
 =====================
 
-Aiven for ClickHouse® is a fully managed distributed columnar database based on open source ClickHouse® – a fast, resource effective solution tailored for data warehouse and generation of real-time analytical data reports using advanced SQL queries.
+Aiven for ClickHouse® is a fully managed distributed columnar database based on open source ClickHouse – a fast, resource effective solution tailored for data warehouse and generation of real-time analytical data reports using advanced SQL queries.
 
 -------------------
 
@@ -23,10 +23,22 @@ Aiven for ClickHouse® is a fully managed distributed columnar database based on
         :shadow: md
         :margin: 2 2 0 0
 
-        Discover step-by-step instructions on the common use cases.
+        Discover step-by-step instructions on common use cases.
 
     .. grid-item-card:: :doc:`Concepts </docs/products/clickhouse/concepts>`
         :shadow: md
         :margin: 2 2 0 0
 
-        Get familiar with the core concepts of Aiven for ClickHouse®.
+        Get familiar with the core concepts of Aiven for ClickHouse.
+
+    .. grid-item-card:: :doc:`Reference </docs/products/clickhouse/reference>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+        Look up parameters, metrics, or formats supported by Aiven for ClickHouse.
+
+    .. grid-item-card:: `What's new <https://aiven.io/changelog>`_
+        :shadow: md
+        :margin: 2 2 0 0
+
+        Check out new features or latest improvements introduced to Aiven for ClickHouse and other Aiven services.


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-249

Aligning the structure of Cassandra docs to the structure we've already had for ClickHouse, Flink, and Grafana.

