### PR TITLE
Change contact for limited availability template

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -210,7 +210,7 @@ Limited availability note template
 For features that are in the limited availability stage, add the following admonition directly undert the article title:
 
 .. important:: 
-    {feature name} is a limited availability feature. If you're interested in trying out this feature, contact your account team or the Aiven support team at support@Aiven.io.
+    {feature name} is a limited availability feature. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 
 Early availability note template


### PR DESCRIPTION
# What changed, and why it matters
Removed the support team as a contact from the template for the limited availability annotation template.


