### PR TITLE
kafka: Clarify upgrade-procedure wording on plan changes

### DIFF
--- a/docs/products/kafka/concepts/upgrade-procedure.rst
+++ b/docs/products/kafka/concepts/upgrade-procedure.rst
@@ -145,8 +145,10 @@ Rollback is not available since old nodes are deleted once they are removed from
 .. Note::
 
     Nodes are not removed from the cluster while they hold data. If an upgrade doesn't progress, the nodes are not removed since that would lead to data loss. 
-    
-In case of an upgrade procedure due to a plan change, the old plan can be restored via the :doc:`Aiven Console </docs/platform/howto/scale-services>` or the :ref:`Aiven CLI <avn-cli-service-update>`.
+
+It is possible to downgrade from a larger service plan back to a smaller service plan, if there is enough disk capacity on the smaller plan, via the :doc:`Aiven Console </docs/platform/howto/scale-services>` or the :ref:`Aiven CLI <avn-cli-service-update>`.
+
+The same upgrade procedure is used for all service plan changes whenever the node type is changed.  When the service plan is downgraded to use nodes with less CPUs, memory or disk, all newly-created nodes are always launched with the latest system software versions, and the data is transferred to new nodes using the upgrade mechanism described in this document.
 
 Upgrade impact and risks
 ------------------------

--- a/docs/products/kafka/concepts/upgrade-procedure.rst
+++ b/docs/products/kafka/concepts/upgrade-procedure.rst
@@ -12,6 +12,7 @@ The upgrade procedure is executed during:
     
 All the above operations involve creating new broker nodes to replace existing ones.
 
+
 Upgrade procedure steps
 ---------------------------
 
@@ -148,7 +149,7 @@ Rollback is not available since old nodes are deleted once they are removed from
 
 It is possible to downgrade from a larger service plan back to a smaller service plan, if there is enough disk capacity on the smaller plan, via the :doc:`Aiven Console </docs/platform/howto/scale-services>` or the :ref:`Aiven CLI <avn-cli-service-update>`.
 
-The same upgrade procedure is used for all service plan changes whenever the node type is changed.  When the service plan is downgraded to use nodes with less CPUs, memory or disk, all newly-created nodes are always launched with the latest system software versions, and the data is transferred to new nodes using the upgrade mechanism described in this document.
+When changing the node type during a service plan change, the upgrade procedure remains the same. In case of downgrading to a service plan with nodes having lesser CPUs, memory, or disk, the latest system software versions will be used for all newly created nodes. The upgrade mechanism, as explained in this document, will be employed to transfer data to the new nodes.
 
 Upgrade impact and risks
 ------------------------


### PR DESCRIPTION
It's important to note that service plan *downgrades* will perform software *upgrades* and that the latest software will be installed ("upgraded") if the hardware is "downgraded".

The previous wording caused some confusion.