### PR TITLE
[SCHEDULED 3.7]: revert pride logo back to normal logo

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -96,8 +96,8 @@ linkcheck_ignore = [
 html_favicon = './_static/images/favicon.ico'
 html_theme = 'furo'
 html_theme_options = {
-    "light_logo": "images/logoLightPride.png",
-    "dark_logo": "images/logoDarkPride.png",
+    "light_logo": "images/logoLight.png",
+    "dark_logo": "images/logoDark.png",
     "light_css_variables": {
         "color-brand-primary": "#FF5200",
         "color-brand-content": "#343745",


### PR DESCRIPTION
# What changed, and why it matters
Pride is over and time to revert back to Aiven logo - scheduled for merge on 3.7

Revert https://github.com/aiven/devportal/pull/1926

Preview https://revert-pride-logo.devportal.pages.dev/

