### PR TITLE
kafka: fix the article title to the correct MQTT => Kafka connector orientation

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.rst
+++ b/docs/products/kafka/kafka-connect/howto/mqtt-source-connector.rst
@@ -1,5 +1,5 @@
-Create a source connector from Apache Kafka® to MQTT
-=======================================================
+Create a source connector from MQTT to Apache Kafka®
+====================================================
 
 The `MQTT source connector <https://docs.lenses.io/5.0/integrations/connectors/stream-reactor/sources/mqttsourceconnector/>`_ copies messages from the MQTT topic into Apache Kafka® where they can be transformed and read by multiple consumers. Then, the Stream Reactor MQTT source connector creates a queue and binds it to the ``amq.topic`` defined in the KCQL statement, then messages are copied to the Apache Kafka® service. 
 


### PR DESCRIPTION
Fixing the title 

