### PR TITLE
postgres: Adding docs for creating a read only user.

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1183,6 +1183,7 @@ entries:
               - file: docs/products/postgresql/howto/use-pgvector
                 title: Enable and use pgvector
               - file: docs/products/postgresql/howto/pg-object-size
+              - file: docs/products/postgresql/howto/readonly-user
           - file: docs/products/postgresql/howto/list-replication-migration
             title: Migrate
             entries:

--- a/docs/products/postgresql/howto.rst
+++ b/docs/products/postgresql/howto.rst
@@ -40,7 +40,7 @@ Aiven for PostgreSQL® how-tos
     - :doc:`Prevent PostgreSQL® full disk issues </docs/products/postgresql/howto/prevent-full-disk>`
     - :doc:`Enable and use pgvector on Aiven for PostgreSQL® </docs/products/postgresql/howto/use-pgvector>`
     - :doc:`Check size of a database, a table or an index </docs/products/postgresql/howto/pg-object-size>`
-    - :doc:`Add Read Only User </docs/products/postgresql/howto/readonly-user>`
+    - :doc:`Restrict access to databases or tables in Aiven for PostgreSQL®". </docs/products/postgresql/howto/readonly-user>`
 
 .. dropdown:: Migration
 

--- a/docs/products/postgresql/howto.rst
+++ b/docs/products/postgresql/howto.rst
@@ -40,6 +40,7 @@ Aiven for PostgreSQL® how-tos
     - :doc:`Prevent PostgreSQL® full disk issues </docs/products/postgresql/howto/prevent-full-disk>`
     - :doc:`Enable and use pgvector on Aiven for PostgreSQL® </docs/products/postgresql/howto/use-pgvector>`
     - :doc:`Check size of a database, a table or an index </docs/products/postgresql/howto/pg-object-size>`
+    - :doc:`Add Read Only User </docs/products/postgresql/howto/readonly-user>`
 
 .. dropdown:: Migration
 

--- a/docs/products/postgresql/howto/list-dba-tasks.rst
+++ b/docs/products/postgresql/howto/list-dba-tasks.rst
@@ -39,7 +39,7 @@ Database administration tasks
         :shadow: md
         :margin: 2 2 0 0
 
-    .. grid-item-card:: :doc:`Use the PostgreSQL® pg_repack extension </docs/productspostgresql/howto/use-pg-repack-extension>`
+    .. grid-item-card:: :doc:`Use the PostgreSQL® pg_repack extension </docs/products/postgresql/howto/use-pg-repack-extension>`
         :shadow: md
         :margin: 2 2 0 0
 

--- a/docs/products/postgresql/howto/list-dba-tasks.rst
+++ b/docs/products/postgresql/howto/list-dba-tasks.rst
@@ -39,7 +39,7 @@ Database administration tasks
         :shadow: md
         :margin: 2 2 0 0
 
-    .. grid-item-card:: :doc:`Use the PostgreSQL® pg_repack extension </docs/products/postgresql/howto/use-pg-repack-extension>`
+    .. grid-item-card:: :doc:`Use the PostgreSQL® pg_repack extension </docs/productspostgresql/howto/use-pg-repack-extension>`
         :shadow: md
         :margin: 2 2 0 0
 
@@ -72,5 +72,9 @@ Database administration tasks
         :margin: 2 2 0 0
 
     .. grid-item-card:: :doc:`Check size of a database, a table or an index </docs/products/postgresql/howto/pg-object-size>`
+        :shadow: md
+        :margin: 2 2 0 0
+
+    .. grid-item-card:: :doc:`Restrict access to databases or tables in Aiven for PostgreSQL®". </docs/products/postgresql/howto/readonly-user>`
         :shadow: md
         :margin: 2 2 0 0

--- a/docs/products/postgresql/howto/readonly-user.rst
+++ b/docs/products/postgresql/howto/readonly-user.rst
@@ -1,0 +1,15 @@
+Read Only User for PostgreSQL
+=============================
+In the interest of having users with the least permissions to complete their tasks, one may need a user with read only access to the whole database or a handful of tables. In some cases, we may want this to happen automatically, below are two approaches to complete this task.
+
+All new objects shall have a role with read-only permissions
+------------------------------------------------------------
+1. Alter the default permissions for the role for the given schema: ``ALTER DEFAULT PRIVILEGES FOR ROLE <target role> IN SCHEMA <schema name> abbreviated_grant_or_revoke``
+
+2.  To update any existing database objects, run the following: ``GRANT SELECT ON ALL TABLES IN SCHEMA <schema name> to <myreadonlyrole>;``
+
+Only certain databases should be read-only for users in a particular role:
+==========================================================================
+1. Create a new database which will be used as a template ``CREATE DATABASE ro_<name>_template...``
+2. Update the standardizable information of the database
+3. When creating a new database, use ``CREATE DATABASE <name> WITH TEMPLATE = 'ro_<name>_template'``

--- a/docs/products/postgresql/howto/readonly-user.rst
+++ b/docs/products/postgresql/howto/readonly-user.rst
@@ -21,5 +21,5 @@ Set read-only access in a database
 You can set up the read-only access for a specific user's role in a particular database.
 
 1. Create a new database which will be used as a template ``CREATE DATABASE ro_<name>_template...``
-2. Update the standardizable information of the database
+2. For the new template database, set permissions and roles that you want as default ones in the template.
 3. When creating a new database, use ``CREATE DATABASE <name> WITH TEMPLATE = 'ro_<name>_template'``

--- a/docs/products/postgresql/howto/readonly-user.rst
+++ b/docs/products/postgresql/howto/readonly-user.rst
@@ -1,9 +1,11 @@
 Restrict access to databases or tables in Aiven for PostgreSQL®
 ===============================================================
-This article shows how you can restrict access to Aiven for PostgreSQL® databases and tables by setting up read-only permissions for specific user's roles.
+
+You can restrict access to Aiven for PostgreSQL® databases and tables by setting up read-only permissions for specific user's roles.
 
 Set read-only access in a schema
 --------------------------------
+
 1. Modify default permissions for a user's role in a particular schema.
 
 .. code-block:: bash
@@ -18,8 +20,9 @@ Set read-only access in a schema
 
 Set read-only access in a database
 ----------------------------------
+
 You can set up the read-only access for a specific user's role in a particular database.
 
-1. Create a new database which will be used as a template ``create database ro_<name>_template...``
+1. Create a new database which will be used as a template ``create database ro_<name>_template...``.
 2. For the new template database, set permissions and roles that you want as default ones in the template.
-3. When creating a new database, use ``create database NAME with template = 'ro_<name>_template'``
+3. When creating a new database, use ``create database NAME with template = 'ro_<name>_template'``.

--- a/docs/products/postgresql/howto/readonly-user.rst
+++ b/docs/products/postgresql/howto/readonly-user.rst
@@ -8,18 +8,18 @@ Set read-only access in a schema
 
 .. code-block:: bash
 
-   ALTER DEFAULT PRIVILEGES FOR ROLE NAME_OF_ROLE IN SCHEMA NAME_OF_SCHEMA abbreviated_grant_or_revoke
+   alter default privileges for role name_of_role in schema name_of_schema YOUR_GRANT_OR_REVOKE_PERMISSIONS
 
 2.  Apply the new read-only access setting to your existing database objects that uses the affected schema.
 
 .. code-block:: bash
 
-   GRANT SELECT ON ALL TABLES IN SCHEMA NAME_OF_SCHEMA to NAME_OF_READ_ONLY_ROLE
+   grant select on all tables in schema name_of_schema to NAME_OF_READ_ONLY_ROLE
 
 Set read-only access in a database
 ----------------------------------
 You can set up the read-only access for a specific user's role in a particular database.
 
-1. Create a new database which will be used as a template ``CREATE DATABASE ro_<name>_template...``
+1. Create a new database which will be used as a template ``create database ro_<name>_template...``
 2. For the new template database, set permissions and roles that you want as default ones in the template.
-3. When creating a new database, use ``CREATE DATABASE <name> WITH TEMPLATE = 'ro_<name>_template'``
+3. When creating a new database, use ``create database NAME with template = 'ro_<name>_template'``

--- a/docs/products/postgresql/howto/readonly-user.rst
+++ b/docs/products/postgresql/howto/readonly-user.rst
@@ -1,15 +1,25 @@
-Read Only User for PostgreSQL
-=============================
-In the interest of having users with the least permissions to complete their tasks, one may need a user with read only access to the whole database or a handful of tables. In some cases, we may want this to happen automatically, below are two approaches to complete this task.
+Restrict access to databases or tables in Aiven for PostgreSQL®
+===============================================================
+This article shows how you can restrict access to Aiven for PostgreSQL® databases and tables by setting up read-only permissions for specific user's roles.
 
-All new objects shall have a role with read-only permissions
-------------------------------------------------------------
-1. Alter the default permissions for the role for the given schema: ``ALTER DEFAULT PRIVILEGES FOR ROLE <target role> IN SCHEMA <schema name> abbreviated_grant_or_revoke``
+Set read-only access in a schema
+--------------------------------
+1. Modify default permissions for a user's role in a particular schema.
 
-2.  To update any existing database objects, run the following: ``GRANT SELECT ON ALL TABLES IN SCHEMA <schema name> to <myreadonlyrole>;``
+.. code-block:: bash
 
-Only certain databases should be read-only for users in a particular role:
-==========================================================================
+   ALTER DEFAULT PRIVILEGES FOR ROLE NAME_OF_ROLE IN SCHEMA NAME_OF_SCHEMA abbreviated_grant_or_revoke
+
+2.  Apply the new read-only access setting to your existing database objects that uses the affected schema.
+
+.. code-block:: bash
+
+   GRANT SELECT ON ALL TABLES IN SCHEMA NAME_OF_SCHEMA to NAME_OF_READ_ONLY_ROLE
+
+Set read-only access in a database
+----------------------------------
+You can set up the read-only access for a specific user's role in a particular database.
+
 1. Create a new database which will be used as a template ``CREATE DATABASE ro_<name>_template...``
 2. Update the standardizable information of the database
 3. When creating a new database, use ``CREATE DATABASE <name> WITH TEMPLATE = 'ro_<name>_template'``


### PR DESCRIPTION
# What changed, and why it matters
Added a page on how to create read only users' on our platform. Helpful for deflecting support requests. Reached out to the SME's about some possible approaches for creating read only users on our platform. Useful in cases where a customer wants to limit a users' ability to access data. 