### PR TITLE
Update project-level billing info

### DIFF
--- a/docs/platform/concepts/corporate-billing.rst
+++ b/docs/platform/concepts/corporate-billing.rst
@@ -8,7 +8,7 @@ Credit card payments
 
 The default billing method for all new Aiven customers is credit card. All costs accrued over a calendar month are charged on the first day of the following month. 
 
-Services are billed by the hour. The costs are automatically calculated based on the services running in a project. Each project is charged separately.
+Services are billed by the hour. The costs are automatically calculated based on the services running in a project. Each project is charged separately, but the charges for multiple projects can be consolidated by assigning them to a :doc:`billing group </docs/platform/concepts/billing-groups>`. Likewise, :doc:`organizations </docs/platform/concepts/projects_accounts_access>` can have multiple billing groups. 
 
 Credit card fees
 """"""""""""""""""

--- a/docs/platform/howto/update-tax-status.rst
+++ b/docs/platform/howto/update-tax-status.rst
@@ -3,15 +3,12 @@ Update your tax status
 
 You can add your VAT ID in the billing information in the Aiven Console:
 
-1. Click **Billing** and select the billing group that you want to update.
-2. Click **Billing information**.
-3. In the **Billing Details** section, click **Edit**.
-4. Enter your VAT ID and click **Save**. 
+#. Click **Billing**. 
+#. Click **Billing groups**.
+#. Select the billing group that you want to update.
+#. Click **Billing information**.
+#. In the **Billing details** section, click **Edit**.
+#. Enter your **VAT ID** and click **Save**. 
 
-.. important::
-
-    Please be aware that you can set up one billing profile per project or create a Billing Group to group costs and consolidate invoices by different business units.
-    For further information please refer to :doc:`Billing Groups </docs/platform/concepts/billing-groups>`. 
-
-If needed, you can change the billing address by clicking **Edit** in the **Company  Details** section. Once the billing country has been updated, it will be used in all future invoices. 
+You can change also the billing address by clicking **Edit** in the **Company  details** section. Once the billing country has been updated, it will be used in all future invoices. 
 Billing estimates are updated approximately once an hour, so it may take up to an hour for the new tax status to become visible on the invoice estimates.


### PR DESCRIPTION
# What changed, and why it matters
New customers will not be able to set up billing at the project level and we want to encourage centralized management of billing on the org level. Also, the instructions for updating the VAT ID have been updated to reflect UI changes.

