### PR TITLE
Update free plan docs - Aiven for MySQL does not have connection pooling

### DIFF
--- a/docs/platform/concepts/free-plan.rst
+++ b/docs/platform/concepts/free-plan.rst
@@ -33,7 +33,7 @@ There are some limitations of the free plan services:
 * No VPC peering
 * No external service integrations
 * No forking
-* For PostgreSQL and MySQL: no connection pooling
+* For PostgreSQL: no connection pooling
 * Support only through the `Aiven Community Forum <https://aiven.io/community/forum/>`_
 * Only a limited number of AWS regions, no other cloud providers
 * Only one service per service type per user and :doc:`organization </docs/platform/concepts/projects_accounts_access>`


### PR DESCRIPTION
# What changed, and why it matters

Currently, the docs state that we do not offer connection pooling on free MySQL plans. While this is technically correct, it is misleading given we do not offer it on paid plans either. Therefore it should be removed and we should only state that we do not offer connection pooling for PostgreSQL on free plans, i.e. pgBouncer is not included.
