### PR TITLE
platform: add clarification to backups storage

### DIFF
--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -6,7 +6,7 @@ This article provides information on general rules for handling service backups 
 About backups at Aiven
 ----------------------
 
-All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. Backups at Aiven are stored in the object storage of the cloud region where a service runs (for example, S3 for AWS or GCS for GCP). You can check the location of your service's backups in `Aiven Console <https://console.aiven.io/>`_ > your service's homepage > **Backups**.
+All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. Backups at Aiven are stored in the object storage of the cloud region where the service is first created (for example, S3 for AWS or GCS for GCP). Notice that the backups are not migrated with the service in case of a change of cloud provider or AZ. You can check the location of your service's backups in `Aiven Console <https://console.aiven.io/>`_ > your service's homepage > **Backups**.
 
 The backup retention times vary based on the service and the selected service plan. 
 

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -12,7 +12,7 @@ The backup retention times vary based on the service and the selected service pl
 
 Aiven takes service backups for managing purposes. These backups are compressed and encrypted by the Aiven management platform and, as such, are not available for download for any service type.
 
-.. note::  In case of a change of cloud provider or availability zone for a service, its backups are not migrated with it.
+.. note::  If you change a cloud provider or an availability zone for your service, its backups are not migrated from their original location.
 
 Service power-off/on backup policy
 ------------------------------------

--- a/docs/platform/concepts/service_backups.rst
+++ b/docs/platform/concepts/service_backups.rst
@@ -6,11 +6,13 @@ This article provides information on general rules for handling service backups 
 About backups at Aiven
 ----------------------
 
-All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. Backups at Aiven are stored in the object storage of the cloud region where the service is first created (for example, S3 for AWS or GCS for GCP). Notice that the backups are not migrated with the service in case of a change of cloud provider or AZ. You can check the location of your service's backups in `Aiven Console <https://console.aiven.io/>`_ > your service's homepage > **Backups**.
+All Aiven services, except for Apache Kafka® and M3 Aggregator/Coordinator, have time-based backups that are encrypted and securely stored. Backups at Aiven are stored in the object storage of the cloud region where the service is first created (for example, S3 for AWS or GCS for GCP). You can check the location of your service's backups in `Aiven Console <https://console.aiven.io/>`_ > your service's homepage > **Backups**.
 
 The backup retention times vary based on the service and the selected service plan. 
 
 Aiven takes service backups for managing purposes. These backups are compressed and encrypted by the Aiven management platform and, as such, are not available for download for any service type.
+
+.. note::  In case of a change of cloud provider or availability zone for a service, its backups are not migrated with it.
 
 Service power-off/on backup policy
 ------------------------------------


### PR DESCRIPTION
Current statement about backups location storage says:

> Backups at Aiven are stored in the object storage of the cloud region where a service runs (for example, S3 for AWS or GCS for GCP).

This is not correct as when the service is migrated the backups are not migrated with it (even for a change of cloud provider), so the proposed change:
Backups at Aiven are stored in the object storage of the cloud region where the service is first created (for example, S3 for AWS or GCS for GCP). Notice that the backups are not migrated with the service in case of a change of cloud provider or AZ.