### PR TITLE
Update hobbyist plan limitation to cloud providers.

### DIFF
--- a/docs/products/postgresql/reference/pg-connection-limits.rst
+++ b/docs/products/postgresql/reference/pg-connection-limits.rst
@@ -8,7 +8,7 @@ Aiven for PostgreSQL® instances limit the number of allowed connections to make
 
    * - Plan
      - Max Connections
-   * - Hobbyist (GCP, DigitalOcean, and UpCloud only)
+   * - Hobbyist (Google Cloud, DigitalOcean, and UpCloud only)
      - 25
    * - Startup/Business/Premium-4
      - 100

--- a/docs/products/postgresql/reference/pg-connection-limits.rst
+++ b/docs/products/postgresql/reference/pg-connection-limits.rst
@@ -8,7 +8,7 @@ Aiven for PostgreSQL® instances limit the number of allowed connections to make
 
    * - Plan
      - Max Connections
-   * - Hobbyist
+   * - Hobbyist (GCP, DigitalOcean, and UpCloud only)
      - 25
    * - Startup/Business/Premium-4
      - 100


### PR DESCRIPTION
# What changed, and why it matters

Current documentation mentions the hobbyist plan but it's not available on AWS or Azure. This PR specifies the cloud providers where hobbyist plan is available. The internal slack conversation mentioned GCP only but I see that hobbyist plan is also available on DO and UpCloud.
