### PR TITLE
Update technical contacts article

### DIFF
--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -3,7 +3,7 @@ Manage project and service notifications
 
 To stay up to date with the latest information about services and projects, you can set service and project contacts to receive email notifications. Notifications include information about plan sizes, performance, outages, and scheduled maintenance. 
 
-The contacts for a project can be set to the admin and operators of that project, or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a separate service contact for a service.
+The contacts for a project can be set to the admin and operators of that project (this is the default), or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a separate service contact for a service.
 
 Service contacts by default are the project contacts. However, if you set other email addresses as serivce contacts for a service, email notifications will only be sent to those contacts for that specific service.
 
@@ -23,11 +23,11 @@ Set project contacts
 Set service contacts 
 """""""""""""""""""""
 
-#. In the service, open the menu in the top right.
+#. In the service, click **Service settings**.
 
-#. Select **Change service contacts**.
+#. In the **Service status** section, open the menu in the top right and select **Change service contacts**.
 
-#. Select the contacts that you want to receive email notifications.
+#. Select the contacts that you want to receive email notifications for this service.
 
 #. Click **Save**. 
 
@@ -42,7 +42,7 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
    .. note::
        If you don't see the email integrations option, ask the owner or admin of the workspace or organization to `allow incoming emails <https://slack.com/help/articles/360053335433-Manage-incoming-emails-for-your-workspace-or-organization>`_.
 
-#. In the Aiven Console, go to the project that you want to get notifications for.
+#. In the `Aiven Console <https://console.aiven.io/>`_, go to the project or service that you want to get notifications for.
 
 #. Follow the instructions to set the Slack email address as a :ref:`project contact <set-project-contacts>` or :ref:`service contact <set-service-contacts>`.
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -3,7 +3,7 @@ Manage project and service notifications
 
 To stay up to date with the latest information about services and projects, you can set service and project contacts to receive email notifications. Notifications include information about plan sizes, performance, outages, and scheduled maintenance. 
 
-The contacts for a project can be set to the admin and operators of that project, or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a seperate service contact for a service.
+The contacts for a project can be set to the admin and operators of that project, or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a separate service contact for a service.
 
 Service contacts by default are the project contacts. However, if you set other email addresses as serivce contacts for a service, email notifications will only be sent to those contacts for that specific service.
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,9 +1,11 @@
-Get technical notifications
-============================
+Manage project and service notifications
+=========================================
 
 To stay up to date with the latest news about the services in a project, you can set up notifications for technical contacts for the project. If you don't add a technical email for a project, email notifications will still be sent to users with admin and operator roles.
 
 Notifications include information about plan sizes, performance, outages and scheduled maintenance. High priority notifications (for example, a plan running out of space) are also sent to project admin users. 
+
+.. _set_contacts:
 
 Set up email notifications
 """""""""""""""""""""""""""
@@ -13,6 +15,7 @@ Set up email notifications
 #. In the **Technical Emails** section, add the email addresses.
 
 #. Click **Save changes**. 
+
 
 Set up Slack notifications
 """""""""""""""""""""""""""
@@ -26,11 +29,6 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
 
 #. In the Aiven Console, go to the project that you want to get notifications for.
 
-#. Click **Settings**.
-
-#. In the **Technical Emails** section, add the email address that you created for the Slack channel or  DM.                
-
-
-#. Click **Save changes**. 
+#. Follow the instructions to :ref:`set the Slack email address as a project or service contact <set_contacts>`.
 
 Alternatively, you can `set up a Slackbot forwarding address <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WE06MBF06BBHQNZ1G0H2K5>`_ and use that to automatically forward Aiven's email notifications from your email client.

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -5,7 +5,7 @@ To stay up to date with the latest information about services and projects, you 
 
 The contacts for a project can be set to the admin and operators of that project (this is the default), or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a separate service contact for a service.
 
-Service contacts by default are the project contacts. However, if you set other email addresses as serivce contacts for a service, email notifications will only be sent to those contacts for that specific service.
+Service contacts by default are the project contacts. However, if you set other email addresses as service contacts for a service, email notifications will only be sent to those contacts for that specific service.
 
 .. _set-project-contacts:
 

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,20 +1,35 @@
 Manage project and service notifications
 =========================================
 
-To stay up to date with the latest news about the services in a project, you can set up notifications for technical contacts for the project. If you don't add a technical email for a project, email notifications will still be sent to users with admin and operator roles.
+To stay up to date with the latest information about services and projects, you can set service and project contacts to receive email notifications. Notifications include information about plan sizes, performance, outages and scheduled maintenance. 
 
-Notifications include information about plan sizes, performance, outages and scheduled maintenance. High priority notifications (for example, a plan running out of space) are also sent to project admin users. 
+The contacts for a project can be set to the admin and operators of that project, or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a seperate service contact for a service.
 
-.. _set_contacts:
+Service contacts by default are the project contacts. However, if you set other email addresses as serivce contacts for a service, email notifications will only be sent to those contacts for that specific service.
 
-Set up email notifications
-"""""""""""""""""""""""""""
+.. _set-project-contacts:
+
+Set project contacts 
+"""""""""""""""""""""
 
 #. In the project, click **Settings**.
 
-#. In the **Technical Emails** section, add the email addresses.
+#. On the **Notifications** tab, select the project contacts that you want to receive email notifications.
 
 #. Click **Save changes**. 
+
+.. _set-service-contacts:
+
+Set service contacts 
+"""""""""""""""""""""
+
+#. In the service, open the menu in the top right.
+
+#. Select **Change service contacts**.
+
+#. Select the contacts that you want to receive email notifications.
+
+#. Click **Save**. 
 
 
 Set up Slack notifications
@@ -29,6 +44,6 @@ To get notifications in Slack, you can add a Slack channel's or DM email address
 
 #. In the Aiven Console, go to the project that you want to get notifications for.
 
-#. Follow the instructions to :ref:`set the Slack email address as a project or service contact <set_contacts>`.
+#. Follow the instructions to set the Slack email address as a :ref:`project contact <set-project-contacts>` or :ref:`service contact <set-service-contacts>`.
 
 Alternatively, you can `set up a Slackbot forwarding address <https://slack.com/help/articles/206819278-Send-emails-to-Slack#h_01F4WE06MBF06BBHQNZ1G0H2K5>`_ and use that to automatically forward Aiven's email notifications from your email client.

--- a/docs/platform/howto/technical-emails.rst
+++ b/docs/platform/howto/technical-emails.rst
@@ -1,7 +1,7 @@
 Manage project and service notifications
 =========================================
 
-To stay up to date with the latest information about services and projects, you can set service and project contacts to receive email notifications. Notifications include information about plan sizes, performance, outages and scheduled maintenance. 
+To stay up to date with the latest information about services and projects, you can set service and project contacts to receive email notifications. Notifications include information about plan sizes, performance, outages, and scheduled maintenance. 
 
 The contacts for a project can be set to the admin and operators of that project, or to specific email addresses. Project contacts receive notifications about the project. They also receive the notifications for all services, unless you set a seperate service contact for a service.
 


### PR DESCRIPTION
# What changed, and why it matters
The settings for who receives notifications are changing, allowing users to set project and service level contacts.

