### PR TITLE
Add AvroConfluent to the ClickHouse-Kafka data formats

### DIFF
--- a/docs/products/clickhouse/reference/supported-input-output-formats.rst
+++ b/docs/products/clickhouse/reference/supported-input-output-formats.rst
@@ -6,9 +6,12 @@ When connecting ClickHouse® to Kafka® using Aiven integrations, data exchange 
 ============================     ====================================================================================
 Format name                      Notes
 ============================     ====================================================================================
-Avro                             Only supports binary Avro format with embedded schema.
+Avro                             Binary Avro format with embedded schema.
 
                                  Libraries and documentation: https://avro.apache.org/
+AvroConfluent                    Binary Avro with schema registry.
+
+                                 Requires the Karapace Schema Registry to be enabled in the Kafka service.
 CSV                              Example: ``123,"Hello"``
 JSONASString                     Example: ``{"x":123,"y":"hello"}``
 JSONCompactEachRow               Example: ``[123,"Hello"]``


### PR DESCRIPTION
# What changed, and why it matters

A new data format was added.

