### PR TITLE
Fix Source Attribute value for Azure SSO setup

### DIFF
--- a/docs/platform/howto/saml/setup-saml-azure.rst
+++ b/docs/platform/howto/saml/setup-saml-azure.rst
@@ -88,7 +88,7 @@ Create a claim and add users
       * - ``Source``
         - ``Attribute``
       * - ``Source Attribute``
-        - ``user.email``
+        - ``user.mail``
 
 3. Download the **Certificate (Base64)** from the **SAML Signing Certificate** section.
 


### PR DESCRIPTION
# What changed, and why it matters
Source Attribute value in the instructions is incorrect. Should be `user.mail` instead of `user.email`.

