### PR TITLE
OS plugins included info about submitting Aiven idea

### DIFF
--- a/docs/products/opensearch/reference/plugins.rst
+++ b/docs/products/opensearch/reference/plugins.rst
@@ -37,4 +37,4 @@ These plugins are enabled on all Aiven for OpenSearch services by default:
 
 Can't find the plugin you need?
 `````````````````````````````````````````````
-If you need a plugin but don't see it here, submit your request through our `Aiven Ideas <https://ideas.aiven.io/>`_ portal. We're always looking to expand our offerings, and your feedback and ideas play a crucial role in shaping the future updates of our product.
+If you need a plugin but don't see it here, submit your request through our `Aiven Ideas <https://ideas.aiven.io/>`_ portal. We're always looking to expand our offerings, and your feedback and ideas are important in shaping the future updates of our product.

--- a/docs/products/opensearch/reference/plugins.rst
+++ b/docs/products/opensearch/reference/plugins.rst
@@ -31,9 +31,10 @@ These plugins are enabled on all Aiven for OpenSearch services by default:
 * `OpenSearch neural search <https://opensearch.org/docs/latest/search-plugins/neural-search/>`__
 * `OpenSearch notifications <https://opensearch.org/docs/latest/observing-your-data/notifications/index/>`__
 
-------
-
 .. note::
     The **Notebooks** and **OpenSearch notification** plugins are part of **OpenSearch observability**.
 
 
+Can't find the plugin you need?
+`````````````````````````````````````````````
+If you need a plugin but don't see it here, submit your request through our `Aiven Ideas <https://ideas.aiven.io/>`_ portal. We're always looking to expand our offerings, and your feedback and ideas play a crucial role in shaping the future updates of our product.


### PR DESCRIPTION
# What changed, and why it matters

There was an ask that on the [OpenSearch’s available plugin page](https://docs.aiven.io/docs/products/opensearch/reference/plugins) append information about requesting plugins or extensions that are not listed through our [Aiven Ideas](https://ideas.aiven.io/) portal - [DOC-524](https://aiven.atlassian.net/browse/DOC-524)

In the PR, add text for users to submit an idea for any missing plugin. 






[DOC-524]: https://aiven.atlassian.net/browse/DOC-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ