### PR TITLE
Stop preserving user in anonymous tracking and use the same state storage strategy

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -36,7 +36,7 @@ snowplow("newTracker", "at", "dc.aiven.io", {
   discoverRootDomain: true,
   cookieSameSite: 'Lax',
   anonymousTracking: { withSessionTracking: true, withServerAnonymisation: true },
-  stateStorageStrategy: 'none',
+  stateStorageStrategy: 'cookieAndLocalStorage',
   eventMethod: 'post',
   postPath: '/aiven/dc2',
   contexts: {
@@ -62,7 +62,7 @@ function OptanonWrapper() {
     snowplow('disableAnonymousTracking', { stateStorageStrategy: 'cookieAndLocalStorage' });
   } else {
     // enable fully anonymous tracking
-    snowplow('clearUserData', { preserveSession: true, preserveUser: true });
+    snowplow('clearUserData', { preserveSession: true });
   }
 
   if (window.firstTimeVisit) {


### PR DESCRIPTION
- Previous configuration stored the user for anonymous users, which is not inline with anonymous session
- Every page view had different session id, so the session was not stored correctly
-> We needed to ensure the tracker and the anonymous tracking uses the same storage strategy
-> https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/additional-options/#disable-anonymous-tracking


