### PR TITLE
Fix algolia index title refer

### DIFF
--- a/.github/workflows/index-devportal.yaml
+++ b/.github/workflows/index-devportal.yaml
@@ -2,7 +2,7 @@ name: Index devportal pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ fix-algolia-index-title-refer ]
 
 jobs:
   build:

--- a/.github/workflows/index-devportal.yaml
+++ b/.github/workflows/index-devportal.yaml
@@ -2,7 +2,7 @@ name: Index devportal pages
 
 on:
   push:
-    branches: [ fix-algolia-index-title-refer ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/scripts/index_algolia.py
+++ b/scripts/index_algolia.py
@@ -26,38 +26,40 @@ def parse_pages(html_build_dir):
 
         with open(filepath) as file:
             doc = BeautifulSoup(file.read(), 'html.parser')
-
+            #set initial value for title
+            title = doc.title.text
             elements = doc.select('div.article-container')[0]
 
-            # Extract title from h1 tag and remove it
-            for h1 in elements.select('h1'):
-                # Decompose the a tag in the h1 tag
-                for a in h1.select('a'):
-                    a.decompose()
+            if elements:
+                # Extract title from h1 tag and remove it
+                for h1 in elements.select('h1'):
+                    # Decompose the a tag in the h1 tag
+                    for a in h1.select('a'):
+                        a.decompose()
 
-                title = h1.text.strip()
-                h1.decompose()
+                    title = h1.text.strip()
+                    h1.decompose()
 
-            # remove admonition
-            for admonition in elements.select('div.admonition'):
-                admonition.decompose()
+                # remove admonition
+                for admonition in elements.select('div.admonition'):
+                    admonition.decompose()
 
-            # remove tables of contents
-            for toc in elements.select('div.toctree-wrapper'):
-                toc.decompose()
+                # remove tables of contents
+                for toc in elements.select('div.toctree-wrapper'):
+                    toc.decompose()
 
-            # remove header links
-            for headerlink in elements.select('a.headerlink'):
-                headerlink.decompose()
+                # remove header links
+                for headerlink in elements.select('a.headerlink'):
+                    headerlink.decompose()
 
-            # remove preamble links etc
-            for backtotop in elements.select('a.back-to-top'):
-                backtotop.decompose()
+                # remove preamble links etc
+                for backtotop in elements.select('a.back-to-top'):
+                    backtotop.decompose()
 
-            for icons in elements.select('div.content-icon-container'):
-                icons.decompose()
+                for icons in elements.select('div.content-icon-container'):
+                    icons.decompose()
 
-            body = elements.text.strip()
+                body = elements.text.strip()
             pages.append({
                 'title': title,
                 'body': body,


### PR DESCRIPTION
# What changed, and why it matters
Noticed that since last week, the Git [workflow](https://github.com/aiven/devportal/actions/workflows/index-devportal.yaml) to push page updates to Algolia index (for search) fails due to error in `title`
[Workflow failed example](https://github.com/aiven/devportal/actions/runs/6036681886/job/16379439636#step:6:33)

<img width="690" alt="Screenshot 2023-08-31 at 16 25 59" src="https://github.com/aiven/devportal/assets/3796599/250365a3-18da-474a-8170-08931943bc07">

# Solution
The error message "UnboundLocalError: local variable 'title' referenced before assignment" suggests that the variable `title` is being used before it has been assigned any value.

To fix this:

1. Initialize variables like title to default value `<title>`
2. Check if `elements` exist before extracting content from it.

# To test the workflow
Temporary set if changes happens to this branch `fix-algolia-index-title-refer`, execute the workflow and [it runs successfully](https://github.com/aiven/devportal/actions/runs/6037965433/job/16383302821).


