### PR TITLE
Update Node.js instructions for connecting to PostgreSQL service

### DIFF
--- a/code/products/postgresql/connect.js
+++ b/code/products/postgresql/connect.js
@@ -1,31 +1,27 @@
-const fs = require('fs');
-const pg = require('pg');
-
-const postgresqlUri = "POSTGRESQL_URI";
-
-const conn = new URL(postgresqlUri);
-conn.search = conn.query = "";
+const fs = require("fs");
+const pg = require("pg");
 
 const config = {
-    connectionString: conn.href,
-    ssl: {
-        rejectUnauthorized: true,
-        ca: fs.readFileSync('./ca.pem').toString(),
-    },
+  user: "USER",
+  password: "PASSWORD",
+  host: "HOST",
+  port: "PORT",
+  database: "DATABASE",
+  ssl: {
+    rejectUnauthorized: true,
+    ca: fs.readFileSync("./ca.pem").toString(),
+  },
 };
 
 const client = new pg.Client(config);
 client.connect(function (err) {
-    if (err)
-        throw err;
-    client.query("SELECT VERSION()", [], function (err, result) {
-        if (err)
-            throw err;
+  if (err) throw err;
+  client.query("SELECT VERSION()", [], function (err, result) {
+    if (err) throw err;
 
-        console.log(result.rows[0]);
-        client.end(function (err) {
-            if (err)
-                throw err;
-        });
+    console.log(result.rows[0]);
+    client.end(function (err) {
+      if (err) throw err;
     });
+  });
 });

--- a/docs/products/postgresql/howto/connect-node.rst
+++ b/docs/products/postgresql/howto/connect-node.rst
@@ -8,11 +8,15 @@ Variables
 
 These are the placeholders you will need to replace in the code sample:
 
-==================      =============================================================
+==================      =======================================================================
 Variable                Description
-==================      =============================================================
-``POSTGRESQL_URI``      URL for PostgreSQL connection, from the service overview page
-==================      =============================================================
+==================      =======================================================================
+``USER``                PostgreSQL username, from the service overview page
+``PASSWORD``            PostgreSQL password, from the service overview page
+``HOST``                Hostname for PostgreSQL connection, from the service overview page
+``PORT``                Port for PostgreSQL connection, from the service overview page
+``DATABASE``            Database Name for PostgreSQL connection, from the service overview page
+==================      =======================================================================
 
 Pre-requisites
 ''''''''''''''
@@ -28,15 +32,12 @@ For this example you will need:
 Code
 ''''
 
-Add the following to ``index.js`` and replace the placeholder with the PostgreSQL URI:
+Add the following to ``index.js`` and replace the connection parameters with the ones from the service overview page:
 
 .. literalinclude:: /code/products/postgresql/connect.js
    :language: javascript
 
 This code creates a PostgreSQL client and opens a connection to the database. Then runs a query checking the database version and prints the response.
-
-.. note::
-    This example removes ``?sslmode=require`` from the URL string to avoid running into `this bug <https://github.com/brianc/node-postgres/issues/2558>`_. Adding the ``rejectUnauthorized: true`` configuration ensures that the certificate is checked.
 
 To run the code::
 


### PR DESCRIPTION
Using the full connection URL for connecting
to a PostgreSQL service with Node.js had
the following issue:

"We can notice the “search” param override from the URL, and then the href being taken from such url into the “connectionString” for the config object.

This seems to be a workaround/patch that stems from a node-postgres/pg-connection-string bug:
the connectionString isn’t properly parsed into its ssl components, an “sslmode” key is retained and probably overrides the “ssl” block content if present, but then the CA
isn’t properly parsed and causes problem.

What’s the problem to the user? conn.search is overridden, so if somebody expects additional parameters from
the connection string to be taken into account,
this creates a subtle bug. The code, generally speaking, is a bit unclear; either you take it as it is, or it can stop working with all kind of certificate errors.
Also, sslmode=require usually implies
“estabilish TLS but don’t verify certificates”; while the “config” ssl block will actually try to verify certificates. The behaviour of the code doesn’t reflect what’s in the connection string."