### PR TITLE
Fix add storage article

### DIFF
--- a/docs/platform/concepts/dynamic-disk-sizing.rst
+++ b/docs/platform/concepts/dynamic-disk-sizing.rst
@@ -1,9 +1,9 @@
 Dynamic Disk Sizing
 ====================
 
-Dynamic Disk Sizing (DDS) allows you to add or remove additional storage to your services from within the `Aiven Console <https://console.aiven.io/>`_. You can add additional storage during service creation or on-demand without interruption to meet the growing business needs. 
+Dynamic Disk Sizing (DDS) allows you to add storage to or remove storage from your services. You can add storage during service creation or later when service is running service without interruption. 
 
-Dynamic Disk Sizing (DDS) is available for the following services:
+DDS is available for the following services:
 
 - Aiven for Apache Kafka®
 - Aiven for PostgreSQL®
@@ -18,33 +18,29 @@ Dynamic Disk Sizing (DDS) is available for the following services:
 
 Why dynamic disk sizing?
 ------------------------
-When creating a service on Aiven, you have a fixed pre-defined storage allocation based on your plan selection. However, when running your service, there is a possibility that you may soon realize the need for scaling up the storage alone.
+When creating a service on Aiven, you have a fixed storage allocation based on your plan selection. When running your service, you may want to scale up only the storage.
 
-Predicting future growth and storage requirements can sometimes be challenging, and upgrading your service plans for additional storage requirements alone may not be feasible. Upgrading the service plans means paying for more compute resources (or RAM) that your current usage does not require. 
-
-To cater to the needs of additional storage requirements on-demand, Aiven provides you the option of Dynamic Disk Sizing to manage storage dynamically.  
+Predicting future growth and storage requirements can sometimes be challenging, and upgrading your service plans for additional storage requirements alone may not be feasible. Upgrading the service plans means paying for more compute resources (or RAM) that your current usage does not require. DDS lets you add storage to meet your requirements.
 
 Using DDS provides the following benefits: 
 
 - Provides an easy way to increase the disk storage available with the selected service plan.
-- You can dynamically add or remove additional storage without disrupting your running service.
-- It is cost-effective, as you pay only for the additional storage, not the compute resources that would have been part of an upgraded service plan. 
+- You can dynamically add or remove storage without disrupting your running service.
+- It is cost-effective as you pay only for the additional storage not the compute resources that are part of an upgraded service plan. 
 
 How does Dynamic Disk Sizing work?
 ----------------------------------
-You can add additional disk storage to your service plan when you :doc:`create a new service <../howto/create_new_service>` on the `Aiven Console <https://console.aiven.io/>`_ or on-demand when you need more storage while :doc:`running your service<../howto/add-storage-space>`. Adding additional storage will not affect or interrupt the operations of your service. 
+You can add disk storage to your service plan when you :doc:`create a new service <../howto/create_new_service>` or on demand when you need more storage while :doc:`running your service<../howto/add-storage-space>`. Adding storage will not affect or interrupt the operations of your service. 
 
-When you add additional storage to your service, the Aiven platform provisions additional disk storage and dynamically adds it to your running instances. The total amount of additional storage you can add to your service is based on your service plan and the cloud provider.
+When you add storage to your service, the Aiven platform provisions the extra disk space and dynamically adds it to your running instances. The total amount of storage you can add to your service is based on your service plan and the cloud provider.
 
-In a clustered service (Apache Cassandra or Apache Kafka), the additional storage added will be equally divided between the nodes. In a shared service, each node receives the total shared capacity of the additional storage added. All the additional storage added will remain usable.
+In a clustered service such as Apache Cassandra or Apache Kafka, the additional storage is equally divided between the nodes. In a shared service, each node receives the total shared capacity of the added storage. 
 
 Pricing for dynamic disk sizing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Suppose you add additional storage at the time of service creation. In that case, the cost is calculated based on the total amount of additional storage added in GB and included as part of your service's total cost. It is also visible in the service summary.
+If you add storage when you create a service, the cost is included as part of your service's total cost and is shown in the service summary. The cost of adding storage to a running service is shown in the Aiven Console when you add it. 
 
-Likewise, the cost of adding storage on-demand when your service is running is visible on the Aiven web console when you add storage. 
-
-The total price you see is the cost of the additional storage and any backups associated with it. You can also see the additional storage usage costs in your invoices.
+The total price you see is the cost of the additional storage and any backups associated with it. You can also see these storage usage costs in your invoices.
 
 Limitations
 ~~~~~~~~~~~
@@ -56,14 +52,10 @@ Limitations
     
    Each time you increase the storage size, plan with foresight so that the amount of the disk space you add is sufficient and you don't need to add it again any time soon.
 
-- If there is an ongoing maintenance update, you cannot add additional storage until the maintenance is completed.
+- If there is an ongoing maintenance update, you cannot add storage until the maintenance is completed.
+
+It is unlikely that any performance degradation from additional disk storage would be noticeable in your clients, but it is possible.
 
 Next steps
 ----------
-For information on how to add additional disk storage to your service from the `Aiven Console <https://console.aiven.io/>`_, see :doc:`Add additional storage <../howto/add-storage-space>`. 
-
-
-.. note:: 
-
-    It is unlikely that any performance degradation from additional disk storage would be noticeable in your clients, but it is possible.
-
+For instructions on how to add or remove disk storage in the Aiven Console, see :doc:`Add or remove storage <../howto/add-storage-space>`. 

--- a/docs/platform/concepts/dynamic-disk-sizing.rst
+++ b/docs/platform/concepts/dynamic-disk-sizing.rst
@@ -1,7 +1,7 @@
-Dynamic Disk Sizing
-====================
+Dynamic Disk Sizing (DDS)
+=========================
 
-Dynamic Disk Sizing (DDS) allows you to add storage to or remove storage from your services. You can add storage during service creation or later when service is running service without interruption. 
+Dynamic Disk Sizing (DDS) allows you to add storage to or remove storage from your services. You can add storage during service creation. You can also add it later to a running service without interruption. 
 
 DDS is available for the following services:
 
@@ -14,13 +14,11 @@ DDS is available for the following services:
 
 .. note::
 
-    Dynamic Disk Sizing is not supported on custom plans.
+    DDS is not supported on custom plans.
 
-Why dynamic disk sizing?
-------------------------
-When creating a service on Aiven, you have a fixed storage allocation based on your plan selection. When running your service, you may want to scale up only the storage.
-
-Predicting future growth and storage requirements can sometimes be challenging, and upgrading your service plans for additional storage requirements alone may not be feasible. Upgrading the service plans means paying for more compute resources (or RAM) that your current usage does not require. DDS lets you add storage to meet your requirements.
+Why use DDS?
+-------------
+When creating a service on Aiven, you have a fixed storage allocation based on the plan you choose. Predicting future growth and storage requirements can sometimes be challenging. Upgrading the service plans means paying for more compute resources (or RAM). However, if you only need additional storage, DDS lets you add storage to meet your requirements without upgrading the plan.
 
 Using DDS provides the following benefits: 
 
@@ -28,31 +26,26 @@ Using DDS provides the following benefits:
 - You can dynamically add or remove storage without disrupting your running service.
 - It is cost-effective as you pay only for the additional storage not the compute resources that are part of an upgraded service plan. 
 
-How does Dynamic Disk Sizing work?
-----------------------------------
+How does DDS work?
+-------------------
 You can add disk storage to your service plan when you :doc:`create a new service <../howto/create_new_service>` or on demand when you need more storage while :doc:`running your service<../howto/add-storage-space>`. Adding storage will not affect or interrupt the operations of your service. 
 
 When you add storage to your service, the Aiven platform provisions the extra disk space and dynamically adds it to your running instances. The total amount of storage you can add to your service is based on your service plan and the cloud provider.
 
 In a clustered service such as Apache Cassandra or Apache Kafka, the additional storage is equally divided between the nodes. In a shared service, each node receives the total shared capacity of the added storage. 
 
-Pricing for dynamic disk sizing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you add storage when you create a service, the cost is included as part of your service's total cost and is shown in the service summary. The cost of adding storage to a running service is shown in the Aiven Console when you add it. 
+Pricing  
+~~~~~~~~
+If you add storage when you create a service, the cost is included as part of your service's total cost and is shown in the service summary. 
 
-The total price you see is the cost of the additional storage and any backups associated with it. You can also see these storage usage costs in your invoices.
+The cost of adding storage to a running service is shown in the Aiven Console when you add it. The total price you see is the cost of the additional storage and any backups associated with it. You can also see these storage usage costs in your invoices.
 
 Limitations
 ~~~~~~~~~~~
 
 - Maximum storage size depends on the plan and the service type. It can go as high as five times the base storage size of the plan. 
-- Storage optimization is performed at the next maintenance update after a change to the storage size. Due to limitations on the cloud provider, there is a limit on how many times storage can be increased between two maintenance updates. If this limit is reached, you see a prompt to perform a maintenance update for performance optimization.
-
-.. topic:: Avoid hitting the limit of times you increase the storage
-    
-   Each time you increase the storage size, plan with foresight so that the amount of the disk space you add is sufficient and you don't need to add it again any time soon.
-
-- If there is an ongoing maintenance update, you cannot add storage until the maintenance is completed.
+- Due to cloud provider restrictions, there is a limit on how many times storage can be increased between two maintenance updates. If this limit is reached, you need to perform a maintenance update for performance optimization.
+- If there is an ongoing maintenance update, you cannot add storage until the update is completed.
 
 It is unlikely that any performance degradation from additional disk storage would be noticeable in your clients, but it is possible.
 

--- a/docs/platform/howto/add-storage-space.rst
+++ b/docs/platform/howto/add-storage-space.rst
@@ -1,56 +1,48 @@
-Add additional storage 
+Add or remove storage 
 =======================
 
-You can add additional storage at the time of new service creation or on-demand to a running service. This section provides you with information on how to add additional storage. 
-For more information, see :doc:`Dynamic disk sizing <../concepts/dynamic-disk-sizing>` . 
+With :doc:`Dynamic disk sizing <../concepts/dynamic-disk-sizing>` you can add or remove disk storage both when you create a service and later on-demand for a running service. This feature is not available for all service plans.
 
-Add additional storage during new service creation
---------------------------------------------------
-You can add additional storage when creating a new service. For information on how to add additional storage during new service creation, see :doc:`Create a new service <../howto/create_new_service>`. 
-
-Add additional storage to running service
+Add storage during new service creation
 -----------------------------------------
-You can :doc:`add additional storage <../concepts/dynamic-disk-sizing>` to your running service from the Aiven web console without interrupting the service. 
+You can add disk storage when :doc:`creating a new service <../howto/create_new_service>`. 
 
-1. Log in to the `Aiven Console <https://console.aiven.io/>`_, and go to **Services** to select your running service. 
-2. In the **Overview** tab, scroll down to **Service plan**.
-3. Click **Add storage**. 
+Add storage to a running service
+---------------------------------
+You can add storage to your running service from the `Aiven Console <https://console.aiven.io/>`_ without interrupting the service. 
 
-   .. image:: /images/platform/howto/add-addition-storage.png
-      :alt: Add additional storage 
+#. In **Services**, select the service.
 
-   .. note:: 
-      This feature is not available for all service plans. 
-4. In the **Upgrade service disk space** pop-up window, use the slider under **Additional disk storage** to add extra disk capacity. As you add storage, you can also see the cost associated with the storage. The price you see is the cost of the storage, as well as any backup associated with it.
-   
-   .. image:: /images/platform/howto/upgrade-service-disk-space.png
-      :alt: Add additional storage using the slider
+#. On the **Overview** tab in the **Service plan** section, click **Add storage**. 
 
-5. Click **Save changes**. The additional storage is added and available for immediate use.  
+4. On the **Upgrade service disk space** window, use the slider to add disk storage. The price shown for the additional storage includes backup costs.
 
-.. note:: 
-   Depending on the service type, the amount of storage you can add in increments varies. For example, some services allow you to add storage in 10GB increments, while others allow 30GB increments. 
+5. Click **Save changes**. 
+
+The additional storage is available for immediate use.  
 
 .. warning::
 
-   Maximum storage size depends on the plan and the service type. It can go as high as five times the base storage size of the plan. A storage optimization is performed at the next maintenance update after a change to the storage size. Due to limitations on the cloud provider, there is a limit on how many times storage can be increased between two maintenance updates. If this limit is reached, you see a prompt to perform a maintenance update for performance optimization. Avoid hitting the limit of times you increase the storage: each time you increase the storage size, plan with foresight so that the amount of the disk space you add is sufficient and you don't need to add it again any time soon.
+   Storage optimization is performed at the next maintenance update after a change to the storage size. Due to cloud provider limitations, there is a limit on how many times storage can be increased between two maintenance updates. When this limit is reached, you need to perform a maintenance update for performance optimization. It's best to carefully plan increases to avoid reaching this limit.
 
-Decrease or remove additional storage
--------------------------------------
-Depending on the business requirements, you can decrease or remove additional storage added.
+Remove additional storage
+---------------------------
+You can remove storage that you previously added to a service. Before you remove storage: 
 
-Before you decrease or remove the additional storage on your service: 
+- Make sure the data in your service does not exceed your service plan's allocated storage. If it does, you will not be able to remove the additional storage. 
+- Plan for the time it takes to recycle the nodes. The service will be in a rebalancing state after removing storage. The time it takes depends on the service. 
 
-- Ensure the amount of data in the additional storage does not exceed your service plan's allocated storage. If the data exceeds the allocated storage, you will not be able to decrease or remove the additional storage. 
-- Decreasing the additional storage capacity or setting it to **None** recycles the nodes and, therefore, can take a moderate amount of time, depending on the service. We advise you to plan this task.   
+Follow these steps to remove added storage:
 
-Follow these steps to decrease or remove the added storage:
+#. In **Services**, select the service.
 
-1. In the `Aiven Console <https://console.aiven.io/>`_, select your **Service**. 
-2. In the **Overview** tab of the service, scroll down to **Service plan**. 
-3. Click **Edit** next to **Additional disk storage**. 
-4. On the **Upgrade service disk space** pop-up window, use the slider under **Additional disk storage** to reduce the additional disk storage capacity or set it to None. 
+#. On the **Overview** tab in the **Service plan** section, click **Edit** next to **Additional disk storage**. 
+
+4. On the **Upgrade service disk space** window, use the slider to remove disk storage. 
+
+   .. note::
+      You can only remove storage that you previously added using this feature. If you want to downgrade further, you can :doc:`change your service plan </docs/platform/howto/scale-services>`.
+
 5. Click **Save changes**. 
 
-   Your service will be in a **Rebalancing** state, indicating the nodes are being recycled. 
-
+Your service will be in a **Rebalancing** state while the nodes are being recycled. 

--- a/docs/platform/howto/add-storage-space.rst
+++ b/docs/platform/howto/add-storage-space.rst
@@ -1,7 +1,10 @@
 Add or remove storage 
 =======================
 
-With :doc:`Dynamic disk sizing <../concepts/dynamic-disk-sizing>` you can add or remove disk storage both when you create a service and later on-demand for a running service. This feature is not available for all service plans.
+With :doc:`dynamic disk sizing <../concepts/dynamic-disk-sizing>` you can add or remove disk storage both when you create a service and later for a running service. 
+
+.. note::
+   This feature is not available for all service plans.
 
 Add storage during new service creation
 -----------------------------------------
@@ -9,7 +12,7 @@ You can add disk storage when :doc:`creating a new service <../howto/create_new_
 
 Add storage to a running service
 ---------------------------------
-You can add storage to your running service from the `Aiven Console <https://console.aiven.io/>`_ without interrupting the service. 
+You can add storage to your running service in the `Aiven Console <https://console.aiven.io/>`_ without interrupting the service. 
 
 #. In **Services**, select the service.
 
@@ -22,7 +25,6 @@ You can add storage to your running service from the `Aiven Console <https://con
 The additional storage is available for immediate use.  
 
 .. warning::
-
    Storage optimization is performed at the next maintenance update after a change to the storage size. Due to cloud provider limitations, there is a limit on how many times storage can be increased between two maintenance updates. When this limit is reached, you need to perform a maintenance update for performance optimization. It's best to carefully plan increases to avoid reaching this limit.
 
 Remove additional storage


### PR DESCRIPTION
# What changed, and why it matters
The _Add additional storage_ article was tweaked slightly to make it clear that storage can also be removed as part of the DDS feature. Also “add additional” is redundant and can be refined to increase readability as well as better align with the language used in Console. There are also some minor changes to the DDS article to reflect the change in the title of the first article and the terminology. 


