### PR TITLE
Updated Service backup content

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -69,6 +69,7 @@ entries:
           - file: docs/platform/howto/migrate-services-cloud-region
           - file: docs/platform/howto/migrate-services-vpc
           - file: docs/platform/howto/recover-a-deleted-service
+          - file: docs/platform/howto/cleanup-powered-off-services
           - file: docs/platform/howto/add-storage-space
           - file: docs/platform/howto/tag-resources
           - file: docs/platform/howto/search-services

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -170,7 +170,7 @@ Aiven for ClickHouse backups contain database lists, table schemas, table conten
 Access to backups
 -----------------
 
-The Aiven platform provides a centralized managed platform for Aiven services, enabling them to run on various cloud providers and regions. The open-source tooling provided for service backups is also available for use in your own infrastructure.
+The Aiven platform provides a centralized managed platform for Aiven services, enabling them to run on various cloud providers and regions. The open-source tools used for service backups can be leveraged in your own infrastructure. 
 
 The Aiven platform is designed to handle the operational aspects of running complex software at scale, allowing you to focus on using the services instead of maintaining them. Aiven handles service availability, security, connectivity, and backups.
 

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -6,14 +6,18 @@ This article provides information on general rules for handling service backups 
 About backups at Aiven
 ----------------------
 
-All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. The backup retention times vary based on the service and the selected service plan. Backups we take for managing the service are not available for download for any service type as they are compressed and encrypted by our management platform.
+All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. The backup retention times vary based on the service and the selected service plan. 
+
+Backups taken by Aiven for managing the service are not available for download for any service type. This is because they are compressed and encrypted by our management platform.
 
 Service power-off/on backup policy
 ------------------------------------
 
-Whenever a service is powered on from a powered-off state, we restore the latest backup available.
+Whenever a service is powered on from a powered-off state, the latest available backup is restored.
 
-We review any services that are powered off for longer than 180 days. We will send you a notification email in advance to take action before we perform house cleaning and delete the service and backup as part of `periodic cleanup of powered-off services <https://help.aiven.io/en/articles/4578430-periodic-cleanup-of-powered-off-services>`__. If you would still like to keep the powered off service for longer than 180 days, you can avoid this routine cleanup by powering on the service and then powering it back off.
+Services that have been powered off for more than 180 days are reviewed. A notification email will be sent to you to provide time for taking action before the service and backup are deleted as part of the :doc:`periodic cleanup of powered-off services <../howto/cleanup-powered-off-services>`.
+
+If you wish to keep the powered-off service for more than 180 days, simply power on the service and then power it off again to avoid the routine cleanup.
 
 Backup profile per service
 --------------------------
@@ -53,12 +57,12 @@ There are specific backup strategies for particular service types.
 Aiven for Apache Kafka®
 '''''''''''''''''''''''
 
-Aiven for Apache Kafka is usually used as a transport tool for data rather than a permanent store and the way it stores data doesn't really allow reasonable backup to be implemented using traditional backup strategies. Hence, Aiven doesn't take backups for managed Apache Kafka services and data durability is determined by the replication of data across the cluster.
+Aiven for Apache Kafka is usually used as a transport tool for data rather than a permanent store. Due to the way it stores data, traditional backup strategies are not feasible. As a result, Aiven does not perform backups for managed Apache Kafka services, and data durability is determined by data replication across the cluster.
 
 To back up data passing through Kafka, we recommend using one of the following tools:
 
-* :doc:`MirrorMaker 2<../../products/kafka/kafka-mirrormaker>` to replicate the data to another cluster, which could be an Aiven service or a Kafka cluster on your own infrastructure. Using MirrorMaker 2, the backup cluster is running as an independent Kafka service, so you have complete freedom of choice in which zone to base the service.
-
+* :doc:`MirrorMaker 2<../../products/kafka/kafka-mirrormaker>` to replicate the data to another cluster, which could be an Aiven service or a Kafka cluster on your own infrastructure. With MirrorMaker 2, the backup cluster operates as an independent Kafka service, giving you complete freedom in choosing which zone to locate the service.
+  
   .. note::
         
       MirrorMaker 2 provides tools for mapping between the source and target offset, so you don't need to make this calculation. For more details, see section *Offset Mapping* in blog post `A look inside Kafka MirrorMaker 2 <https://blog.cloudera.com/a-look-inside-kafka-mirrormaker-2/>`__.
@@ -76,14 +80,14 @@ To back up data passing through Kafka, we recommend using one of the following t
 Aiven for PostgreSQL®
 '''''''''''''''''''''
 
-For Aiven for PostgreSQL, full daily backups are taken and WAL segments are constantly archived to the cloud object storage. In case of node failure,
+For Aiven for PostgreSQL, full daily backups are taken, and WAL segments are constantly archived to the cloud object storage. In case of node failure,
 
 * For a business or premium plan, Aiven can reconstruct the latest state from a replica
 * For a startup plan, Aiven can reconstruct the latest state from the latest base backup and replay the latest WAL segments on top of that.
 
 You can supplement this with a remote read replica service, which you can run in a different cloud region or with another cloud provider and promote to master if needed.
 
-To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. If there has been a recent backup taken, it may take another backup cycle before the new backup time takes effect.
+To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. f a recent backup has been taken, it may take another backup cycle before the new backup time takes effect.
 
 .. seealso::
     
@@ -98,7 +102,7 @@ Aiven for MySQL®
 
 Aiven for MySQL databases are automatically backed up with full daily backups and binary logs recorded continuously. All backups are encrypted with the open source `myhoard <https://github.com/aiven/myhoard>`_ software. Myhoard uses `Percona XtraBackup <https://www.percona.com/>`_ internally for taking full (or incremental) snapshots for MySQL.
 
-To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. If there has been a recent backup taken, it may take another backup cycle before the new backup time takes effect.
+To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. If a recent backup has been taken, it may take another backup cycle before the new backup time takes effect.
 
 .. seealso::
     
@@ -107,7 +111,7 @@ To shift the backup schedule to a new time, you can modify the backup time confi
 Aiven for OpenSearch®
 '''''''''''''''''''''
 
-Aiven for OpenSearch databases are automatically backed up, encrypted, and stored securely in the object storage. The backups are taken every hour and the retention period varies based on the service plan.
+Aiven for OpenSearch databases are automatically backed up, encrypted, and stored securely in the object storage. The backups are taken every hour, and the retention period varies based on the service plan.
 
 .. seealso::
 
@@ -123,7 +127,7 @@ Aiven for Apache Cassandra backups are taken every 24 hours. The point-in-time r
 
 .. note::
     
-    If you'd like to be notified once the PITR feature is available for Cassandra, contact the Aiven support.
+    If you'd like to be notified once the PITR feature is available for Cassandra, contact Aiven support.
 
 Aiven for Redis™*
 '''''''''''''''''
@@ -139,12 +143,12 @@ You can control the persistence feature using ``redis_persistence`` under **Adva
 
 .. note::
 
-    AOF persistence is currently not supported by the Aiven for the managed Redis service.
+    AOF persistence is currently not supported by Aiven for the managed Redis service.
 
 Aiven for InfluxDB®
 '''''''''''''''''''
 
-Aiven for InfluxDB backups are taken every 12 hours with 2.5 days of retention. InfluxDB® is automatically backed up, encrypted, and uploaded to the Aiven's S3 account in the same region. When an instance has to be rebuilt, the backup is downloaded and restored to create a new instance.
+Aiven for InfluxDB backups are taken every 12 hours with 2.5 days of retention. InfluxDB® is automatically backed up, encrypted, and uploaded to Aiven's S3 account in the same region. When an instance has to be rebuilt, the backup is downloaded and restored to create a new instance.
 
 Aiven for ClickHouse®
 '''''''''''''''''''''
@@ -166,11 +170,12 @@ Aiven for ClickHouse backups contain database lists, table schemas, table conten
 Access to backups
 -----------------
 
-The Aiven platform provides a centralised managed platform for Aiven services to run across many different cloud providers and regions. Tooling that built to provide the service backups are open source and available for you to use in your own infrastructure. 
+The Aiven platform provides a centralized managed platform for Aiven services, enabling them to run on various cloud providers and regions. The open-source tooling provided for service backups is also available for use in your own infrastructure.
 
-The nature of the Aiven platform is to manage the operational tasks of running complex software at scale so that you are able to focus your efforts on using the services, not maintaining them. Aiven takes care of service availability, security, connectivity, and backups.
+The Aiven platform is designed to handle the operational aspects of running complex software at scale, allowing you to focus on using the services instead of maintaining them. Aiven handles service availability, security, connectivity, and backups.
 
-Access to backups of your services is not possible. The backups are encrypted and stored in the object storage. If you do need to backup your service, you can use the standard tooling for this service.
+Access to backups of your services is not possible due to their encryption and storage in object storage. However, if you do need to backup your service, you can use the standard tooling for this service.
+
 
 Recommended backup tools per service are as follows:
 

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -87,7 +87,7 @@ For Aiven for PostgreSQL, full daily backups are taken, and WAL segments are con
 
 You can supplement this with a remote read replica service, which you can run in a different cloud region or with another cloud provider and promote to master if needed.
 
-To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. f a recent backup has been taken, it may take another backup cycle before the new backup time takes effect.
+To shift the backup schedule to a new time, you can modify the backup time configuration option in **Advanced Configuration** in the Aiven console. If a recent backup has been taken, it may take another backup cycle before the new backup time takes effect.
 
 .. seealso::
     

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -8,7 +8,7 @@ About backups at Aiven
 
 All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. The backup retention times vary based on the service and the selected service plan. 
 
-Backups taken by Aiven for managing the service are not available for download for any service type. This is because they are compressed and encrypted by our management platform.
+Aiven takes service backups for managing purposes. These backups are compressed and encrypted by the Aiven management platform and, as such, are not available for download for any service type.
 
 Service power-off/on backup policy
 ------------------------------------
@@ -17,7 +17,7 @@ Whenever a service is powered on from a powered-off state, the latest available 
 
 Services that have been powered off for more than 180 days are reviewed. A notification email will be sent to you to provide time for taking action before the service and backup are deleted as part of the :doc:`periodic cleanup of powered-off services <../howto/cleanup-powered-off-services>`.
 
-If you wish to keep the powered-off service for more than 180 days, simply power on the service and then power it off again to avoid the routine cleanup.
+If you wish to keep the powered-off service for more than 180 days, power on the service and then power it off again to avoid the routine cleanup.
 
 Backup profile per service
 --------------------------
@@ -59,9 +59,9 @@ Aiven for Apache Kafka®
 
 Aiven for Apache Kafka is usually used as a transport tool for data rather than a permanent store. Due to the way it stores data, traditional backup strategies are not feasible. As a result, Aiven does not perform backups for managed Apache Kafka services, and data durability is determined by data replication across the cluster.
 
-To back up data passing through Kafka, we recommend using one of the following tools:
+To back up data passing through Apache Kafka, we recommend using one of the following tools:
 
-* :doc:`MirrorMaker 2<../../products/kafka/kafka-mirrormaker>` to replicate the data to another cluster, which could be an Aiven service or a Kafka cluster on your own infrastructure. With MirrorMaker 2, the backup cluster operates as an independent Kafka service, giving you complete freedom in choosing which zone to locate the service.
+* :doc:`MirrorMaker 2<../../products/kafka/kafka-mirrormaker>` to replicate the data to another cluster, which could be an Aiven service or a Apache Kafka cluster on your own infrastructure. With MirrorMaker 2, the backup cluster operates as an independent Apache Kafka service. You can freely choose a zone for your backup service since it operates independently from the primary service.
   
   .. note::
         
@@ -127,7 +127,7 @@ Aiven for Apache Cassandra backups are taken every 24 hours. The point-in-time r
 
 .. note::
     
-    If you'd like to be notified once the PITR feature is available for Cassandra, contact Aiven support.
+    If you'd like to be notified once the PITR feature is available for Cassandra, contact the Aiven support.
 
 Aiven for Redis™*
 '''''''''''''''''
@@ -170,11 +170,11 @@ Aiven for ClickHouse backups contain database lists, table schemas, table conten
 Access to backups
 -----------------
 
-The Aiven platform provides a centralized managed platform for Aiven services, enabling them to run on various cloud providers and regions. The open-source tools used for service backups can be leveraged in your own infrastructure. 
+The Aiven platform takes care of all maintenance operations required for running complex software at scale, allowing you to focus on using your services. The open-source tools used for service backups can be leveraged in your own infrastructure. 
 
 The Aiven platform is designed to handle the operational aspects of running complex software at scale, allowing you to focus on using the services instead of maintaining them. Aiven handles service availability, security, connectivity, and backups.
 
-Access to backups of your services is not possible due to their encryption and storage in object storage. However, if you do need to backup your service, you can use the standard tooling for this service.
+Since service backups are encrypted and stored in the object storage, accessing them is not possible. If you do need to backup your service, use the standard tooling for this service.
 
 
 Recommended backup tools per service are as follows:

--- a/docs/platform/howto/cleanup-powered-off-services.rst
+++ b/docs/platform/howto/cleanup-powered-off-services.rst
@@ -1,0 +1,22 @@
+Periodic cleanup of powered-off services
+========================================
+
+Aiven platform provides a way to power-off services stop accumulating usage costs when not in use. However leaving them powered-off for an extended period of time comes with disadvantages too.
+
+Aiven platform receive regular maintenance updates to keep the services updated with the latest supported versions upstream, including fixes to bugs, possible security vulnerabilities, and overall improvements to performance and memory consumption.
+
+Keeping services in powered-off state for a long time lowers the feasibility of a smooth upgrade path, making it harder for us to continue supporting your needs.
+
+.. note:: 
+    * It is recommended that you regularly review your services and delete those that are no longer needed. This will allow Aiven to focus on supporting the services that you actively use and better utilize platform resources. 
+    * If a service has been powered off for 90 days, you will receive email notifications reminding you that the service has been inactive for a prolonged period. If the service remains powered off for 180 consecutive days, it will be marked for automatic deletion.
+
+
+Delete a powered-off service
+------------------------------
+
+1. In the `Aiven Console <https://console.aiven.io/>`_, select **Services** in the left navigation bar to display a list of all services.
+2. Use the search bar to locate a specific powered-off service or the filter to display a list of services with the status **Powered off**.
+3. Click on the powered-off service to access the Service Overview page, then click the **Delete Service** option.
+4. A confirmation dialog box will appear. Enter the name of the service to delete and select **Delete** to confirm the action.
+

--- a/docs/platform/howto/cleanup-powered-off-services.rst
+++ b/docs/platform/howto/cleanup-powered-off-services.rst
@@ -1,22 +1,22 @@
 Periodic cleanup of powered-off services
 ========================================
 
-Aiven platform provides a way to power-off services stop accumulating usage costs when not in use. However leaving them powered-off for an extended period of time comes with disadvantages too.
+The Aiven platform provides a way to power-off services to stop accumulating usage costs when not in use. However, leaving them powered-off for an extended period of time comes with disadvantages.
 
-Aiven platform receive regular maintenance updates to keep the services updated with the latest supported versions upstream, including fixes to bugs, possible security vulnerabilities, and overall improvements to performance and memory consumption.
+The Aiven platform receive regular maintenance updates to keep the services updated with the latest supported versions upstream, including fixes to bugs, security vulnerabilities, and overall improvements to performance and memory consumption.
 
-Keeping services in powered-off state for a long time lowers the feasibility of a smooth upgrade path, making it harder for us to continue supporting your needs.
+Keeping services in powered-off state for a long time lowers the feasibility of a smooth upgrade path, making it harder for Aiven to continue supporting your needs.
 
 .. note:: 
-    * It is recommended that you regularly review your services and delete those that are no longer needed. This will allow Aiven to focus on supporting the services that you actively use and better utilize platform resources. 
-    * If a service has been powered off for 90 days, you will receive email notifications reminding you that the service has been inactive for a prolonged period. If the service remains powered off for 180 consecutive days, it will be marked for automatic deletion.
+    * It is recommended that you regularly review your services and delete those that are no longer needed. This allows Aiven to focus on supporting the services that you actively use and better utilize platform resources.
+    * If a service has been powered off for 90 days, you will receive email notifications reminding you that the service has been inactive for a prolonged period. If the service remains powered off for 180 consecutive days, it is subject to automatic deletion.
 
 
 Delete a powered-off service
 ------------------------------
 
-1. In the `Aiven Console <https://console.aiven.io/>`_, select **Services** in the left navigation bar to display a list of all services.
-2. Use the search bar to locate a specific powered-off service or the filter to display a list of services with the status **Powered off**.
-3. Click on the powered-off service to access the Service Overview page, then click the **Delete Service** option.
-4. A confirmation dialog box will appear. Enter the name of the service to delete and select **Delete** to confirm the action.
+1. In `Aiven Console <https://console.aiven.io/>`_, select **Services** in the left navigation bar to display a list of all services.
+2. Use the search bar to locate a specific powered off service or the filter to display a list of services with status **Powered off**.
+3. Select the powered off service to access its **Overview** page, and select **Delete Service**.
+4. On the confirmation dialog, enter the name of the service to delete and select **Delete** to confirm the action.
 


### PR DESCRIPTION
# What changed, and why it matters

Updated Service backup content to improve readability. Additionally, migrated related topic (https://github.com/aiven/aiven-intercom-docs-archive/blob/main/archive/4578430/4578430-periodic-cleanup-of-powered-off-services.rst#deleting-a-powered-off-service).

