### PR TITLE
Added note to inform users to check ACLs so MirrorMaker will work.

### DIFF
--- a/docs/products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster.rst
+++ b/docs/products/kafka/kafka-mirrormaker/howto/integrate-external-kafka-cluster.rst
@@ -17,3 +17,5 @@ An external Apache Kafka® service integration endpoint can be defined in the `A
 4. Fill the **Endpoint name**, **Bootstrap servers** and the security settings and click **Create**.
 
 5. The external Apache Kafka cluster is now available under the alias defined in the **Endpoint name** parameter
+
+.. note::  Configure the ACLs for both the source and target cluster such that the MirrorMaker 2 service can describe and create topics, as well as produce and consume messages. 


### PR DESCRIPTION
# What changed, and why it matters

I added information about making sure that the ACLs for Kafka & MM are correct so that customers know that they have to provide access to these clusters to each user. This will help customers be more self service and deflect cases from support. 
