### PR TITLE
Removed limited availability note for OSS

### DIFF
--- a/docs/products/opensearch/concepts/os-security.rst
+++ b/docs/products/opensearch/concepts/os-security.rst
@@ -1,11 +1,6 @@
 OpenSearch Security for Aiven for OpenSearch®
 =====================================================
 
-.. important::
-
-  OpenSearch Security for Aiven for Apache OpenSearch® is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
-
 OpenSearch Security is a powerful feature that enhances the security of your OpenSearch service. By :doc:`enabling OpenSearch Security management <../howto/enable-opensearch-security>`, you can implement fine-grained access controls, SAML authentication, and audit logging to track and analyze activities within your OpenSearch environment. 
 
 With OpenSearch Security enabled, you can manage user access and permissions directly from the :doc:`OpenSearch Dashboard <../dashboards>`, giving you full control over your service's security.

--- a/docs/products/opensearch/howto/audit-logs.rst
+++ b/docs/products/opensearch/howto/audit-logs.rst
@@ -1,12 +1,6 @@
 Enable, configure, and visualize OpenSearch® Audit logs
 ===============================================================
 
-.. important::
-
-   OpenSearch Security management for Aiven for OpenSearch is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
-
-
 Aiven for OpenSearch® enables audit logging functionality via the OpenSearch Security dashboard, which allows OpenSearch Security administrators to track system events, security-related events, and user activity. These audit logs contain information about user actions, such as login attempts, API calls, index operations, and other security-related events. 
 
 This article details the steps required to enable, configure, and visualize OpenSearch audit logs through the OpenSearch Security dashboard.

--- a/docs/products/opensearch/howto/enable-opensearch-security.rst
+++ b/docs/products/opensearch/howto/enable-opensearch-security.rst
@@ -1,11 +1,6 @@
 Enable OpenSearch® Security management for Aiven for OpenSearch® 
 ========================================================================
 
-.. important::
-
-  OpenSearch® Security management for Aiven for Apache OpenSearch® is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
-
 :doc:`OpenSearch Security <../concepts/os-security>` provides a range of security features, including fine-grained access controls, SAML authentication, and audit logging to monitor activity within your OpenSearch service. By enabling this, you can easily manage user permissions, roles, and other security aspects through the OpenSearch Dashboard.
 
 This article provides information on how to enable OpenSearch Security from the Aiven Console. 

--- a/docs/products/opensearch/howto/list-opensearch-security.rst
+++ b/docs/products/opensearch/howto/list-opensearch-security.rst
@@ -1,10 +1,6 @@
 OpenSearch® Security management in Aiven for OpenSearch®
 ================================================================
 
-.. important::
-
-    OpenSearch Security for Aiven for Apache OpenSearch® is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
 Using OpenSearch Security can significantly strengthen the security of your service. By enabling and leveraging this feature for your Aiven for OpenSearch service, you gain access to a wide range of advanced functionalities that will allow you to manage security and access control effectively. 
 
 

--- a/docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy.rst
+++ b/docs/products/opensearch/howto/opensearch-dashboard-multi_tenancy.rst
@@ -1,11 +1,6 @@
 Set up OpenSearch® Dashboard multi-tenancy |beta|
 ==================================================
 
-.. important::
-
-   To create custom tenants for OpenSearch® Dashboards, enabling OpenSearch Security management is required. OpenSearch Security management for Aiven for OpenSearch is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
-
 Aiven for OpenSearch® provides support for multi-tenancy through OpenSearch Security Dashboard. Multi-tenancy in OpenSearch Security enables multiple users or groups to securely access the same OpenSearch cluster while maintaining their distinct permissions and data access levels. With multi-tenancy, each tenant has its own isolated space for working with indexes, visualizations, dashboards, and other OpenSearch objects, ensuring tenant-specific data and resources are protected from unauthorized access. 
 
 This article provides you with information on how to set up OpenSearch Dashboard multi-tenancy using the OpenSearch Dashboard user interface.

--- a/docs/products/opensearch/howto/saml-sso-authentication.rst
+++ b/docs/products/opensearch/howto/saml-sso-authentication.rst
@@ -1,11 +1,6 @@
 Enable SAML authentication on Aiven for OpenSearch® 
 ==========================================================
 
-.. important::
-
-   SAML authentication on Aiven for OpenSearch® combined with OpenSearch® Security management is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_.
-
-
 SAML (Security Assertion Markup Language) is a standard protocol for exchanging authentication and authorization data between an identity provider (IdP) and a Service Provider (SP). SAML enables users to authenticate themselves to a service provider with credentials from a trusted third-party identity provider without the need to create and manage separate user accounts for each service provider.
 
 SAML authentication on Aiven for OpenSearch® can enhance the authentication process for users, providing increased security and a more streamlined experience. With SAML, OpenSearch can delegate authentication and authorization to a trusted external identity provider, reducing security risks and simplifying user management. Additionally, SAML allows for Single Sign-On (SSO) functionality, enabling users to access several OpenSearch instances without the need to log in multiple times.


### PR DESCRIPTION
# What changed, and why it matters


OpenSearch Security is going to be GA and hence removed the limited availability note for all topics related to OSS. 