### PR TITLE
Add article on feature previews

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -44,6 +44,7 @@ entries:
     - file: docs/platform/howto
       title: HowTo
       entries:
+      - file: docs/platform/howto/feature-preview 
       - file: docs/platform/howto/list-user
         title: User and authentication management
         entries:

--- a/docs/platform/howto/feature-preview.rst
+++ b/docs/platform/howto/feature-preview.rst
@@ -1,0 +1,15 @@
+Feature previews
+=================
+
+Before an official release, some features are available to our customers for testing. These feature previews let you try out upcoming enhancements and give our product teams feedback to help improve them.
+
+Enable a feature preview
+-------------------------
+
+To try upcoming features before they are released:
+
+#. Click the **User information** icon in the top right and select **Feature preview**.
+
+#. On the **Feature preview** tab, click **Enable** for any of the features you want to test.
+
+After enabling a feature preview and testing it, you can provide feedback from this page by clicking **Give feedback**.


### PR DESCRIPTION
# What changed, and why it matters
Added an article about the feature preview in the user profile explaining its purpose and how to enable features for testing.


