### PR TITLE
Remove instructions for invoices

### DIFF
--- a/docs/platform/howto/use-billing-groups.rst
+++ b/docs/platform/howto/use-billing-groups.rst
@@ -12,15 +12,6 @@ Rename billing groups
 
 #. Enter the new name and click **Rename**.
 
-Download invoices
-""""""""""""""""""
-
-#. Select the name of the billing group.
-
-#. On the **Invoices** tab, find the billing period that you want to download an invoice for. 
-
-#. Click the three dots in the **Actions** column and select **Download PDF** or **Download CSV**.
-
 Update your billing information
 """"""""""""""""""""""""""""""""
 


### PR DESCRIPTION
# What changed, and why it matters
Invoices will be separated from billing groups. This PR removes the instructions for downloading invoices from the manage billing groups article.


