### PR TITLE
Remove instructions for adding followers to support tickets

### DIFF
--- a/docs/platform/howto/project-support-center.rst
+++ b/docs/platform/howto/project-support-center.rst
@@ -22,14 +22,3 @@ To create support tickets in the `Aiven Console <https://console.aiven.io/>`_:
 Your new ticket is sent to our support team for review and you also receive an confirmation email. You can reply to this email to update your ticket with new information. Replies from the Aiven support team will be sent directly to your email.
 
 You can also track the status of your tickets and review them from the project support center.
-
-Add followers to an open ticket
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If other users want to track and manage a ticket, the owner can add them to an open ticket by the owner of the ticket:
-
-#. Click **Support** to open the Project Support Center.
-#. Find the ticket you want to add users to in the list and click **Add follower**. 
-#. Select the user's email and click **Add follower**.
-
-You can also add users to a ticket by copying them into the support ticket email. 


### PR DESCRIPTION
# What changed, and why it matters
Feature is not currently available, so this PR removes the instructions for it.

