### PR TITLE
Updating Aiven Terraform provider versions based on discussion.

### DIFF
--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -34,7 +34,7 @@ Add the following to a new ``provider.tf`` file:
      required_providers {
        aiven = {
          source  = "aiven/aiven"
-         version = "~> 3.11.0"
+         version = ">=4.0.0, < 5.0.0"
        }
      }
    }

--- a/docs/tools/terraform/howto/config-postgresql-provider.rst
+++ b/docs/tools/terraform/howto/config-postgresql-provider.rst
@@ -18,7 +18,7 @@ The new provider must be added to the ``required_providers`` block in the Terraf
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = "~> 3.9.0"
+          version = ">=4.0.0, < 5.0.0"
         }
         postgresql = {
           source  = "cyrilgdn/postgresql"

--- a/docs/tools/terraform/howto/upgrade-provider-v1-v2.rst
+++ b/docs/tools/terraform/howto/upgrade-provider-v1-v2.rst
@@ -35,7 +35,7 @@ the Aiven Terraform Provider (v2.3.1 at the time of writing):
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = ">= 2.3.1"
+          version = ">=3.0.0, < 4.0.0"
         }
       }
     }

--- a/docs/tools/terraform/howto/upgrade-provider-v2-v3.rst
+++ b/docs/tools/terraform/howto/upgrade-provider-v2-v3.rst
@@ -25,7 +25,7 @@ the Aiven Terraform Provider (v3.8.1 at the time of writing):
       required_providers {
         aiven = {
           source  = "aiven/aiven"
-          version = ">= 3.9.0"
+          version = ">=3.0.0, < 4.0.0"
         }
       }
     }

--- a/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/clickhouse-access-setup-recipe.rst
@@ -40,7 +40,7 @@ Configure common files
 	 required_providers {
 	   aiven = {
 	     source  = "aiven/aiven"
-	     version = "~> 3.10.0"
+	     version = ">=4.0.0, < 5.0.0"
 	   }
 	 }
        }

--- a/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/grafana-m3db-postgresql-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-clickhouse-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-clickhouse-integration-recipe.rst
@@ -60,7 +60,7 @@ Configure common files
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-connect-terraform-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-custom-conf-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-debezium-postgres-source.rst
@@ -44,7 +44,7 @@ For example, you'll need to declare the variables for ``project`` and ``api_toke
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-flink-integration-recipe.rst
@@ -44,7 +44,7 @@ In order to do so, you'll need to use Aiven console or Aiven CLI.
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.12.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-karapace-recipe.rst
@@ -32,7 +32,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mirrormaker-recipe.rst
@@ -57,7 +57,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-mongodb-recipe.rst
@@ -42,7 +42,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/kafka-topics-http-connector-recipe.rst
@@ -52,7 +52,7 @@ example, you'll need to declare the variables for ``project_name`` and
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/m3db-m3agg-recipe.rst
@@ -36,7 +36,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/multicloud-postgresql-recipe.rst
@@ -31,7 +31,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgres-clickhouse-integration-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgres-clickhouse-integration-recipe.rst
@@ -41,7 +41,7 @@ Configure common files
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-custom-configs-recipe.rst
@@ -34,7 +34,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }

--- a/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
+++ b/docs/tools/terraform/reference/cookbook/postgresql-read-replica-recipe.rst
@@ -48,7 +48,7 @@ Be sure to check out the :doc:`getting started guide <../../get-started>` to lea
          required_providers {
            aiven = {
              source  = "aiven/aiven"
-             version = "~> 3.10.0"
+             version = ">=4.0.0, < 5.0.0"
            }
          }
        }


### PR DESCRIPTION
# What changed, and why it matters

Updating Terraform version on articles so that Aiven customers can stay up to date. 

For v2-->v3 and similar articles, `version = ">=3.0.0, < 4.0.0"`

For Terraform cookbook and getting started articles, `version = ">=4.0.0, < 5.0.0"` (the latest)

@byashimov kindly review.
