### PR TITLE
Planned for end of June - Add instructions for managing org users

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -47,6 +47,7 @@ entries:
       - file: docs/platform/howto/list-user
         title: User and authentication management
         entries:
+          - file: docs/platform/howto/manage-org-users
           - file: docs/platform/howto/add-authentication-method
           - file: docs/platform/howto/change-your-email-address
           - file: docs/platform/howto/create_authentication_token

--- a/docs/platform/howto/manage-org-users.rst
+++ b/docs/platform/howto/manage-org-users.rst
@@ -1,0 +1,59 @@
+Manage users in an organization
+================================
+
+.. important::
+    Organization users are available as a feature preview and must be :doc:`enabled in the user profile </docs/platform/howto/feature-preview>`.
+
+Adding users to your organization lets you give them access to specific organizational units, projects, and services within that organization. 
+
+Invite users to an organization
+---------------------------------
+
+To add users to your organization, send them an invite:
+
+#. Click **Admin**.
+
+#. Click **Users**.
+
+#. Click **Invite users**.
+
+#. Enter the email addresses of the people you want to invite. 
+
+#. Click **Invite users**.
+
+The users receive an email with instructions to sign up (for new users) and accept the invite.
+
+
+Remove users from an organization
+----------------------------------
+
+If you remove a user from an organization, they will also be removed from all teams and projects and no longer have access to any resources in the organization. 
+
+To remove a user from an organization: 
+
+#. Click **Admin**.
+
+#. Click **Users**.
+
+#. Find the user that you want to remove and click the **Actions** menu. 
+
+#. Select **Remove**.
+
+#. Confirm you want to remove the user by clicking **Remove user**.
+
+
+Resend an invite
+-----------------
+
+If you need to resend an invite to a user:
+
+#. Click **Admin**.
+
+#. Click **Users**.
+
+#. Find the email address that you want to resend an invite to and click the **Actions** menu. 
+
+#. Select **Resend invite**.
+
+They get a new email with instructions for signing up or accepting the invite.
+


### PR DESCRIPTION
# What changed, and why it matters
In an upcoming release it will be possible to add users directly to an organization to control their access to its units and projects. These instructions cover inviting and removing users from orgs.


