### PR TITLE
platform: temporary add beta as a counterpart to limited availability

### DIFF
--- a/docs/platform/concepts/beta_services.rst
+++ b/docs/platform/concepts/beta_services.rst
@@ -1,21 +1,19 @@
 Service and feature releases
 =============================
 
-Before general availability, the lifecycle of new services and features includes a limited availability (beta) stage and an early availability stage.
+Before general availability, the lifecycle of new services and features includes a limited availability (private beta) stage and an early availability (public beta) stage.
 
+Limited availability (private beta)
+-----------------------------------
 
-Limited availability (beta)
----------------------------
+The limited availability (private beta) stage is an initial release of a new functionality that you can try out by invitation only. If you are interested in trying a service or feature in this stage, contact the sales team at sales@Aiven.io.
 
-The limited availability (beta) stage is an initial release that customers can try out. If you are interested in trying a service or feature in this stage, contact the sales team at sales@Aiven.io.
+Early availability (public beta)
+--------------------------------
 
+Features and services in the early availability (public beta) stage are released to all users with some restrictions on the functionality and `service level agreement <https://aiven.io/sla>`_. They are intended for use in non-production environments, but you can test them with production-like workloads to gauge their behavior under heavy loads. Issues raised for these services and features are considered `low severity <https://aiven.io/support-services>`_.
 
-Early availability
--------------------
-
-Features and services in the early availability stage are released to all users with some restrictions on the functionality and `service level agreement <https://aiven.io/sla>`_. They are intended for use in non-production environments, but you can test them with production-like workloads to gauge their behavior under heavy loads. Issues raised for these services and features are considered `low severity <https://aiven.io/support-services>`_.
-
-You can enable most early availability features yourself on the :doc:`feature preview page </docs/platform/howto/feature-preview>` in the user profile. This is also where you can provide feedback about the feature after trying it out.
+You can enable most early availability (public beta) features yourself on the :doc:`feature preview page </docs/platform/howto/feature-preview>` in the user profile. This is also where you can provide feedback about the feature after trying it out.
 
 Using a service in this stage means that you consent to us contacting you to request qualitative feedback. The feedback we receive helps us shape the products you use.
 
@@ -23,7 +21,7 @@ Using a service in this stage means that you consent to us contacting you to req
 General availability
 ---------------------
 
-New services and features become generally available once they are ready for production use at scale. The duration of the early and limited availability stages depends on how quickly the service or feature has been adopted by our customers and what changes are required to address the key issues that are discovered.
+New services and features become generally available once they are ready for production use at scale. The duration of the early and limited availability stages depends on how quickly the service or feature has been adopted by the users and what changes are required to address the key issues that are discovered.
 
 
 Billing for limited and early availability services

--- a/docs/platform/concepts/beta_services.rst
+++ b/docs/platform/concepts/beta_services.rst
@@ -1,13 +1,13 @@
 Service and feature releases
 =============================
 
-Before general availability, the lifecycle of new services and features includes a limited availability stage and an early availability stage.
+Before general availability, the lifecycle of new services and features includes a limited availability (beta) stage and an early availability stage.
 
 
-Limited availability
----------------------
+Limited availability (beta)
+---------------------------
 
-The limited availability stage is an initial release that customers can try out. If you are interested in trying a service or feature in this stage, contact the sales team at sales@Aiven.io.
+The limited availability (beta) stage is an initial release that customers can try out. If you are interested in trying a service or feature in this stage, contact the sales team at sales@Aiven.io.
 
 
 Early availability


### PR DESCRIPTION
Although term "beta" is being removed now from the product lifecycle, it has been agreed that at least in the BYOC copy we keep "beta" by Organizations' GA, when the beta label will be removed.

Consequently, there is discrepancy in the product lifecycle naming between what we ('re gonna) have in the BYOC copy and what we have in the documentation.

* [In the doc](https://docs.aiven.io/docs/platform/concepts/beta_services#limited-availability), we have already updated the terminology and we use "limited availability - early availability - general availability" (no "beta").
* In the BYOC copy, we still use "beta" for "limited availability". The banner informing the users about the feature being in the beta version redirects them to [the doc](https://docs.aiven.io/docs/platform/concepts/beta_services#limited-availability) that already includes the new naming (so instead of finding "beta" over there, the users will find "limited availability").

This might be confusing and raise questions. This PR is to walk around this issue by adding the "beta" terms next to the "limited availability" instances in the doc so that the users, when redirected from the banner in the console to the doc, are aware that the limited availability is a counterpart of the beta.

This additional beta annotation in the doc will be removed at Organizations' GA, when the beta label is also gone from the console.

https://aiven.atlassian.net/browse/DOC-463