### PR TITLE
Added a warning for OpenSearch Dashboards

### DIFF
--- a/docs/products/opensearch/dashboards.rst
+++ b/docs/products/opensearch/dashboards.rst
@@ -11,6 +11,8 @@ Get started with Aiven for OpenSearch Dashboards
 
 Take your first steps with Aiven for OpenSearch Dashboards by following our :doc:`/docs/products/opensearch/dashboards/getting-started` article.
 
+.. warning:: 
+    OpenSearch Dashboard will be **unavailable** during a **maintenance update** that consists of a version update to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
 
 Ways to use OpenSearch Dashboards
 ---------------------------------

--- a/docs/products/opensearch/dashboards.rst
+++ b/docs/products/opensearch/dashboards.rst
@@ -12,7 +12,7 @@ Get started with Aiven for OpenSearch Dashboards
 Take your first steps with Aiven for OpenSearch Dashboards by following our :doc:`/docs/products/opensearch/dashboards/getting-started` article.
 
 .. warning:: 
-    OpenSearch Dashboard will be **unavailable** during a **maintenance update** that consists of a version update to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
+    OpenSearch Dashboard will be **not accessible** during a **maintenance update** that also consists of version updates to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
 
 Ways to use OpenSearch Dashboards
 ---------------------------------

--- a/docs/products/opensearch/dashboards/getting-started.rst
+++ b/docs/products/opensearch/dashboards/getting-started.rst
@@ -3,6 +3,9 @@ Getting started
 
 To start using **Aiven for OpenSearch® Dashboards**, :doc:`create Aiven for OpenSearch® service first</docs/products/opensearch/getting-started>` and OpenSearch Dashboards service will be added alongside it. Once the Aiven for OpenSearch service is running you can find connection information to your OpenSearch Dashboards in the service overview page and use your favourite browser to access OpenSearch Dashboards service.
 
+.. warning:: 
+    OpenSearch Dashboard will be **unavailable** during a **maintenance update** that consists of a version update to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
+
 Load sample data
 *****************
 

--- a/docs/products/opensearch/dashboards/getting-started.rst
+++ b/docs/products/opensearch/dashboards/getting-started.rst
@@ -4,7 +4,9 @@ Getting started
 To start using **Aiven for OpenSearch® Dashboards**, :doc:`create Aiven for OpenSearch® service first</docs/products/opensearch/getting-started>` and OpenSearch Dashboards service will be added alongside it. Once the Aiven for OpenSearch service is running you can find connection information to your OpenSearch Dashboards in the service overview page and use your favourite browser to access OpenSearch Dashboards service.
 
 .. warning:: 
-    OpenSearch Dashboard will be **unavailable** during a **maintenance update** that consists of a version update to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
+
+    OpenSearch Dashboard will be **not accessible** during a **maintenance update** that also consists of version updates to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. Once the maintenance update is completed, the OpenSearch Dashboard will be available again.
+
 
 Load sample data
 *****************


### PR DESCRIPTION
# What changed, and why it matters


OpenSearch Dashboards will be accessible while a maintenance update for the service is ongoing, which also includes version upgrades. 
