### PR TITLE
Updated note for TS to limited availability

### DIFF
--- a/docs/products/kafka/concepts/kafka-tiered-storage.rst
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.rst
@@ -5,7 +5,7 @@ Tiered storage in Aiven for Apache Kafka® enables more effective data managemen
 
 .. important:: 
 
-    Aiven for Apache Kafka® tiered storage is an early availability feature, which means it has some restrictions on the functionality and service level agreement. It is intended for non-production environments, but you can test it with production-like workloads to assess the performance. To enable this feature, navigate to the :doc:`Feature preview </docs/platform/howto/feature-preview>` page within your user profile.
+    Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 
 .. note:: 

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.rst
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.rst
@@ -1,6 +1,10 @@
 How tiered storage works in Aiven for Apache Kafka®
 ===================================================
 
+.. important:: 
+  
+  Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
+
 Aiven for Apache Kafka® tiered storage is a feature that optimizes data management across two distinct storage tiers:
 
 * **Local tier**: Primarily consists of faster and typically more expensive storage solutions like solid-state drives (SSDs).

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.rst
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.rst
@@ -5,7 +5,7 @@ Aiven for Apache Kafka® offers flexibility in configuring tiered storage and se
 
 .. important:: 
     
-   Aiven for Apache Kafka® tiered storage is an early availability feature, which means it has some restrictions on the functionality and service level agreement. It is intended for non-production environments, but you can test it with production-like workloads to assess the performance. To enable this feature, navigate to the :doc:`Feature preview </docs/platform/howto/feature-preview>` page within your user profile.
+    Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 Prerequisite
 ------------

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.rst
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.rst
@@ -4,7 +4,7 @@ Learn how to enable tiered storage capability of Aiven for Apache Kafka®. This 
 
 .. important:: 
     
-   Aiven for Apache Kafka® tiered storage is an early availability feature, which means it has some restrictions on the functionality and service level agreement. It is intended for non-production environments, but you can test it with production-like workloads to assess the performance. To enable this feature, navigate to the :doc:`Feature preview </docs/platform/howto/feature-preview>` page within your user profile.
+   Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 Prerequisites
 --------------

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.rst
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.rst
@@ -8,7 +8,7 @@ For an in-depth understanding of tiered storage, how it works, and its benefits,
 
 .. important:: 
     
-   Aiven for Apache Kafka® tiered storage is an early availability feature, which means it has some restrictions on the functionality and service level agreement. It is intended for non-production environments, but you can test it with production-like workloads to assess the performance. To enable this feature, navigate to the :doc:`Feature preview </docs/platform/howto/feature-preview>` page within your user profile.
+    Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 Enable tiered storage for service
 ----------------------------------

--- a/docs/products/kafka/howto/tiered-storage-overview-page.rst
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.rst
@@ -5,7 +5,7 @@ Aiven for Apache Kafka® offers a comprehensive overview of tiered storage, allo
 
 .. important:: 
    
-   Aiven for Apache Kafka® tiered storage is an early availability feature, which means it has some restrictions on the functionality and service level agreement. It is intended for non-production environments, but you can test it with production-like workloads to assess the performance. To enable this feature, navigate to the :doc:`Feature preview </docs/platform/howto/feature-preview>` page within your user profile.
+   Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you’re interested in trying out this feature, contact the sales team at sales@Aiven.io.
 
 
 Access tiered storage overview


### PR DESCRIPTION
# What changed, and why it matters

Updated the note for Kafka tiered storage topics to indicate that it is a limited availability feature and contact sales to enable it.