### PR TITLE
Update Kafka custom datadog metrics example

### DIFF
--- a/docs/products/kafka/howto/datadog-customised-metrics.rst
+++ b/docs/products/kafka/howto/datadog-customised-metrics.rst
@@ -35,7 +35,7 @@ Variable               Description
 Customise Apache Kafka® metrics sent to Datadog
 -----------------------------------------------
 
-Before customising the metrics, make sure that you have a Datadog endpoint configured and enabled in your Aiven for Apache Kafka service. For details on how to set up the Datadog integration, check the :doc:`dedicated article </docs/integrations/datadog/datadog-metrics>`.
+Before customising the metrics, make sure that you have a Datadog endpoint configured and enabled in your Aiven for Apache Kafka service. For details on how to set up the Datadog integration, check the :doc:`dedicated article </docs/integrations/datadog/datadog-metrics>`.  Please note that in all the below parameters a 'comma separated list' has the following format: ``['value0','value1','value2','...']``.
 
 To customise the metrics sent to Datadog, you can use the ``service integration-update`` passing the following customised parameters:
 
@@ -53,9 +53,9 @@ To customise the metrics sent to Datadog, you can use the ``service integration-
 
 As example to sent the ``kafka.log.log_size`` and ``kafka.log.log_end_offset`` metrics for ``topic1`` and ``topic2`` execute the following code::
 
-    avn service integration-update                                          \
-        -c kafka_custom_metrics=kafka.log.log_size,kafka.log.log_end_offset \
-        -c include_topics=topic1,topic2                                     \
+    avn service integration-update                                                \
+        -c kafka_custom_metrics=['kafka.log.log_size','kafka.log.log_end_offset'] \
+        -c include_topics=['topic1','topic2']                                     \
         INTEGRATION_ID
 
 Once the update is successful and metrics have been collected and pushed, you should see them in your Datadog explorer.


### PR DESCRIPTION
# What changed, and why it matters
I'll be honest, I'm not sure if this is a bug in the CLI, or just mis-documented here. 
The issue arrises in the fact that in the CLI, array value parameters are processed as Python literals [cli.py#L77](https://github.com/aiven/aiven-client/blob/0366b6b0eb78cab430168d7dcbc4e28faf3406bb/aiven/client/cli.py#L77)

This means that either the code there needs to be update, or the documentation needs to be updated. If you try to run these examples as is, it always seems to give a very unobviouse parsing error.

I assumed it would be easiest to fix the documentation (and have less side effects to others who may have already figured this out), however if it would be better to raise a PR in the client to fix the layout, please let me know and I would be happy to do so.
