### PR TITLE
kafka-connect: fix gcp storage sink perm requirements [HELP-155]

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/gcs-sink-prereq.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcs-sink-prereq.rst
@@ -30,4 +30,9 @@ The JSON service key will be used in the connector configuration
 Grant the service account access to the GCS bucket
 --------------------------------------------------
 
-Navigate in the GCS bucket detail page, in the **Permissions** tab and grant access to the newly created service account to the bucket. The **Storage Object Creator** role is sufficient for the connector.
+Navigate in the GCS bucket detail page, in the **Permissions** tab and grant access to the newly created service account to the bucket. The following object permissions must be enabled in the bucket:
+
+* `storage.objects.create`
+* `storage.objects.delete` (needed for overwriting, for example on re-processing)
+
+The connector should be granted these permissions via a custom role or the standard role **Storage Legacy Bucket Writer**. You also need to ensure the bucket doesn't have a retention policy that prohibits overwriting.


### PR DESCRIPTION
Unlike stated within the current documentation, the role `Storage Object Creator` is NOT sufficient for the connector to operate properly. Specifically, the object permission `storage.objects.delete` is not part of this role although it is actually required for re-processing.

The change provides more transparency as per the [connector repo](https://github.com/aiven/gcs-connector-for-apache-kafka), and eventually suggests to use a different [IAM role](https://cloud.google.com/storage/docs/access-control/iam-roles).

[HELP-155](https://aiven.atlassian.net/browse/HELP-155)

[HELP-155]: https://aiven.atlassian.net/browse/HELP-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ