### PR TITLE
Fix double quote typo on S3 sink connector docs

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
+++ b/docs/products/kafka/kafka-connect/howto/s3-sink-connector-aiven.rst
@@ -42,7 +42,7 @@ Define the connector configurations in a file (we'll refer to it with the name `
     {
         "name": "<CONNECTOR_NAME>",
         "connector.class": "io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector",
-        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"",
+        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
         "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
         "topics": "<TOPIC_NAME>",
         "aws.access.key.id": "<AWS_USER_ACCESS_KEY_ID>",


### PR DESCRIPTION
# What changed, and why it matters

There is a rogue, extra double-quote character in a code example which means that copy/pasting this would fail (or cause confusion). Here's a simple patch to fix that. 
