### PR TITLE
clickhouse: add redirect for the ClickHouse-PostgreSQL integration article to fix a broken link in the console

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -54,6 +54,7 @@
 /docs/products/flink/howto/real-time-alerting-solution.html            /docs/tutorials/anomaly-detection.html
 /docs/products/postgresql/reference/high-cpu-load-of-pgbouncer.html    /docs/products/postgresql/troubleshooting/troubleshooting-connection-pooling.html
 /docs/products/clickhouse/concepts/databases-and-tables.html           /docs/products/clickhouse/howto/manage-databases-tables.html
+/docs/products/clickhouse/howto/integrate-pg.html                      /docs/products/clickhouse/howto/integrate-postgresql.html
 
 # Redirect from .index.html to specific page names for landing
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-279

