### PR TITLE
add missing parameter for google psc instructions

### DIFF
--- a/docs/platform/howto/use-google-private-service-connect.rst
+++ b/docs/platform/howto/use-google-private-service-connect.rst
@@ -111,7 +111,7 @@ To approve the connection, run the following approval command:
 
 .. code:: shell
 
-    avn privatelink google connection approve MY_SERVICE_NAME --privatelink-connection-id PRIVATELINK_CONNECTION_ID --user-ip-address PSC_ENDPOINT_IP_ADDRESS
+    avn service privatelink google connection approve MY_SERVICE_NAME --privatelink-connection-id PRIVATELINK_CONNECTION_ID --user-ip-address PSC_ENDPOINT_IP_ADDRESS
 
 As a result, the connection initially transitions to the user-approved state.
 


### PR DESCRIPTION
Google Private Service Connect instruction - added a missing parameter in avn command for one of the steps.


