### PR TITLE
Query statistics view and fetch instructions

### DIFF
--- a/docs/products/clickhouse/howto/query-stats.rst
+++ b/docs/products/clickhouse/howto/query-stats.rst
@@ -1,13 +1,23 @@
 Query Statstics in ClickHouse®
 ================================
 
-Usually, Query stats in ClickHouse can be obtained using the ``system.query_log`` table, which stores statistics of each executed query, including memory usage and duration. Aiven for ClickHouse® currently do not give access to the table ``system.query_log`` table, in order to directly query the table for the required statistics.
+Usually, Query statistics in ClickHouse can be obtained using the ``system.query_log`` table, which stores statistics of each executed query, including memory usage and duration. Aiven for ClickHouse® currently do not give access to the table ``system.query_log`` table, in order to directly query the table for the required statistics.
 
-Instead, we currently display the contents of the table on the service dashboard in Aiven Console. It can be viewed under the tab *Query Statstics* .
-Alternatively, we also provide access to *Query Statstics* via `Aiven API<https://docs.aiven.io/docs/tools/api>`_. The following is the endpoint for the same:
+Instead,use one of the two approach to view *Query Statstics* for Aiven for ClickHouse®
+
+With Aiven console
+---------------------
+
+1. Log in to the `Aiven web console <https://console.aiven.io/>`_, choose the right project, and select your Aiven for ClickHouse service.
+2. Navigate to the **Query Statstics** tab, and you can visulize the content in the dashboard.
+
+With Aiven API
+----------------------
+
+Alternatively, you can access *Query Statstics* via `Query statistics endpoint<https://api.aiven.io/doc/#tag/Service:_ClickHouse/operation/ServiceClickHouseQueryStats>`_. Example endpoint skeloton:
 
     .. code:: bash
 
         GET /project/<project>/service/<service_name>/clickhouse/query/stats
 
-The detalied usage of API can be found `here<https://api.aiven.io/doc/#tag/Service:_ClickHouse/operation/ServiceClickHouseQueryStats>_`.
+Learn more about API usage in the :doc:`Aiven API overview </docs/tools/api>`.

--- a/docs/products/clickhouse/howto/query-stats.rst
+++ b/docs/products/clickhouse/howto/query-stats.rst
@@ -1,0 +1,13 @@
+Query Statstics in ClickHouse®
+================================
+
+Usually, Query stats in ClickHouse can be obtained using the ``system.query_log`` table, which stores statistics of each executed query, including memory usage and duration. Aiven for ClickHouse® currently do not give access to the table ``system.query_log`` table, in order to directly query the table for the required statistics.
+
+Instead, we currently display the contents of the table on the service dashboard in Aiven Console. It can be viewed under the tab *Query Statstics* .
+Alternatively, we also provide access to *Query Statstics* via `Aiven API<https://docs.aiven.io/docs/tools/api>`_. The following is the endpoint for the same:
+
+    .. code:: bash
+
+        GET /project/<project>/service/<service_name>/clickhouse/query/stats
+
+The detalied usage of API can be found `here<https://api.aiven.io/doc/#tag/Service:_ClickHouse/operation/ServiceClickHouseQueryStats>_`.


### PR DESCRIPTION
# What changed, and why it matters

Based on recent customer support tickets, where they asked to how to fetch query statistics from system.query_log table - it seems like we do not allow due to security reasons. But, we do have API to fetch this. (recently added to our API docs)

This KB contains instructions to fetch the query stats via console and API.
