### PR TITLE
Update Terraform category page and get started

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -58,9 +58,9 @@ You can use the Aiven platform in the way that best fits your workflow with our 
         :shadow: md
         :margin: 2 2 0 0
 
-        **Aiven Terraform Provider** 
+        **Aiven Provider for Terraform** 
         
-        An infrastructure-as-code tool to manage cloud infrastructure.
+        An infrastructure as code tool to manage cloud infrastructure.
 
         .. button-link:: tools/terraform
             :align: right

--- a/docs/tools/terraform.rst
+++ b/docs/tools/terraform.rst
@@ -3,8 +3,8 @@ Aiven Provider for Terraform
 
 With Aiven's `Terraform <https://www.terraform.io>`_ provider, you can use an open source infrastructure as code tool to declare and manage your cloud services.
 
-Start using Aiven Provider
----------------------------
+Start using Aiven Provider for Terraform
+-----------------------------------------
 
 .. grid:: 2 2 2 2
 
@@ -22,7 +22,7 @@ Start using Aiven Provider
 
         `Aiven Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_
 
-        Details on the data sources and resources supported by the Aiven Provider.
+        Details on the data sources and resources supported by the Aiven Provider for Terraform.
 
 
     .. grid-item-card::

--- a/docs/tools/terraform.rst
+++ b/docs/tools/terraform.rst
@@ -13,6 +13,8 @@ Start using Aiven Provider
         :margin: 2 2 0 0
 
         :doc:`Get started </docs/tools/terraform/get-started>`
+        
+        Follow an example to learn how to set up a Terraform project.
 
     .. grid-item-card::
         :shadow: md
@@ -20,12 +22,18 @@ Start using Aiven Provider
 
         `Aiven Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_
 
+        Details on the data sources and resources supported by the Aiven Provider.
+
+
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
         `Aiven Terraform Cookbook <https://aiven.io/developer/terraform>`_
 
+        Sample code for different use cases available on the Aiven Developer Center.
+
+
 Get involved
 -------------
-To report issues, give feedback, or to contribute to the tool, join us on the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_.
+To report issues, give feedback, or to contribute to the tool join us on the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_.

--- a/docs/tools/terraform.rst
+++ b/docs/tools/terraform.rst
@@ -1,44 +1,31 @@
 Aiven Provider for Terraform
 =============================
 
-With Aiven's `Terraform <https://www.terraform.io>`_ provider, you can use an open-source infrastructure as code software tool to declare and manage your cloud services.
+With Aiven's `Terraform <https://www.terraform.io>`_ provider, you can use an open source infrastructure as code tool to declare and manage your cloud services.
 
-See the `Aiven Terraform provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_ to learn about the services and resources,and visit the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_ to report any issues or contribute to the project.
+Start using Aiven Provider
+---------------------------
 
-.. caution::
-
-  Recreating stateful services with Terraform will possibly delete the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be deleted or replaced, a catastrophic action is possibly about to happen.
-
-  Some properties, like project and the resource name, cannot be changed and it will trigger a resource replacement.
-
-  We recommend you set the ``termination_protection`` property to true on all production services, it will prevent Terraform from removing the service. Be aware that any logical databases, topics or other configurations may be removed even when this setting is enabled. Be very careful!
-
-Getting started
----------------
-
-Check out the :doc:`get started guide </docs/tools/terraform/get-started>` for your first Terraform project.
-
-.. grid:: 1 2 2 2
+.. grid:: 2 2 2 2
 
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        💻 :doc:`/docs/tools/terraform/howto`
+        :doc:`Get started </docs/tools/terraform/get-started>`
 
     .. grid-item-card::
         :shadow: md
         :margin: 2 2 0 0
 
-        📖 :doc:`/docs/tools/terraform/reference`
+        `Aiven Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_
 
-Learn more
-----------
-Check out these resources to learn more:
+    .. grid-item-card::
+        :shadow: md
+        :margin: 2 2 0 0
 
-* `Aiven Terraform Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_
-* `Terraform scripts and code samples on GitHub <https://github.com/aiven/aiven-examples/tree/main/terraform>`_
+        `Aiven Terraform Cookbook <https://aiven.io/developer/terraform>`_
 
 Get involved
-------------
-If you have any comments or want to contribute to the tool, please join us on the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_.
+-------------
+To report issues, give feedback, or to contribute to the tool, join us on the `GitHub repository <https://github.com/aiven/terraform-provider-aiven>`_.

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -112,7 +112,7 @@ Plan and apply the configuration
 
    terraform plan
 
-3. To create the Redis service, run:
+3. To create the resources, run:
 
 .. code:: bash
 
@@ -131,13 +131,13 @@ Clean up
 
 To delete the service and its data:
 
-1. To create a destroy plan to preview the changes using the following command, run:
+1. To create a destroy plan and preview the changes to your infrastructure, run:
 
 .. code:: bash
 
    terraform plan -destroy
 
-2. To delete the resource and all data, run: 
+2. To delete the resources and all data, run: 
 
 .. code:: bash
 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,17 +1,17 @@
 Get started with Aiven Provider for Terraform
 ==============================================
 
-This example shows you how to use the Aiven Provider to set up your data infrastructure by creating an :doc:`Aiven project </docs/platform/concepts/projects_accounts_access>` with a single Aiven for Redis®* service. 
+This example shows you how to use the Aiven Provider to set up your data infrastructure by creating a single Aiven for Redis®* service in an :doc:`Aiven project </docs/platform/concepts/projects_accounts_access>`. 
 
 .. caution::
 
   Recreating stateful services with Terraform may delete the service and all its data before creating it again. Some properties, like project and resource name, cannot be changed and it will trigger a resource replacement. Check the Terraform plan to find out whether a service will be deleted or replaced.
 
-  It's recommended to set the ``termination_protection`` property to true on all production services. This prevents Terraform from removing the service. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
+  You can set the ``termination_protection`` property to true on all production services to prevent Terraform from removing services. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
 
 
-Prerequisities  
-'''''''''''''''
+Prerequisites  
+''''''''''''''
 - `Sign up for Aiven <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ 
 - `Download and install Terraform <https://www.terraform.io/downloads>`_
 - `Create an authentication token <https://docs.aiven.io/docs/platform/howto/create_authentication_token.html>`_
@@ -19,13 +19,15 @@ Prerequisities
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
 
-In this section, you'll learn how to structure a simple Terraform project. Terraform files declare the structure of the infrastructure, the dependencies, and configuration. These can be grouped together in one file, but it's ideal to put them in separate files.
+In this section, you'll learn how to structure a simple Terraform project. 
 
-In an empty folder and follow these steps to define your Aiven project and Redis®* service: 
+Terraform files declare the structure of the infrastructure, the dependencies, and configuration. These can be grouped together in one file, but it's ideal to put them in separate files.
 
-1. Create a new Terraform file, ``provider.tf``. This will be used to declare a dependency on the Aiven Provider for Terraform.
+Set up the Terraform project in an empty folder: 
 
-Add the following code to the file and specify the version in the ``required_providers`` block:
+1. Create a new Terraform file, ``provider.tf``, to declare a dependency on the Aiven Provider for Terraform.
+
+Add the following code to the file and specify the version in the ``required_providers`` block. You can find the latest version on the `Aiven Provider page <https://registry.terraform.io/providers/aiven/aiven/latest>`_.
 
 .. code:: terraform
 
@@ -42,16 +44,13 @@ Add the following code to the file and specify the version in the ``required_pro
     api_token = var.aiven_api_token
   }
 
-.. tip::
-  View the latest version on the `Aiven Provider page <https://registry.terraform.io/providers/aiven/aiven/latest>`_.
+3. Create a file named ``redis.tf``. 
 
-3. Create a file named ``redis.tf`` to define the configuration of an Aiven for Redis®* service.
-
-Add the following block for a single-node Redis service:
+Add the following code to define the configuration of a single-node Aiven for Redis®* service:
 
 .. code:: terraform
 
-    # A single-node Redis service
+    # Redis service
     
     resource "aiven_redis" "single-node-aiven-redis" {
       project                 = var.project_name
@@ -71,9 +70,9 @@ Add the following block for a single-node Redis service:
     }
     
     
-5. Create a new file named ``variables.tf``. This is used to avoid including sensitive information in source control. 
+5. Create a file named ``variables.tf``. This is used to avoid including sensitive information in source control. 
 
-Add the following code to define both the API token and the project name:
+Add the following code to declare the API token and project name variables:
 
 .. code:: terraform
 
@@ -88,7 +87,7 @@ Add the following code to define both the API token and the project name:
    }
    
    
-6. Create a file named ``var-values.tfvars`` to hold the actual values of the sensitive information. The values are passed to Terraform using the ``-var-file`` flag.
+6. Create a file named ``terraform.tfvars`` to define the values of the sensitive information. 
 
 Add the following code, replacing ``AIVEN_AUTHENTICATION_TOKEN`` with your API token and ``AIVEN_PROJECT_NAME`` with the name of your project:
 
@@ -98,32 +97,26 @@ Add the following code, replacing ``AIVEN_AUTHENTICATION_TOKEN`` with your API t
    project_name    = "AIVEN_PROJECT_NAME"
    
 
-Apply the Terraform configuration
+Plan and apply the configuration
 '''''''''''''''''''''''''''''''''
 
-1. The ``init`` command performs several different initialization steps to prepare the current working directory for use with Terraform. 
-
-Run this command to automatically find, download, and install the necessary Aiven Provider plugins:
+1. The ``init`` command prepares the working directly for use with Terraform. Run this command to automatically find, download, and install the necessary Aiven Provider plugins:
 
 .. code:: bash
 
    terraform init 
 
-2. The ``plan`` command creates an execution plan and shows you the resources that will be created or modified. It does not actually create any resources. 
-
-Run this command to preview the changes:
+2. Run the ``plan`` command to create an execution plan and view the resources that will be created or modified. This command does not create any resources. 
 
 .. code:: bash
 
-   terraform plan -var-file=var-values.tfvars
+   terraform plan
 
-3. The ``terraform apply`` command creates or modifies the infrastructure resources. 
-
-Run the following command to create the Redis service:
+3. To create the Redis service, run:
 
 .. code:: bash
 
-   terraform apply -var-file=var-values.tfvars
+   terraform apply
 
 The output will be similar to the following:
 
@@ -136,23 +129,25 @@ You can also see the service in the `Aiven Console <https://console.aiven.io>`_.
 Clean up
 ''''''''
 
-1. Create a destroy plan to preview the changes by running the following command:
+To delete the service and its data:
+
+1. To create a destroy plan to preview the changes using the following command, run:
 
 .. code:: bash
 
-   terraform plan -var-file=var-values.tfvars -destroy
+   terraform plan -destroy
 
-This runs ``terraform plan`` in destroy mode and shows you the proposed changes without making them.
-
-2. To delete the resources and all their data, run the following command: 
+2. To delete the resource and all data, run: 
 
 .. code:: bash
 
-   terraform destroy -var-file=var-values.tfvars
+   terraform destroy
 
 
 Next steps 
 '''''''''''
-* Try `another sample project <https://github.com/aiven/terraform-provider-aiven/blob/main/sample_project/sample.tf>`_ to set up integrated Kafka, PostgreSQL, InfluxDB, and Grafana services.
+* Try `another sample project <https://github.com/aiven/terraform-provider-aiven/blob/main/sample_project/sample.tf>`_ to set up integrated Aiven for Kafka®, PostgreSQL®, InfluxDB®, and Grafana® services.
 
-* Read the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_ to learn about more complex project structures. 
+* Read the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_ to learn about more complex project structures.
+
+* `Import your existing Aiven resources <https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/importing-resources>`_ to Terraform.

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -148,6 +148,7 @@ To delete the service and its data:
 3. Enter "yes" to confirm. The output will be similar to the following:
 
 .. code:: bash
+
   Do you really want to destroy all resources?
   Terraform will destroy all your managed infrastructure, as shown above.
   There is no undo. Only 'yes' will be accepted to confirm.

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -158,6 +158,6 @@ This runs ``terraform plan`` in destroy mode and shows you the proposed changes 
 
 Next steps 
 '''''''''''
-* Try `another sample project <https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/sample-project>`_ to set up Kafka, PostgreSQL, InfluxDB, and Grafana.
+* Try `another sample project <https://github.com/aiven/terraform-provider-aiven/blob/main/sample_project/sample.tf>`_ to set up integrated Kafka, PostgreSQL, InfluxDB, and Grafana services.
 
 * Read the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_ to learn about more complex project structures. 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -7,7 +7,7 @@ This example shows you how to use the Aiven Provider to set up your data infrast
 
   Recreating stateful services with Terraform may delete the service and all its data before creating it again. Some properties, like project and resource name, cannot be changed and it will trigger a resource replacement. Run the Terraform :ref:`plan command <plan-and-apply>` to find out whether a service will be deleted or replaced.
 
-  You can set the ``termination_protection`` property to true on production services, topics, and databases to prevent Terraform from removing them. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
+  You can set the ``termination_protection`` property to true on production services, topics, and databases to prevent Terraform from removing them. However, logical databases, topics, or other configurations may still be removed even with this setting enabled.
 
 
 Prerequisites  
@@ -108,7 +108,7 @@ Plan and apply the configuration
 
    terraform init 
 
-2. Run the ``plan`` command to create an execution plan and preview the changes that will be made (for example, what resources will be created or modified).
+2. Run the ``plan`` command to create an execution plan and preview the changes that will be made (for example, what resources will be created or modified):
 
 .. code:: bash
 
@@ -118,7 +118,7 @@ Plan and apply the configuration
 
 .. code:: bash
 
-   terraform apply
+   terraform apply --auto-approve
 
 The output will be similar to the following:
 
@@ -126,7 +126,7 @@ The output will be similar to the following:
   
   Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
-You can also see the Redis service in the `Aiven Console <https://console.aiven.io>`_.
+You can also see the new Redis service in the `Aiven Console <https://console.aiven.io>`_.
 
 Clean up
 ''''''''
@@ -145,6 +145,16 @@ To delete the service and its data:
 
    terraform destroy
 
+3. Enter "yes" to confirm. The output will be similar to the following:
+
+.. code:: bash
+  Do you really want to destroy all resources?
+  Terraform will destroy all your managed infrastructure, as shown above.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+  ...
+  Destroy complete! Resources: 1 destroyed.
 
 Next steps 
 '''''''''''

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -25,12 +25,7 @@ In an empty folder and follow these steps to define your Aiven project and Redis
 
 1. Create a new Terraform file, ``provider.tf``. This will be used to declare a dependency on the Aiven Provider for Terraform.
 
-2. In the ``required_providers`` block, add the source of the provider and specify the version. In the provider configuration block, ``api_token`` is the only parameter.
-
-.. tip::
-  View the latest version on the `Aiven Provider page <https://registry.terraform.io/providers/aiven/aiven/latest>`_.
-
-Add the following code to the ``provider.tf`` file:
+Add the following code to the file and specify the version in the ``required_providers`` block:
 
 .. code:: terraform
 
@@ -46,13 +41,13 @@ Add the following code to the ``provider.tf`` file:
   provider "aiven" {
     api_token = var.aiven_api_token
   }
-  
+
 .. tip::
-  Set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property so that you you don't need to pass the ``-var-file`` flag when executing Terraform commands.
+  View the latest version on the `Aiven Provider page <https://registry.terraform.io/providers/aiven/aiven/latest>`_.
 
 3. Create a file named ``redis.tf`` to define the configuration of an Aiven for Redis®* service.
 
-4. Add the following block for a single-node Redis service to the ``redis.tf`` file:
+Add the following block for a single-node Redis service:
 
 .. code:: terraform
 
@@ -78,7 +73,7 @@ Add the following code to the ``provider.tf`` file:
     
 5. Create a new file named ``variables.tf``. This is used to avoid including sensitive information in source control. 
 
-It defines both the API token and the project name:
+Add the following code to define both the API token and the project name:
 
 .. code:: terraform
 
@@ -93,14 +88,14 @@ It defines both the API token and the project name:
    }
    
    
-6. Create a file named ``var-values.tfvars`` to hold the actual values of the sensitive information. The values are passed to Terraform using the ``-var-file=`` flag.
+6. Create a file named ``var-values.tfvars`` to hold the actual values of the sensitive information. The values are passed to Terraform using the ``-var-file`` flag.
 
-Add your API token and project name to the ``var-values.tfvars`` file:
+Add the following code, replacing ``AIVEN_AUTHENTICATION_TOKEN`` with your API token and ``AIVEN_PROJECT_NAME`` with the name of your project:
 
 .. code:: terraform
 
-   aiven_api_token = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
-   project_name    = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
+   aiven_api_token = "AIVEN_AUTHENTICATION_TOKEN"
+   project_name    = "AIVEN_PROJECT_NAME"
    
 
 Apply the Terraform configuration

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,7 +1,7 @@
 Get started with Aiven Provider for Terraform
 ==============================================
 
-This example shows the setup for a Terraform project containing a single Redis®* service, and shows off some useful commands to stand up (and destroy) your Aiven data infrastructure.
+This example shows you how to use the Aiven Provider to set up your Aiven data infrastructure by creating a :doc:`project </docs/platform/concepts/projects_accounts_access>` with a single Aiven for Redis®* service. 
 
 .. caution::
 
@@ -12,21 +12,18 @@ This example shows the setup for a Terraform project containing a single Redis®
 
 Prerequisities  
 '''''''''''''''
-- `Download and install Terraform <https://www.terraform.io/downloads>`_
 - `Sign up for Aiven <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ 
+- `Download and install Terraform <https://www.terraform.io/downloads>`_
 - `Create an authentication token <https://docs.aiven.io/docs/platform/howto/create_authentication_token.html>`_
-
 
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
 
-In this section, you'll learn how to structure a simple Terraform project. 
+In this section, you'll learn how to structure a simple Terraform project. Terraform files declare the structure of the infrastructure, the dependencies, and configuration. These can be grouped together in one file, but it's ideal to put them in separate files.
 
-Terraform files declare the structure of the infrastructure, the dependencies, and configuration. These can be grouped together in one file, but it's ideal to put them in separate files.
+In an empty folder and follow these steps to define your Aiven project and Redis®* service: 
 
-Start with an empty folder, and follow these steps to define and then create your Aiven services.
-
-1. Create a new Terraform file, ``provider.tf``. This will be used to declar a dependency on the Aiven Provider for Terraform.
+1. Create a new Terraform file, ``provider.tf``. This will be used to declare a dependency on the Aiven Provider for Terraform.
 
 2. In the ``required_providers`` block, add the source of the provider and specify the version. In the provider configuration block, ``api_token`` is the only parameter.
 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,7 +1,7 @@
 Get started with Aiven Provider for Terraform
 ==============================================
 
-This example shows you how to use the Aiven Provider to set up your Aiven data infrastructure by creating a :doc:`project </docs/platform/concepts/projects_accounts_access>` with a single Aiven for Redis®* service. 
+This example shows you how to use the Aiven Provider to set up your data infrastructure by creating an :doc:`Aiven project </docs/platform/concepts/projects_accounts_access>` with a single Aiven for Redis®* service. 
 
 .. caution::
 
@@ -156,7 +156,8 @@ This runs ``terraform plan`` in destroy mode and shows you the proposed changes 
    terraform destroy -var-file=var-values.tfvars
 
 
-Further reference
-'''''''''''''''''
+Next steps 
+'''''''''''
+* Try `another sample project <https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/sample-project>`_ to set up Kafka, PostgreSQL, InfluxDB, and Grafana.
 
-This article outlined a simple Terraform project structure. For a more complex project structure, refer to the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_. 
+* Read the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_ to learn about more complex project structures. 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -1,53 +1,61 @@
-Set up your first Aiven Terraform project
-=========================================
+Get started with Aiven Provider for Terraform
+==============================================
 
 This example shows the setup for a Terraform project containing a single Redis®* service, and shows off some useful commands to stand up (and destroy) your Aiven data infrastructure.
 
-Prepare the dependencies 
-''''''''''''''''''''''''
+.. caution::
+
+  Recreating stateful services with Terraform may delete the service and all its data before creating it again. Some properties, like project and resource name, cannot be changed and it will trigger a resource replacement. Check the Terraform plan to find out whether a service will be deleted or replaced.
+
+  It's recommended to set the ``termination_protection`` property to true on all production services. This prevents Terraform from removing the service. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
+
+
+Prerequisities  
+'''''''''''''''
 - `Download and install Terraform <https://www.terraform.io/downloads>`_
-- `Sign up <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ for Aiven if you haven't already
-- `Generate an authentication token <https://docs.aiven.io/docs/platform/howto/create_authentication_token.html>`_
+- `Sign up for Aiven <https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo>`_ 
+- `Create an authentication token <https://docs.aiven.io/docs/platform/howto/create_authentication_token.html>`_
 
-.. Tip::
-
-    Make sure that you have either the *Administrator* or *Operator* role when creating the API token. When you create a project, you automatically receive the *Administrator* access.
-
-    For more details, refer to the `Project members and roles page <https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html#project-members-and-roles>`_.
 
 Configure your project and services
 '''''''''''''''''''''''''''''''''''
 
-Your Terraform files declare the structure of your infrastructure as well as required dependencies and configuration. While you can stuff these together in one file, it's ideal to keep those as separate files.
 In this section, you'll learn how to structure a simple Terraform project. 
+
+Terraform files declare the structure of the infrastructure, the dependencies, and configuration. These can be grouped together in one file, but it's ideal to put them in separate files.
 
 Start with an empty folder, and follow these steps to define and then create your Aiven services.
 
-1. First we declare a dependency on the *Aiven Terraform Provider*. Within the ``required_providers`` block, you mention the source of the provider and specify a certain version (check which are the current versions and update accordingly).
-Following `Aiven Terraform Provider documentation <https://registry.terraform.io/providers/aiven/aiven/latest/docs>`_, ``api_token`` is the only parameter for the provider configuration.
+1. Create a new Terraform file, ``provider.tf``. This will be used to declar a dependency on the Aiven Provider for Terraform.
 
-Add the following to a new ``provider.tf`` file:
+2. In the ``required_providers`` block, add the source of the provider and specify the version. In the provider configuration block, ``api_token`` is the only parameter.
+
+.. tip::
+  View the latest version on the `Aiven Provider page <https://registry.terraform.io/providers/aiven/aiven/latest>`_.
+
+Add the following code to the ``provider.tf`` file:
 
 .. code:: terraform
 
-   terraform {
-     required_providers {
-       aiven = {
-         source  = "aiven/aiven"
-         version = ">=4.0.0, < 5.0.0"
-       }
-     }
-   }
-   
-   provider "aiven" {
-     api_token = var.aiven_api_token
-   }
-   
-You can also set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property. With this, you don't need to pass the ``-var-file`` flag when executing Terraform commands.
- 
-2.  The following Terraform script deploys a single-node Redis service. This is a minimal example which you can swap out with your own Terraform scripts or other advanced recipes from `the Terraform cookbook <https://aiven.io/developer/terraform>`_.
+  terraform {
+    required_providers {
+      aiven = {
+        source  = "aiven/aiven"
+        version = ">=4.0.0, < 5.0.0"
+      }
+    }
+  }
+  
+  provider "aiven" {
+    api_token = var.aiven_api_token
+  }
+  
+.. tip::
+  Set the environment variable ``AIVEN_TOKEN`` for the ``api_token`` property so that you you don't need to pass the ``-var-file`` flag when executing Terraform commands.
 
-The contents of the ``redis.tf`` file should look like this:
+3. Create a file named ``redis.tf`` to define the configuration of an Aiven for Redis®* service.
+
+4. Add the following block for a single-node Redis service to the ``redis.tf`` file:
 
 .. code:: terraform
 
@@ -71,9 +79,9 @@ The contents of the ``redis.tf`` file should look like this:
     }
     
     
-3. To avoid including sensitive information in source control, the variables are defined here in the ``variables.tf`` file. You can then use a ``*.tfvars`` file with the actual values so that Terraform receives the values during runtime, and exclude it.
+5. Create a new file named ``variables.tf``. This is used to avoid including sensitive information in source control. 
 
-The ``variables.tf`` file defines both the API token, and the project name to use:
+It defines both the API token and the project name:
 
 .. code:: terraform
 
@@ -88,64 +96,70 @@ The ``variables.tf`` file defines both the API token, and the project name to us
    }
    
    
-The ``var-values.tfvars`` file holds the actual values and is passed to Terraform using the ``-var-file=`` flag.
+6. Create a file named ``var-values.tfvars`` to hold the actual values of the sensitive information. The values are passed to Terraform using the ``-var-file=`` flag.
 
-``var-values.tfvars`` file:
+Add your API token and project name to the ``var-values.tfvars`` file:
 
 .. code:: terraform
 
    aiven_api_token = "<YOUR-AIVEN-AUTHENTICATION-TOKEN-GOES-HERE>"
    project_name    = "<YOUR-AIVEN-CONSOLE-PROJECT-NAME-GOES-HERE>"
    
-Edit the file and replace the ``<..>`` sections with the API token you created earlier, and the name of the Aiven project that resources should be created in.
-
 
 Apply the Terraform configuration
 '''''''''''''''''''''''''''''''''
 
+1. The ``init`` command performs several different initialization steps to prepare the current working directory for use with Terraform. 
 
-The ``init`` command performs several different initialization steps in order to prepare the current working directory for use with Terraform. In our case, this command automatically finds, downloads, and installs the necessary Aiven Terraform provider plugins.
+Run this command to automatically find, download, and install the necessary Aiven Provider plugins:
 
 .. code:: bash
 
    terraform init 
 
-The ``plan`` command creates an execution plan and shows you the resources that will be created (or modified) for you. This command does not actually create any resource; this is more like a preview.
+2. The ``plan`` command creates an execution plan and shows you the resources that will be created or modified. It does not actually create any resources. 
+
+Run this command to preview the changes:
 
 .. code:: bash
 
    terraform plan -var-file=var-values.tfvars
 
-If you're satisfied with the output of ``terraform plan``, go ahead and run the ``terraform apply`` command which actually does the task or creating (or modifying) your infrastructure resources. 
+3. The ``terraform apply`` command creates or modifies the infrastructure resources. 
+
+Run the following command to create the Redis service:
 
 .. code:: bash
 
    terraform apply -var-file=var-values.tfvars
 
-The output will show you if everything worked well. You can now visit the `Aiven web console <https://console.aiven.io>`_ and admire your new services.
+The output will be similar to the following:
+
+.. code:: bash
+  
+  Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+You can also see the service in the `Aiven Console <https://console.aiven.io>`_.
 
 Clean up
 ''''''''
 
-If this was a test environment, be sure to delete the resources once you're done to avoid consuming unwanted bills. To be confident about the service termination, you can create a speculative destroy plan by running the following command:
+1. Create a destroy plan to preview the changes by running the following command:
 
 .. code:: bash
 
-   terraform plan -destroy
+   terraform plan -var-file=var-values.tfvars -destroy
 
-This will run ``terraform plan`` in destroy mode and show you the proposed destroy changes without executing them.
+This runs ``terraform plan`` in destroy mode and shows you the proposed changes without making them.
 
-.. warning::
-
-   Use the following command with caution. This will actually delete resources that might have important data.
+2. To delete the resources and all their data, run the following command: 
 
 .. code:: bash
 
    terraform destroy -var-file=var-values.tfvars
 
-By destroying your services when you don't need them, for example in a testing environment, you can be confident that no unnecessary services are left running up the bills.
 
 Further reference
 '''''''''''''''''
 
-This article outlined a simple Terraform project structure. For a more complex project structure, please refer to the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_. 
+This article outlined a simple Terraform project structure. For a more complex project structure, refer to the `Terraform Docs <https://www.terraform.io/language/modules/develop/structure>`_. 

--- a/docs/tools/terraform/get-started.rst
+++ b/docs/tools/terraform/get-started.rst
@@ -5,9 +5,9 @@ This example shows you how to use the Aiven Provider to set up your data infrast
 
 .. caution::
 
-  Recreating stateful services with Terraform may delete the service and all its data before creating it again. Some properties, like project and resource name, cannot be changed and it will trigger a resource replacement. Check the Terraform plan to find out whether a service will be deleted or replaced.
+  Recreating stateful services with Terraform may delete the service and all its data before creating it again. Some properties, like project and resource name, cannot be changed and it will trigger a resource replacement. Run the Terraform :ref:`plan command <plan-and-apply>` to find out whether a service will be deleted or replaced.
 
-  You can set the ``termination_protection`` property to true on all production services to prevent Terraform from removing services. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
+  You can set the ``termination_protection`` property to true on production services, topics, and databases to prevent Terraform from removing them. However, logical databases, topics, or other configurations may still be removed with this setting enabled.
 
 
 Prerequisites  
@@ -97,6 +97,8 @@ Add the following code, replacing ``AIVEN_AUTHENTICATION_TOKEN`` with your API t
    project_name    = "AIVEN_PROJECT_NAME"
    
 
+.. _plan-and-apply:
+
 Plan and apply the configuration
 '''''''''''''''''''''''''''''''''
 
@@ -106,7 +108,7 @@ Plan and apply the configuration
 
    terraform init 
 
-2. Run the ``plan`` command to create an execution plan and view the resources that will be created or modified. This command does not create any resources. 
+2. Run the ``plan`` command to create an execution plan and preview the changes that will be made (for example, what resources will be created or modified).
 
 .. code:: bash
 
@@ -124,14 +126,14 @@ The output will be similar to the following:
   
   Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
-You can also see the service in the `Aiven Console <https://console.aiven.io>`_.
+You can also see the Redis service in the `Aiven Console <https://console.aiven.io>`_.
 
 Clean up
 ''''''''
 
 To delete the service and its data:
 
-1. To create a destroy plan and preview the changes to your infrastructure, run:
+1. Create a destroy plan and preview the changes to your infrastructure with the following command:
 
 .. code:: bash
 

--- a/docs/tools/terraform/reference.rst
+++ b/docs/tools/terraform/reference.rst
@@ -3,5 +3,6 @@
 Reference
 =========
 
-`Aiven Terraform Cookbook <https://aiven.io/developer/terraform>`_.
+`Aiven Terraform Cookbook <https://aiven.io/developer/terraform>`_
+
 :doc:`Troubleshooting </docs/tools/terraform/reference/troubleshooting>`


### PR DESCRIPTION
# What changed, and why it matters
* Remove links to pages that are no longer being used in the new structure
* Add link to the Cookbook, which is now hosted on the Dev Center
* Reword get started and align with style guide
* Minor changes to simplify get started sample

