### PR TITLE
include / for genindex and index

### DIFF
--- a/scripts/postprocess_sitemap.py
+++ b/scripts/postprocess_sitemap.py
@@ -14,9 +14,9 @@ for url in urls:
     if '404' in text:
         url.decompose()
         continue
-    if text.endswith('genindex.html'):
+    if text.endswith('/genindex.html'):
         loc.string = text[:-5]  # removes the ".html"
-    elif text.endswith('index.html'):
+    elif text.endswith('/index.html'):
         loc.string = text[:-10]  # removes the "index.html"
     elif text.endswith('.html'):
         loc.string = text[:-5]  # removes the ".html"


### PR DESCRIPTION
# What changed, and why it matters
Fixing issue https://github.com/aiven/devportal/issues/2002

# Demo
https://fix-broken-page-in-sitemap.devportal.pages.dev/sitemap.xml -> notice the two 404 page is now fixed

```
<url>
    <loc>https://docs.aiven.io/docs/products/opensearch/concepts/when-create-</loc>
</url>

<url>
    <loc>https://docs.aiven.io/docs/products/postgresql/howto/repair-pg-</loc>
</url>
```

Corrected to

```
<url>
    <loc>https://docs.aiven.io/docs/products/opensearch/concepts/when-create-index</loc>
</url>
<url>
    <loc>https://docs.aiven.io/docs/products/postgresql/howto/repair-pg-index</loc>
</url>
```

