### PR TITLE
Added a note about forking OS service with SSO configured

### DIFF
--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -23,6 +23,10 @@ You can fork the following Aiven services:
 - Apache Cassandra® (Limitation: you cannot fork to a lower amount of nodes)
 - Elasticsearch
 - OpenSearch®
+   
+  .. important:: 
+        When you fork an OpenSearch service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
+
 - InfluxDB®
 - M3DB
 - Grafana®

--- a/docs/platform/concepts/service-forking.rst
+++ b/docs/platform/concepts/service-forking.rst
@@ -25,7 +25,7 @@ You can fork the following Aiven services:
 - OpenSearch®
    
   .. important:: 
-        When you fork an OpenSearch service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
+        When you fork an Aiven for OpenSearch® service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
 
 - InfluxDB®
 - M3DB

--- a/docs/products/opensearch/howto/saml-sso-authentication.rst
+++ b/docs/products/opensearch/howto/saml-sso-authentication.rst
@@ -5,6 +5,9 @@ SAML (Security Assertion Markup Language) is a standard protocol for exchanging 
 
 SAML authentication on Aiven for OpenSearch® can enhance the authentication process for users, providing increased security and a more streamlined experience. With SAML, OpenSearch can delegate authentication and authorization to a trusted external identity provider, reducing security risks and simplifying user management. Additionally, SAML allows for Single Sign-On (SSO) functionality, enabling users to access several OpenSearch instances without the need to log in multiple times.
 
+.. important:: 
+   When you fork an OpenSearch service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
+
 
 Prerequisites
 ---------------

--- a/docs/products/opensearch/howto/saml-sso-authentication.rst
+++ b/docs/products/opensearch/howto/saml-sso-authentication.rst
@@ -6,7 +6,7 @@ SAML (Security Assertion Markup Language) is a standard protocol for exchanging 
 SAML authentication on Aiven for OpenSearch® can enhance the authentication process for users, providing increased security and a more streamlined experience. With SAML, OpenSearch can delegate authentication and authorization to a trusted external identity provider, reducing security risks and simplifying user management. Additionally, SAML allows for Single Sign-On (SSO) functionality, enabling users to access several OpenSearch instances without the need to log in multiple times.
 
 .. important:: 
-   When you fork an OpenSearch service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
+   When you fork an Aiven for OpenSearch® service, any Single Sign-On (SSO) methods configured at the service level, such as SAML, must be explicitly reconfigured for the forked service. SSO configurations are linked to specific URLs and endpoints, which change during forking. Failing to reconfigure SSO methods for the forked service can lead to authentication problems and potentially disrupt user access. 
 
 
 Prerequisites


### PR DESCRIPTION
# What changed, and why it matters


Added a note that Single Sign-On (SSO) must be reconfigured on the forked OS services.