### PR TITLE
Enable activity tracking on docs [STORM-923]

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -44,6 +44,12 @@ snowplow("newTracker", "at", "dc.aiven.io", {
   }
 });
 
+// Must be called before snowplow('trackPageView')
+snowplow('enableActivityTracking', { 
+  minimumVisitLength: 10, 
+  heartbeatDelay: 10 
+});
+
 </script>
 <!-- End Snowplow Analytics -->
 


### PR DESCRIPTION
- Activity tracking must be enabled before calling track page view

We want to know if user spends time in our docs or not


