### PR TITLE
kafka-connect: Prevent bad config of Pg publication as of Debezium 1.9.7

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.rst
+++ b/docs/products/kafka/kafka-connect/howto/debezium-source-connector-pg.rst
@@ -134,10 +134,21 @@ When creating a Debezium source connector pointing to Aiven for PostgreSQL using
 
     Caused by: org.postgresql.util.PSQLException: ERROR: must be superuser to create FOR ALL TABLES publication
     
-The error is due to Debezium trying to create a publication and failing because ``avnadmin`` is not a superuser. To avoid the problem you either:
+The error is due to Debezium trying to create a publication and failing because ``avnadmin`` is not a superuser. There are 2 different ways of working around this issue:
 
-* add the `"publication.autocreate.mode": "filtered"` parameter to the Debezium connector configuration to enable the publication creation only for the tables defined in the `table.include.list` parameter
-* create the publication on the source database before configuring the connector as defined in the section below.
+* either add the ``"publication.autocreate.mode": "filtered"`` parameter to the Debezium connector configuration to enable the publication creation only for the tables defined in the ``table.include.list`` parameter
+* or create the publication on the source database before configuring the connector as defined in the section further below.
+
+Note that with older versions of Debezium, there was a bug preventing the addition of more tables to the filter with ``filtered`` mode. As a result, this configuration was not conflicting with a publication ``FOR ALL TABLES``. Starting with Debezium 1.9.7, those configurations are conflicting and you could get the following error:
+
+::
+
+    Caused by: org.postgresql.util.PSQLException: ERROR: publication "dbz_publication" is defined as FOR ALL TABLES
+       Detail: Tables cannot be added to or dropped from FOR ALL TABLES publications.
+
+The error is due to Debezium attempting to include more tables into the publication which is incompatible with ``FOR ALL TABLES``.
+
+You can get rid of this error by removing ``publication.autocreate.mode`` configuration, which will default to ``all_tables``. In case you want to maintain ``filtered`` mode for some reason, then the publication should be recreated accordingly, so as the replication slot.
 
 Create the publication in PostgreSQL
 ''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
As part of [#inc-504](https://aiven-io.slack.com/archives/C05CY7VUFML), we found that an upgrade to Aiven for Apache Kafka Connect 3.4 (from Debezium 1.9.5 to 1.9.7) can lead to Pg source connector failing because of some conflicting configurations. This issue can be mitigated or avoided with a better documentation of how to properly configure the connector.

[HELP-160]




[HELP-160]: https://aiven.atlassian.net/browse/HELP-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ