### PR TITLE
added extra workaround to the KStream bug

### DIFF
--- a/docs/products/kafka/reference/kstream-data-write-issue.rst
+++ b/docs/products/kafka/reference/kstream-data-write-issue.rst
@@ -3,23 +3,23 @@ Resolving data write issue on Apache Kafka® Streams 3.6.0
 
 Issue description
 ------------------
-If you are encountering an ``UNKNOWN_SERVER_ERROR`` while producing data using Apache Kafka® Streams version 3.6.0, it may result in the prevention of data writing. This issue has been identified and logged in the Apache Kafka® project's issue tracker with the reference: `Kafka-15653 <https://issues.apache.org/jira/browse/KAFKA-15653>`_.
-
-This could lead to errors in broker logs as,
+If you get the ``UNKNOWN_SERVER_ERROR`` error while generating data using Apache Kafka® Streams **version 3.6.0**, it may result in data write issues.
+and errors in broker logs such as:
 
 .. code-block:: bash
 
     "Error processing append operation on partition XXXX (kafka.server.ReplicaManager) java.lang.NullPointerException."
 
+This issue is known to the Apache Kafka® project. See `Kafka-15653 <https://issues.apache.org/jira/browse/KAFKA-15653>`_.
 
 Solution
 --------
-**Recommended solution:** To address this issue, it is recommended to upgrade your Apache Kafka® Streams clients to version 3.6.1. This version contains the necessary fixes to resolve the ``UNKNOWN_SERVER_ERROR``.
 
-**Quick workaround:** Alternatively, in the event of encountering a failure requiring an immediate remedy, users can set the ``transaction_partition_verification_enable`` parameter to ``false`` under advanced configuration of the service. This configuration allows Kafka to accept messages despite the existing bug.
+- **Recommended solution:** It is recommended to upgrade your Apache Kafka® Streams clients to **version 3.6.1**.
+- **Alternative solution:** Alternatively, in case of a failure requiring an immediate fix, users
+  can set the ``transaction_partition_verification_enable`` parameter to ``false`` under advanced configuration of the service. This allows Kafka to accept messages despite the existing bug.
 
-.. Important::
-    However, it is essential to re-enable ``transaction_partition_verification_enable``  setting once the client is upgraded.
+  .. Important::
+     When you can update to 3.6.1, do not forget to set ``transaction_partition_verification_enable`` to ``true``.
 
-.. Note::
-    If the issue persists even after trying the above remedies, please reach out to our support team for further assistance.
+If the issue persists even after trying these solutions, reach out to our support team.

--- a/docs/products/kafka/reference/kstream-data-write-issue.rst
+++ b/docs/products/kafka/reference/kstream-data-write-issue.rst
@@ -14,8 +14,12 @@ This could lead to errors in broker logs as,
 
 Solution
 --------
-To address this issue, it is recommended to upgrade your Apache Kafka® Streams clients to version 3.6.1. This version contains the necessary fixes to resolve the ``UNKNOWN_SERVER_ERROR``.
+**Recommended solution:** To address this issue, it is recommended to upgrade your Apache Kafka® Streams clients to version 3.6.1. This version contains the necessary fixes to resolve the ``UNKNOWN_SERVER_ERROR``.
 
+**Quick workaround:** Alternatively, in the event of encountering a failure requiring an immediate remedy, users can set the ``transaction_partition_verification_enable`` parameter to ``false`` under advanced configuration of the service. This configuration allows Kafka to accept messages despite the existing bug.
+
+.. Important::
+    However, it is essential to re-enable ``transaction_partition_verification_enable``  setting once the client is upgraded.
 
 .. Note::
-    If the issue persists even after upgrading Apache Kafka® Streams to 3.6.1 version, please reach out to our support team for further assistance.
+    If the issue persists even after trying the above remedies, please reach out to our support team for further assistance.


### PR DESCRIPTION
We recently exposed a user-config for this issue as a workaround. Added additional details to leverage the workaround in case the customers wanted quick remedy.
More details: https://aiven-io.slack.com/archives/C066M97D679/p1700836968902459?thread_ts=1700812250.838659&cid=C066M97D679


