### PR TITLE
SUP-553: Updating datasource integration

### DIFF
--- a/docs/products/postgresql/howto/datasource-integration.rst
+++ b/docs/products/postgresql/howto/datasource-integration.rst
@@ -1,14 +1,14 @@
 Connect two PostgreSQL® services via datasource integration
 ===========================================================
 
-There are two types of datasource integrations you can use with Aiven for PostgreSQL®: :doc:`Aiven for Grafana® <visualize-grafana>`, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to :doc:`query across them <use-dblink-extension>`, but still want to have a restricted IP allow-list, then you will need to use the ``Datasource`` service integration.
+There are two types of datasource integrations you can use with Aiven for PostgreSQL®: :doc:`Aiven for Grafana® <visualize-grafana>`, and another Aiven for PostgreSQL® service.  If you are connecting two PostgreSQL® services together, perhaps to :doc:`query across them <use-dblink-extension>`, but still want to have a restricted IP allow-list, then you will need to use the ``Allow IP-List`` service integration.
 
-Whenever a service node needs to be recycled, e.g. for maintenance, a new node is created with a new IP address.  As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ``Datasource`` service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.
+Whenever a service node needs to be recycled, e.g. for maintenance, a new node is created with a new IP address.  As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ``Allow IP-List`` service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.
 
 Integrate two PostgreSQL services
 ---------------------------------
 
-1. On the service overview page for your PostgreSQL service, go to **Manage Integrations** and choose the **datasource** option.
+1. On the service overview page for your PostgreSQL service, go to **Manage Integrations** and choose the **Allow IP-List** option.
 
 2. Choose either a new or existing PostgreSQL service.
 


### PR DESCRIPTION
# What's wrong?

There is no longer a **"datasource"** integration option available that the Datasource integration document is mentioning with the below currently available options:

![image](https://user-images.githubusercontent.com/10273586/230473736-97cbc7a1-222e-44d8-95e8-8d31d01f3681.png)

Instead, what appears is being described is the **IP Allow-List** option

![image](https://user-images.githubusercontent.com/10273586/230475962-e6b88139-4f97-4fe8-b90f-7947ada821f5.png)

I believe this was changed recently so my plan is to update the content with the following:

> There are two types of datasource integrations you can use with Aiven for PostgreSQL®: Aiven for Grafana®, and another Aiven for PostgreSQL® service. If you are connecting two PostgreSQL® services together, perhaps to query across them, but still want to have a restricted IP allow-list, then you will need to use the ~Datasource~ **IP Allow-List** service integration.

> As the new IP address cannot be predicted, if you want to maintain a connection between two PostgreSQL services your choices are either to have a very broad IP allow-list (which might be acceptable in the private IP-range of a project VPC) or to use the ~Datasource~ **IP Allow-List** service integration to dynamically create an IP allow-list entry for the other PostgreSQL service.

>  1. On the service overview page for your PostgreSQL service, go to Manage Integrations and choose the ~datasource~ **IP Allow-List** option.

The above should be up to date with our current console options.


# URL of affected page, and any other information

https://docs.aiven.io/docs/products/postgresql/howto/datasource-integration

https://docs.aiven.io/docs/products/postgresql/howto/datasource-integration#integrate-two-postgresql-services


