### PR TITLE
SUP-700: Added paragraph of notification of security tokens

### DIFF
--- a/docs/platform/concepts/cloud-security.rst
+++ b/docs/platform/concepts/cloud-security.rst
@@ -70,7 +70,7 @@ Customer data privacy
 
 Customer data privacy is of utmost importance to Aiven, and is covered by internal security and customer privacy policies as well as strict EU regulations.  
 
-Aiven has partnered with GitHub in scanning for service token leaks and will inform customers of tokens being made public through an email notification.  More details can be found on our `Improving security: Aiven and GitHub's secret scanning partnership <https://aiven.io/blog/aiven-and-github's-secret-scanning-partnership>`_  blog post.
+Aiven has partnered with GitHub in scanning for service token leaks and will inform customers of tokens being made public through an email notification.  For more details, check `Improving security: Aiven and GitHub's secret scanning partnership <https://aiven.io/blog/aiven-and-github's-secret-scanning-partnership>`_.
 
 Aiven operators never access customer data, unless explicitly requested to do so by the customer in order to troubleshoot a technical issue.
 

--- a/docs/platform/concepts/cloud-security.rst
+++ b/docs/platform/concepts/cloud-security.rst
@@ -68,7 +68,9 @@ No customer access to the virtual machine level is provided.
 Customer data privacy
 ----------------------
 
-Customer data privacy is of utmost importance to Aiven, and is covered by internal security and customer privacy policies as well as strict EU regulations.
+Customer data privacy is of utmost importance to Aiven, and is covered by internal security and customer privacy policies as well as strict EU regulations.  
+
+Aiven has partnered with GitHub in scanning for service token leaks and will inform customers of tokens being made public through an email notification.  More details can be found on our `Improving security: Aiven and GitHub's secret scanning partnership <https://aiven.io/blog/aiven-and-github's-secret-scanning-partnership>`_  blog post.
 
 Aiven operators never access customer data, unless explicitly requested to do so by the customer in order to troubleshoot a technical issue.
 


### PR DESCRIPTION
# Summary

We now have enabled email notifications if there are detected service token leaks. If Github notifies Aiven about a token being made public, our team will check if the token is still active or valid and send a notification. Only one notification is sent out for each unique token. This is just a summarized sentence and will point that we can refer to in our documentation and points to the main blog post - https://aiven.io/blog/aiven-and-github's-secret-scanning-partnership

Added to the following section page - https://docs.aiven.io/docs/platform/concepts/cloud-security


