### PR TITLE
fixed os trademark

### DIFF
--- a/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.rst
+++ b/docs/products/kafka/kafka-connect/howto/elasticsearch-sink.rst
@@ -248,4 +248,4 @@ The configuration file contains the following peculiarities:
 
 ------
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*
+

--- a/docs/products/opensearch/concepts/opensearch-vs-elasticsearch.rst
+++ b/docs/products/opensearch/concepts/opensearch-vs-elasticsearch.rst
@@ -7,5 +7,4 @@ The v1.0 release of OpenSearch should be very much similar to the Elasticsearch 
 
 -----
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*
-*Kibana is a trademark of Elasticsearch BV, registered in the U.S. and in other countries.*
+

--- a/docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aiven.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aiven.rst
@@ -80,4 +80,4 @@ Aiven for OpenSearch databases are automatically backed up, so you can check mor
    "elasticsearch" so it is probably polite to include the following
    disclaimer
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*
+

--- a/docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aws.rst
+++ b/docs/products/opensearch/howto/import-opensearch-data-elasticsearch-dump-to-aws.rst
@@ -57,4 +57,4 @@ Aiven for OpenSearch databases are automatically backed up, so you can check mor
    "elasticsearch" so it is probably polite to include the following
    disclaimer
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*
+

--- a/docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven.rst
+++ b/docs/products/opensearch/howto/migrating_elasticsearch_data_to_aiven.rst
@@ -103,4 +103,3 @@ To migrate or copy data:
 
 ------
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*

--- a/docs/products/opensearch/reference/plugins.rst
+++ b/docs/products/opensearch/reference/plugins.rst
@@ -36,4 +36,4 @@ These plugins are enabled on all Aiven for OpenSearch services by default:
 .. note::
     The **Notebooks** and **OpenSearch notification** plugins are part of **OpenSearch observability**.
 
-*Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries.*
+


### PR DESCRIPTION
# What changed, and why it matters

Removed reference to Elasticsearch trademarks in topics. 