### PR TITLE
Re-organized TOC for OpenSearch Security

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -939,7 +939,8 @@ entries:
             title: Access control
             entries:
               - file: docs/products/opensearch/concepts/users-access-controls
-              - file: docs/products/opensearch/concepts/os-security
+          - file: docs/products/opensearch/concepts/os-security
+            title: Security 
           - file: docs/products/opensearch/concepts/backups
           - file: docs/products/opensearch/concepts/indices
           - file: docs/products/opensearch/concepts/aggregations
@@ -955,7 +956,7 @@ entries:
             title: Manage access control
             entries:  
             - file: docs/products/opensearch/howto/control_access_to_content
-            - file: docs/products/opensearch/howto/enable-opensearch-security
+            
           - file: docs/products/opensearch/howto/list-connect-to-service
             title: Connect with service
             entries:
@@ -970,6 +971,8 @@ entries:
             entries:  
             - file: docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aiven
             - file: docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aws
+            - file: docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven
+              title: Migrate Elasticsearch data
           - file: docs/products/opensearch/howto/list-search-service
             title: Search and aggregation
             entries:
@@ -979,8 +982,17 @@ entries:
               title: Search with NodeJS
             - file: docs/products/opensearch/howto/opensearch-aggregations-and-nodejs
               title: Aggregation with NodeJS
-          - file: docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven
-            title: Migrate Elasticsearch data
+          - file: docs/products/opensearch/howto/list-opensearch-security
+            title: Manage OpenSearch Security
+            entries:
+              - file: docs/products/opensearch/howto/enable-opensearch-security
+                title: Enable OpenSearch Security management
+              - file: docs/products/opensearch/howto/saml-sso-authentication
+                title: SAML authentication
+              - file: docs/products/opensearch/howto/audit-logs
+                title: Audit logs
+              - file: docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy
+                title: OpenSearch Dashboard multi-tenancy
           - file: docs/products/opensearch/howto/list-manage-service
             title: Manage service
             entries:
@@ -988,18 +1000,8 @@ entries:
             - file: docs/products/opensearch/howto/set_index_retention_patterns
             - file: docs/products/opensearch/howto/opensearch-alerting-api
             - file: docs/products/opensearch/howto/handle-low-disk-space
-
-            - file: docs/products/opensearch/howto/saml-sso-authentication
-
-
-            - file: docs/products/opensearch/howto/audit-logs
-              title: Audit logs
-
             - file: docs/products/opensearch/howto/setup-cross-cluster-replication-opensearch
               title: Cross-cluster replication
-            - file: docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy
-              title: OpenSearch Dashboard multi-tenancy
-
           - file: docs/products/opensearch/howto/list-integrations
             title: Integrate service
             entries:

--- a/docs/products/opensearch/howto/enable-opensearch-security.rst
+++ b/docs/products/opensearch/howto/enable-opensearch-security.rst
@@ -24,14 +24,16 @@ Follow these steps to activate OpenSearch Security management for your Aiven for
 
 1. Log in to the `Aiven Console <https://console.aiven.io/>`_ and access the Aiven for OpenSearch service for which you want to enable security.
 2. Navigate to the **Users** tab within the service.
-3. Click the **Enable** button in the OpenSearch Security management banner.
+3. Select **Enable** in the OpenSearch Security management banner.
 4. Review the information presented on the **Enable OpenSearch Security for this service** screen and confirm by selecting the checkbox.
 5. In the OpenSearch Security administrator section, enter and confirm a password for the user.
 
-.. note:: 
-   * The username for the OpenSearch Security administrator is set by default and cannot be changed.
-   * In case you forget the password, it can only be reset by contacting Aiven support.
+   .. note:: 
+     * The username for the OpenSearch Security administrator is set by default and cannot be changed.
+     * In case you forget the password, it can only be reset by contacting Aiven support.
 
-6. Click the **Enable** button to activate the OpenSearch Security administrator user.
+6. Select **Enable** to activate the OpenSearch Security administrator user.
 
-After activating OpenSearch Security, you will be redirected to the **Users** screen, where you can verify that the security feature is enabled. Next, log in to the OpenSearch Dashboard using your security admin credentials to access OpenSearch Security, where you can manage user permissions and other security settings.
+After activating OpenSearch Security, you will be redirected to the **Users** screen, where you can verify that the security feature is enabled. 
+
+Next, log in to the :doc:`OpenSearch Dashboard <../dashboards>` using your security admin credentials to access OpenSearch Security, where you can manage user permissions and other security settings.

--- a/docs/products/opensearch/howto/list-opensearch-security.rst
+++ b/docs/products/opensearch/howto/list-opensearch-security.rst
@@ -1,0 +1,23 @@
+OpenSearch® Security management in Aiven for OpenSearch®
+=========================================================
+
+Using OpenSearch Security can significantly strengthen the security of your service. By enabling and leveraging this feature for your Aiven for OpenSearch service, you gain access to a wide range of advanced functionalities that will allow you to manage security and access control effectively. 
+
+
+.. grid:: 1 2 2 2
+
+    .. grid-item-card:: :doc:`Enable OpenSearch® Security management </docs/products/opensearch/howto/enable-opensearch-security>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`SAML authentication </docs/products/opensearch/howto/saml-sso-authentication>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`Enable, configure, and visualize OpenSearch® Audit logs </docs/products/opensearch/howto/audit-logs>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`Set up OpenSearch® Dashboard multi-tenancy </docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy>`
+        :shadow: md
+        :margin: 2 2 0 0

--- a/docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy.rst
+++ b/docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy.rst
@@ -18,7 +18,7 @@ This section provides information on configuring multi-tenancy in OpenSearch Das
 
 Step 1: Enable OpenSearch® Security management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The first step in setting up multi-tenancy in OpenSearch Dashboard is to enable OpenSearch Security management on your Aiven for OpenSearch service. OpenSearch Security management provides authentication and authorization features that are required for multi-tenancy.  
+To set up multi-tenancy in OpenSearch Dashboard, the initial step is to :doc:`enable OpenSearch Security management <../howto/enable-opensearch-security>` on your Aiven for OpenSearch service. This will provide necessary authentication and authorization features required for multi-tenancy. 
 To enable OpenSearch Security management, see enable OpenSearch . 
 
 Step 2: Create a tenant
@@ -57,7 +57,8 @@ To assign a tenant to a role, follow these steps:
 
 Step 4: Map roles to users
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Once you have assigned tenants to roles and set the necessary permissions, you need to link each user with a specific role to allow them access to the tenant and its resources. The role assigned to each user will determine their level of access and control over the tenant's data and resources.
+After assigning tenants to roles and setting the required permissions, the next step is associating each user with a specific role, granting them access to the tenant and its resources. The level of access and control a user has over the tenant's data and resources will be determined by their assigned role. 
+
 To map roles to internal users, follow these steps:
 
 1. In the OpenSearch dashboard, navigate to the **Security** section in the left-hand navigation menu, then select **Roles**. 

--- a/docs/products/opensearch/howto/saml-sso-authentication.rst
+++ b/docs/products/opensearch/howto/saml-sso-authentication.rst
@@ -1,4 +1,4 @@
-SAML authentication on Aiven for OpenSearch® 
+SAML authentication on Aiven for OpenSearch® |beta|
 ====================================================
 
 SAML (Security Assertion Markup Language) is a standard protocol for exchanging authentication and authorization data between an identity provider (IdP) and a Service Provider (SP). SAML enables users to authenticate themselves to a service provider with credentials from a trusted third-party identity provider without the need to create and manage separate user accounts for each service provider.
@@ -9,7 +9,7 @@ SAML authentication on Aiven for OpenSearch® can enhance the authentication pro
 Prerequisites
 ---------------
 * Aiven for OpenSearch® version 2.4 or later is required. If you are using an earlier version, upgrade to the latest version.
-* OpenSearch Security management must be enabled on the Aiven for OpenSearch® service.
+* OpenSearch Security management must be :doc:`enabled <../howto/enable-opensearch-security>` on the Aiven for OpenSearch® service.
 * You will need a SAML identity provider (IdP), the Metadata URL, and IdP entity ID.
 
 


### PR DESCRIPTION
# What changed, and why it matters

Re-organized the TOC to make OpenSearch Security-related content more prominent and easy to find. 