### PR TITLE
postgresql: remove the note about DBB limitation to new services only

### DIFF
--- a/docs/products/postgresql/concepts/pg-backups.rst
+++ b/docs/products/postgresql/concepts/pg-backups.rst
@@ -69,10 +69,6 @@ Aiven for PostgreSQL uses delta base backups, which allows to store data files t
 
 Since delta base backups don't take all the data files, they are faster and easier to perform on large databases with huge volumes of data. Because performing a delta base backup doesn't last long, Aiven can back up data more frequently if required and applicable to specific datasets. With the increased backup frequency, service restoration and node replacement potentially can be faster for highly updated services because fewer WAL files need to be restored since the last backup (WAL restoration in PostgreSQL is single-threaded and, therefore, slow).
 
-.. note:: 
-
-  Currently, the delta base backup feature is enabled for newly-created services only. The scope is going to be extended to existing services soon.
-
 .. seealso::
 
    To restore a backup, see :doc:`../howto/restore-backup`.


### PR DESCRIPTION
[DOC-300]

DBB is covered for all the services now. Removing the note informing about the limitation of DBB for new services only.



[DOC-300]: https://aiven.atlassian.net/browse/DOC-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ