### PR TITLE
Fixed Debezium publication name in Flink CDC docs

### DIFF
--- a/docs/products/flink/howto/pg-cdc-connector.rst
+++ b/docs/products/flink/howto/pg-cdc-connector.rst
@@ -99,7 +99,7 @@ If you encounter the ``must be superuser to create FOR ALL TABLES publication`` 
 .. code:: 
   
     SELECT * FROM aiven_extras.pg_create_publication_for_all_tables(
-        'my_test_publication',
+        'dbz_publication',
         'INSERT,UPDATE,DELETE'
         );
 


### PR DESCRIPTION
# What changed, and why it matters

Debezium expects the use the name `dbz_publication` when creating the publication and it doesn't seem like there is any way to change that in the Flink connector configuration, so I'm updating the example code to use the right value.

