### PR TITLE
Add some pointers to the Vale readme file from the CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ Example: Get partition details of an Apache Kafka topic
 
  - only the first letter, and the proper noun for the product name, are capitalized
 
-The automated check for this can get confused by proper nouns; for information on how to fix this case-by-case, see the `Vale readme file <.github/vale/README.rst>`_.
+You may get errors from the automated checks when using proper nouns. In these cases, you might need to add the words as an exception or add them to the dictionary file. For information on how to do this, see the `Vale readme file <.github/vale/README.rst>`_.
 
 Add hyperlinks
 ''''''''''''''

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,7 @@ To keep all the content consistent and easy to follow for our audience, use `Goo
 
     Remember we review your pull request against these guidelines, so for fewer rounds of revisions, follow this advice!
 
-Where possible, these rules are checked automatically using Vale.  For more information on how this is setup, see the `Vale readme file <.github/vale/README.rst>`_.
+Where possible, these rules are checked automatically using Vale.  For more information on how this is set up, see the `Vale readme file <.github/vale/README.rst>`_.
 
 Use a specific template
 '''''''''''''''''''''''

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,6 +73,8 @@ To keep all the content consistent and easy to follow for our audience, use `Goo
 
     Remember we review your pull request against these guidelines, so for fewer rounds of revisions, follow this advice!
 
+Where possible, these rules are checked automatically using Vale.  For more information on how this is setup, see the `Vale readme file <.github/vale/README.rst>`_.
+
 Use a specific template
 '''''''''''''''''''''''
 
@@ -86,6 +88,8 @@ Rather than using Capital Letters for Almost Every Word, titles are written like
 Example: Get partition details of an Apache Kafka topic
 
  - only the first letter, and the proper noun for the product name, are capitalized
+
+The automated check for this can get confused by proper nouns; for information on how to fix this case-by-case, see the `Vale readme file <.github/vale/README.rst>`_.
 
 Add hyperlinks
 ''''''''''''''


### PR DESCRIPTION
# What changed, and why it matters

Based on a recent experience where I hit a failing Vale rule and had to seek assistance to get past it, I have added a pointer to the relevant README file from the CONTRIBUTING file (which is where I went first to look for help).
