### PR TITLE
Udpated note about OpenSearch Dashboards availability

### DIFF
--- a/docs/platform/concepts/maintenance-window.rst
+++ b/docs/platform/concepts/maintenance-window.rst
@@ -18,8 +18,8 @@ In case of **Apache Kafka®** and **OpenSearch®** the service DNS address resol
 
     While the DNS name remains the same, the IP address it points to, will change during a maintenance break. To know more about static IP addresses, check the :doc:`related documentation <static-ips>`.
 
-.. warning:: 
-    OpenSearch Dashboards will be **not accessible** during a **maintenance update** that also consists of version updates to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. The dashboards will be accessible again once the update is completed.
+.. note:: 
+    Starting with Aiven for OpenSearch® versions 1.3.13 and 2.10, OpenSearch Dashboards will remain available during a maintenance update that also consists of version updates to your Aiven for OpenSearch service.
 
 Maintenance updates
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/products/opensearch/dashboards.rst
+++ b/docs/products/opensearch/dashboards.rst
@@ -11,8 +11,8 @@ Get started with Aiven for OpenSearch Dashboards
 
 Take your first steps with Aiven for OpenSearch Dashboards by following our :doc:`/docs/products/opensearch/dashboards/getting-started` article.
 
-.. warning:: 
-    OpenSearch Dashboards will be **not accessible** during a **maintenance update** that also consists of version updates to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates. The dashboards will be accessible again once the update is completed.
+.. note:: 
+    Starting with Aiven for OpenSearch® versions 1.3.13 and 2.10, OpenSearch Dashboards will remain available during a maintenance update that also consists of version updates to your Aiven for OpenSearch service.
 
 Ways to use OpenSearch Dashboards
 ---------------------------------

--- a/docs/products/opensearch/dashboards/getting-started.rst
+++ b/docs/products/opensearch/dashboards/getting-started.rst
@@ -3,9 +3,9 @@ Getting started
 
 To start using **Aiven for OpenSearch® Dashboards**, :doc:`create Aiven for OpenSearch® service first</docs/products/opensearch/getting-started>` and OpenSearch Dashboards service will be added alongside it. Once the Aiven for OpenSearch service is running you can find connection information to your OpenSearch Dashboards in the service overview page and use your favourite browser to access OpenSearch Dashboards service.
 
-.. warning:: 
+.. note:: 
 
-    OpenSearch Dashboards will be **not accessible** during a **maintenance update** that also consists of version updates to your Aiven for OpenSearch service. The duration of the maintenance window can vary based on the updates.The dashboards will be accessible again once the update is completed.
+    Starting with Aiven for OpenSearch® versions 1.3.13 and 2.10, OpenSearch Dashboards will remain available during a maintenance update that also consists of version updates to your Aiven for OpenSearch service.
 
 
 Load sample data


### PR DESCRIPTION
# What changed, and why it matters

Starting with OS version 1.3.13 and OS 2.10 OSD will be available during minor version upgrades. 
Changed the warning message to note 
