### PR TITLE
platform: add clickhouse as a supported service for privatelink docs

### DIFF
--- a/docs/platform/howto/use-azure-privatelink.rst
+++ b/docs/platform/howto/use-azure-privatelink.rst
@@ -11,6 +11,7 @@ Azure Private Link is supported for the following services:
 
 * Aiven for Apache Kafka®
 * Aiven for Apache Kafka Connect®
+* Aiven for ClickHouse®
 * Aiven for Grafana®
 * Aiven for InfluxDB®
 * Aiven for MySQL®

--- a/docs/platform/howto/use-google-private-service-connect.rst
+++ b/docs/platform/howto/use-google-private-service-connect.rst
@@ -5,7 +5,7 @@ Use Google Private Service Connect with Aiven services
 
     Google Private Service Connect is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`, which you can request from the sales team (sales@Aiven.io). During the limited availability stage, you can use the feature at no cost. If you want to continue using Google Private Service Connect after it reaches general availability, you'll be billed according to the latest applicable price.
 
-    Google Private Service Connect is only supported for Aiven for Apache Kafka®.
+    Google Private Service Connect is supported for Aiven for Apache Kafka® and Aiven for ClickHouse® only.
 
 Discover Google Private Service Connect and benefits of using it with your Aiven services. Learn how to enable Google Private Service Connect for Aiven services.
 


### PR DESCRIPTION
https://aiven.atlassian.net/browse/DOC-534

Aiven for ClickHouse now supports private link and private connect features.
