### PR TITLE
Added Kafka connect and mirror maker to filter

### DIFF
--- a/docs/platform/howto/search-services.rst
+++ b/docs/platform/howto/search-services.rst
@@ -47,6 +47,10 @@ To filter the services by service type, use the filter values in this table.
       - ``flink``
     * - Apache Kafka®
       - ``kafka``
+    * - Apache Kafka® Connect
+      - ``kafkaconnect``
+    * - Apache Kafka® MirrorMaker
+      - ``mirrormaker``
     * - ClickHouse®
       - ``clickhouse``  
     * - Grafana®


### PR DESCRIPTION
# What changed, and why it matters
Added Apache Kafka Connect and Apache Kafka Mirror Maker to the list of filters (Filter by service types)

Fixes: #1802 