### PR TITLE
Removed preview tag for HTTP and Snowflake connectors

### DIFF
--- a/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
+++ b/docs/products/kafka/kafka-connect/concepts/list-of-connector-plugins.rst
@@ -56,13 +56,13 @@ Sink connectors enable the integration of data from an existing Apache Kafka top
 
 * :doc:`Google Cloud Storage </docs/products/kafka/kafka-connect/howto/gcs-sink>`
 
-* `HTTP <https://github.com/aiven/http-connector-for-apache-kafka>`__ |preview|
+* `HTTP <https://github.com/aiven/http-connector-for-apache-kafka>`__
 
 * `JDBC <https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/docs/sink-connector.md>`__
 
 * `Official MongoDB® <https://docs.mongodb.com/kafka-connector/current/>`__
 
-* `Snowflake <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`__ |preview|
+* `Snowflake <https://docs.snowflake.net/manuals/user-guide/kafka-connector.html>`__ 
 
 * `Splunk <https://github.com/splunk/kafka-connect-splunk>`__
 


### PR DESCRIPTION
# What changed, and why it matters

Removed the preview tag for HTTP and SnowFlake connectors, as these connectors are stable now, 