### PR TITLE
Issue 2004, update to session_timeout_ms default value

### DIFF
--- a/includes/config-kafka.rst
+++ b/includes/config-kafka.rst
@@ -515,7 +515,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 *integer*
 
-**The timeout used to detect failures when using Kafka’s group management facilities** The timeout in milliseconds used to detect failures when using Kafka’s group management facilities (defaults to 10000).
+**The timeout used to detect failures when using Kafka’s group management facilities** The timeout in milliseconds used to detect failures when using Kafka’s group management facilities (defaults to 45000).
 
 
 


### PR DESCRIPTION
# What changed, and why it matters
Updating session_timeout_ms default value on the Kafka advanced parameter document. 
Changing value from 10000 to 45000, according  to current Kafka doc: https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms

Fixes: https://github.com/aiven/devportal/issues/2004


