### PR TITLE
changing the title for opensearch backup help article

### DIFF
--- a/docs/products/opensearch/concepts/backups.rst
+++ b/docs/products/opensearch/concepts/backups.rst
@@ -1,7 +1,7 @@
 .. _opensearch-backup:
 
-Backups
-=======
+Aiven for OpenSearch® backups 
+=============================
 
 Aiven for OpenSearch® databases are automatically backed up, :doc:`encrypted </docs/platform/concepts/cloud-security>`, and stored securely in object storage. Backups are stored in the same region as the main service nodes.
 


### PR DESCRIPTION
When we or customer wants to look for how backups are taken for each of the Aiven service - we do have a help article for the same [Aiven](https://docs.aiven.io/docs/platform/concepts/service_backups) 
But, when we search “Backup” as the keyword in our Aiven docs - it shows the first result as “[Backups - Aiven](https://docs.aiven.io/search?q=Backup)“ that actually refers to Aiven Opensearch Backups.



