### PR TITLE
Remove unused pages from TOC

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -19,7 +19,6 @@ entries:
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
     - file: docs/platform/howto/feature-preview
-    - file: docs/platform
 
   # -------- ORGANIZATIONS, UNITS, PROJECTS --------
   - file: docs/platform/howto/list-account

--- a/_toc.yml
+++ b/_toc.yml
@@ -19,6 +19,7 @@ entries:
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
     - file: docs/platform/howto/feature-preview
+    - file: docs/platform
 
   # -------- ORGANIZATIONS, UNITS, PROJECTS --------
   - file: docs/platform/howto/list-account

--- a/_toc.yml
+++ b/_toc.yml
@@ -19,11 +19,6 @@ entries:
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
     - file: docs/platform/howto/feature-preview
-    - file: docs/platform
-      entries:
-      - file: docs/platform/concepts
-      - file: docs/platform/howto
-      - file: docs/platform/reference
 
   # -------- ORGANIZATIONS, UNITS, PROJECTS --------
   - file: docs/platform/howto/list-account

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Aiven platform
 ==================
 

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -1,8 +1,6 @@
 Aiven platform
 ==================
 
-:orphan:
-
 Aiven provides managed open source data technologies on all major clouds. Through Aiven, developers can do what they do best: create applications. Meanwhile, Aiven does what it does best; manage cloud data infrastructure. 
 
 The Aiven platform consists of the :doc:`Aiven Console </docs/tools/aiven-console>`, :doc:`tools </docs/tools>`, and Aiven services:

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -1,6 +1,8 @@
 Aiven platform
 ==================
 
+:orphan:
+
 Aiven provides managed open source data technologies on all major clouds. Through Aiven, developers can do what they do best: create applications. Meanwhile, Aiven does what it does best; manage cloud data infrastructure. 
 
 The Aiven platform consists of the :doc:`Aiven Console </docs/tools/aiven-console>`, :doc:`tools </docs/tools>`, and Aiven services:

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -1,7 +1,7 @@
+:orphan:
+
 Concepts
 ========
-
-:orphan:
 
 Learn more about the Aiven platform. 
 

--- a/docs/platform/concepts.rst
+++ b/docs/platform/concepts.rst
@@ -1,6 +1,8 @@
 Concepts
 ========
 
+:orphan:
+
 Learn more about the Aiven platform. 
 
 * :doc:`Get started with the Aiven platform </docs/get-started>` 

--- a/docs/platform/howto.rst
+++ b/docs/platform/howto.rst
@@ -1,7 +1,7 @@
+:orphan:
+
 How-To
 =======
-
-:orphan:
 
 Find instructions for common Aiven platform tasks for the following categories:
 

--- a/docs/platform/howto.rst
+++ b/docs/platform/howto.rst
@@ -1,6 +1,8 @@
 How-To
 =======
 
+:orphan:
+
 Find instructions for common Aiven platform tasks for the following categories:
 
 * :doc:`Billing and payments </docs/platform/concepts/list-billing>`

--- a/docs/platform/reference.rst
+++ b/docs/platform/reference.rst
@@ -1,6 +1,8 @@
 Reference
 =========
 
+:orphan:
+
 Reference materials for working with the Aiven platform using the Aiven tools:
 
 * :doc:`Aiven Console </docs/tools/aiven-console>` 

--- a/docs/platform/reference.rst
+++ b/docs/platform/reference.rst
@@ -1,7 +1,7 @@
+:orphan:
+
 Reference
 =========
-
-:orphan:
 
 Reference materials for working with the Aiven platform using the Aiven tools:
 


### PR DESCRIPTION
# What changed, and why it matters
Make the now unused/redundant platform list pages orphans and remove them from the TOC.

