### PR TITLE
fix: update gcp pub/sub connector link

### DIFF
--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -21,9 +21,9 @@ Source connectors enable the integration of data from an existing technology int
 
 * `Debezium for SQL Server <https://debezium.io/docs/connectors/sqlserver/>`__ 
 
-* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector>`__ 
+* `Google Cloud Pub/Sub <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`__
 
-* `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_ 
+* `Google Cloud Pub/Sub Lite <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_
 
 * `JDBC <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/source-connector.md>`__
 
@@ -50,9 +50,9 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * `Google BigQuery <https://github.com/confluentinc/kafka-connect-bigquery>`__
 
-* `Google Cloud Pub/Sub <https://github.com/GoogleCloudPlatform/pubsub/>`__
+* `Google Cloud Pub/Sub <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`__
 
-* `Google Cloud Pub/Sub Lite <https://github.com/GoogleCloudPlatform/pubsub/>`_
+* `Google Cloud Pub/Sub Lite <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_
 
 * :doc:`Google Cloud Storage </docs/products/kafka/kafka-connect/howto/gcs-sink>`
 

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-sink.rst
@@ -1,11 +1,11 @@
 Create a sink connector from Apache Kafka® to Google Pub/Sub Lite
 =================================================================
 
-The `Google Pub/Sub Lite sink connector <https://github.com/GoogleCloudPlatform/pubsub>`_ enables you to push data from an Aiven for Apache Kafka® topic to a Google Pub/Sub Lite topic. 
+The `Google Pub/Sub Lite sink connector <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_ enables you to push data from an Aiven for Apache Kafka® topic to a Google Pub/Sub Lite topic.
 
 .. note::
 
-    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/GoogleCloudPlatform/pubsub>`_.
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_.
 
 .. _connect_pubsub_lite_sink_prereq:
 
@@ -83,7 +83,7 @@ The configuration file contains the following entries:
      * ``value.converter.schema.registry.basic.auth.user.info``: passing the required schema registry credentials in the form of ``SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`` with the ``SCHEMA_REGISTRY_USER`` and ``SCHEMA_REGISTRY_PASSWORD`` parameters :ref:`retrieved in the previous step <connect_pubsub_lite_sink_prereq>`.
 
   
-The full list of parameters is available in the `dedicated GitHub page <https://github.com/GoogleCloudPlatform/pubsub/>`_.
+The full list of parameters is available in the `dedicated GitHub page <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_.
 
 Create a Kafka Connect connector with the Aiven Console
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-lite-source.rst
@@ -1,11 +1,11 @@
 Create a Google Pub/Sub Lite source connector to Apache Kafka®
 ==============================================================
 
-The `Google Pub/Sub Lite source connector <https://github.com/GoogleCloudPlatform/pubsub/>`_ enables you to push from a Google Pub/Sub subscription to an Aiven for Apache Kafka® topic. 
+The `Google Pub/Sub Lite source connector <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_ enables you to push from a Google Pub/Sub subscription to an Aiven for Apache Kafka® topic.
 
 .. note::
 
-    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/GoogleCloudPlatform/pubsub/>`_.
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_.
 
 .. _connect_pubsub_lite_source_prereq:
 
@@ -82,7 +82,7 @@ The configuration file contains the following entries:
      * ``value.converter.schema.registry.basic.auth.user.info``: passing the required schema registry credentials in the form of ``SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`` with the ``SCHEMA_REGISTRY_USER`` and ``SCHEMA_REGISTRY_PASSWORD`` parameters :ref:`retrieved in the previous step <connect_pubsub_lite_source_prereq>`.
 
 
-The full list of parameters is available in the `dedicated GitHub page <https://github.com/GoogleCloudPlatform/pubsub/>`_.
+The full list of parameters is available in the `dedicated GitHub page <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_.
 
 Create a Kafka Connect connector with the Aiven Console
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-sink.rst
@@ -1,11 +1,11 @@
 Create a sink connector from Apache Kafka® to Google Pub/Sub
 ============================================================
 
-The `Google Pub/Sub sink connector <https://github.com/GoogleCloudPlatform/pubsub>`_ enables you to push data from an Aiven for Apache Kafka® topic to a Google Pub/Sub topic. 
+The `Google Pub/Sub sink connector <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_ enables you to push data from an Aiven for Apache Kafka® topic to a Google Pub/Sub topic.
 
 .. note::
 
-    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/GoogleCloudPlatform/pubsub>`_.
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_.
 
 .. _connect_pubsub_sink_prereq:
 
@@ -90,7 +90,7 @@ The configuration file contains the following entries:
      * ``value.converter.schema.registry.basic.auth.user.info``: passing the required schema registry credentials in the form of ``SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`` with the ``SCHEMA_REGISTRY_USER`` and ``SCHEMA_REGISTRY_PASSWORD`` parameters :ref:`retrieved in the previous step <connect_pubsub_sink_prereq>`.
 
   
-The full list of parameters is available in the `dedicated GitHub page <https://github.com/GoogleCloudPlatform/pubsub/>`_.
+The full list of parameters is available in the `dedicated GitHub page <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_.
 
 Create a Kafka Connect connector with the Aiven Console
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.rst
+++ b/docs/products/kafka/kafka-connect/howto/gcp-pubsub-source.rst
@@ -1,11 +1,11 @@
 Create a Google Pub/Sub source connector to Apache Kafka®
 =========================================================
 
-The `Google Pub/Sub source connector <https://github.com/GoogleCloudPlatform/pubsub>`_ enables you to push from a Google Pub/Sub subscription to an Aiven for Apache Kafka® topic. 
+The `Google Pub/Sub source connector <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_ enables you to push from a Google Pub/Sub subscription to an Aiven for Apache Kafka® topic.
 
 .. note::
 
-    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/GoogleCloudPlatform/pubsub>`_.
+    You can check the full set of available parameters and configuration options in the `connector's documentation <https://github.com/googleapis/java-pubsub-group-kafka-connector>`_.
 
 .. _connect_pubsub_source_prereq:
 
@@ -90,7 +90,7 @@ The configuration file contains the following entries:
      * ``value.converter.schema.registry.basic.auth.user.info``: passing the required schema registry credentials in the form of ``SCHEMA_REGISTRY_USER:SCHEMA_REGISTRY_PASSWORD`` with the ``SCHEMA_REGISTRY_USER`` and ``SCHEMA_REGISTRY_PASSWORD`` parameters :ref:`retrieved in the previous step <connect_pubsub_source_prereq>`.
 
   
-The full list of parameters is available in the `dedicated GitHub page <https://github.com/GoogleCloudPlatform/pubsub/>`_.
+The full list of parameters is available in the `dedicated GitHub page <https://github.com/googleapis/java-pubsub-group-kafka-connector/>`_.
 
 Create a Kafka Connect connector with the Aiven Console
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Google Cloud Pub/Sub Connector has migrate its repo to https://github.com/googleapis/java-pubsub-group-kafka-connector

More info: https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector\#deprecation-notice
