### PR TITLE
added -c flag + example to documentation

### DIFF
--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -743,6 +743,8 @@ Updates the settings for an Aiven service.
     - The name of the service
   * - ``--cloud``
     - The name of the cloud region where to deploy the service; check :ref:`avn-cloud-list` for more information
+  * - ``-c KEY=VALUE``
+    - Apply a configuration setting. See 'avn service types -v' for available values.
   * - ``--disk-space-gib``
     - Total amount of disk space for data storage (GiB)
   * - ``--plan``
@@ -791,6 +793,14 @@ Updates the settings for an Aiven service.
 
 .. note:: There is no whitespace between the IP addresses and comma in the command.
 
+**Example:** Update the Kafka version of the service named ``kafka-service``. 
+
+::
+
+    avn service update \ 
+      kafka-service -c kafka_version=X.X
+
+.. note:: This also works for other service types. To see a full list of configuration parameters, have a look at ``avn service types -v``
 
 ``avn service user``
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/tools/cli/service.rst
+++ b/docs/tools/cli/service.rst
@@ -744,7 +744,7 @@ Updates the settings for an Aiven service.
   * - ``--cloud``
     - The name of the cloud region where to deploy the service; check :ref:`avn-cloud-list` for more information
   * - ``-c KEY=VALUE``
-    - Apply a configuration setting. See 'avn service types -v' for available values.
+    - Apply a configuration setting. Run ``avn service types -v`` to view available values.
   * - ``--disk-space-gib``
     - Total amount of disk space for data storage (GiB)
   * - ``--plan``


### PR DESCRIPTION
# What changed, and why it matters
`avn service update -c <SERVICE>_version=X.X` allows a user to trigger a version upgrade. This isn't listed in our official documentation: https://docs.aiven.io/docs/tools/cli/service#avn-service-update 

I have therefore added the following: 
1. Updated the command documentation to reflect the -c flag. 
2. Added an example that shows how to use the flag to run version upgrades. 

