### PR TITLE
Remove outdated note about payment cards

### DIFF
--- a/docs/platform/howto/use-billing-groups.rst
+++ b/docs/platform/howto/use-billing-groups.rst
@@ -21,8 +21,6 @@ To change the payment card, address, billing contacts, or other billing details:
 
 #. On the **Billing information** tab click **Edit** to update the details for that section.
 
-.. note:: You can :doc:`add or update payment card details</docs/platform/howto/manage-payment-card/>` on the user information page. 
-
 Assign projects to a billing group
 """"""""""""""""""""""""""""""""""
 


### PR DESCRIPTION
# What changed, and why it matters
Previously, a note was added to the billing group page about credit cards being managed in the user information section. As this has now moved under the billing section, no note is needed here.


