### PR TITLE
feat: remove code block from algolia index

### DIFF
--- a/scripts/index_algolia.py
+++ b/scripts/index_algolia.py
@@ -44,6 +44,10 @@ def parse_pages(html_build_dir):
                 for admonition in elements.select('div.admonition'):
                     admonition.decompose()
 
+                # remove code block
+                for code in elements.select('div.highlight-shell.notranslate'):
+                    code.decompose()
+
                 # remove tables of contents
                 for toc in elements.select('div.toctree-wrapper'):
                     toc.decompose()


### PR DESCRIPTION
## Issues
We got an error while indexing document pages
See: https://github.com/aiven/devportal/actions/workflows/index-devportal.yaml

![CleanShot 2023-11-27 at 16 11 44](https://github.com/aiven/devportal/assets/26871154/d798b7f0-4886-47ff-9562-0e7171ae4907)

The reason is that[ this record](https://docs.aiven.io/docs/products/cassandra/reference/cassandra-metrics-prometheus) is too big (167k bytes while our plan allows only 100k bytes) to upload to Algolia. 


## Solution
I remove the code block from the document, aiming to reduce the file size. Based on the search data on the website aiven.io, users barely search for the code block

![CleanShot 2023-11-28 at 09 58 45](https://github.com/aiven/devportal/assets/26871154/78419a98-9e9c-4f0b-bd89-0b9b17fb15a5)
