### PR TITLE
Update beta services article for new lifecycle

### DIFF
--- a/docs/platform/concepts/beta_services.rst
+++ b/docs/platform/concepts/beta_services.rst
@@ -1,7 +1,7 @@
 Service and feature releases
 =============================
 
-Before an official release, the lifecycle of new services and features includes a limited availability stage and an early availability stage.
+Before general availability, the lifecycle of new services and features includes a limited availability stage and an early availability stage.
 
 
 Limited availability
@@ -23,7 +23,7 @@ Using a service in this stage means that you consent to us contacting you to req
 General availability
 ---------------------
 
-New services and features become generally available once we are confident that they are ready for production use at scale. The duration of the early stages depends on how quickly the service or feature has been adopted by our customers and what changes are required to address the key issues that are discovered.
+New services and features become generally available once they are ready for production use at scale. The duration of the early and limited availability stages depends on how quickly the service or feature has been adopted by our customers and what changes are required to address the key issues that are discovered.
 
 
 Billing for limited and early availability services

--- a/docs/platform/concepts/beta_services.rst
+++ b/docs/platform/concepts/beta_services.rst
@@ -1,32 +1,32 @@
-Service and feature release stages
-===================================
+Service and feature releases
+=============================
 
-The lifecycle for new Aiven services and features
-
-Aiven releases new services at the beta stage for all customers so that you have the opportunity to test and validate your business needs for these new services.
-
-The reason for the wide availability is that we believe that customer feedback is critical during the development cycle, and the feedback that we receive during the beta stage helps us shape the products that you use.
+Before an official release, the lifecycle of new services and features includes a limited availability stage and an early availability stage.
 
 
-What does beta mean?
---------------------
+Limited availability
+---------------------
 
-Any service tagged as beta is intended as early access for use in non-production environments. You can however test them with production-like workloads so that you can gauge how the service behaves under heavy loads.
-
-Issues raised for beta services are considered low severity issues and are handled according to our support SLAs.
-
-Using a beta service means that you consent to us contacting you to request qualitative feedback and to test the service to help Aiven improve its product offering.
+The limited availability stage is an initial release that customers can try out. If you are interested in trying a service or feature in this stage, contact the sales team at sales@Aiven.io.
 
 
-How long will it be in beta?
-----------------------------
+Early availability
+-------------------
 
-An Aiven service will advance from beta status and become generally available once we are confident that it is ready for production use at scale.
+Features and services in the early availability stage are released to all users with some restrictions on the functionality and `service level agreement <https://aiven.io/sla>`_. They are intended for use in non-production environments, but you can test them with production-like workloads to gauge their behavior under heavy loads. Issues raised for these services and features are considered `low severity <https://aiven.io/support-services>`_.
 
-The duration of the beta period largely depends on how quickly the service has been adopted by our customers and what changes are required to address the key issues that are discovered.
+You can enable most early availability features yourself on the :doc:`feature preview page </docs/platform/howto/feature-preview>` in the user profile. This is also where you can provide feedback about the feature after trying it out.
+
+Using a service in this stage means that you consent to us contacting you to request qualitative feedback. The feedback we receive helps us shape the products you use.
 
 
-Billing for beta services
--------------------------
+General availability
+---------------------
 
-We provide campaign credit codes to encourage you to try out our beta services. Once the campaign code expires or you have used the credit in full, we charge you for the service according to the normal rate.
+New services and features become generally available once we are confident that they are ready for production use at scale. The duration of the early stages depends on how quickly the service or feature has been adopted by our customers and what changes are required to address the key issues that are discovered.
+
+
+Billing for limited and early availability services
+----------------------------------------------------
+
+Aiven provides credits for you to try out limited and early availability services. Once the credit code expires or you have used all of the credits, you are charged for the service according to the normal rate.

--- a/docs/platform/concepts/beta_services.rst
+++ b/docs/platform/concepts/beta_services.rst
@@ -1,5 +1,7 @@
-Beta services
-=============
+Service and feature release stages
+===================================
+
+The lifecycle for new Aiven services and features
 
 Aiven releases new services at the beta stage for all customers so that you have the opportunity to test and validate your business needs for these new services.
 

--- a/docs/platform/howto/use-azure-privatelink.rst
+++ b/docs/platform/howto/use-azure-privatelink.rst
@@ -1,5 +1,9 @@
-Use Azure Private Link with Aiven services |beta|
-=================================================
+Use Azure Private Link with Aiven services 
+===========================================
+
+.. important
+
+    Azure Private Link is an :doc:`early availability feature </docs/platform/concepts/beta_services>`.
 
 Azure Private Link lets you bring your Aiven services into your virtual network (VNet) over a private endpoint. The endpoint creates a network interface into one of the VNet subnets, and receives a private IP address from its IP range. The private endpoint is routed to your Aiven service.
 

--- a/docs/platform/howto/use-google-private-service-connect.rst
+++ b/docs/platform/howto/use-google-private-service-connect.rst
@@ -1,11 +1,11 @@
-Use Google Private Service Connect with Aiven services |beta|
-=============================================================
+Use Google Private Service Connect with Aiven services 
+=======================================================
 
 Discover Google Private Service Connect and benefits of using it with your Aiven services. Learn how to enable Google Private Service Connect for Aiven services.
 
 .. important::
 
-   Google Private Service Connect is in beta, and it is currently supported for Aiven for Apache Kafka®. Contact support@Aiven.io to enable it on your Aiven projects.
+    Google Private Service Connect is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. It's only supported for Aiven for Apache Kafka®. Contact support@Aiven.io to enable it on your Aiven projects.
 
 About Private Service Connect
 -----------------------------


### PR DESCRIPTION
# What changed, and why it matters
Change the beta services article to a service and feature lifecycle article with explanations of the newly named stages.
Also removing beta tag and adding note to two networking articles for the tech writing team, as discussed.


