### PR TITLE
Add verification tag for Zendesk

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -5,6 +5,9 @@
 
 <meta name="description" content="{{ body|striptags|replace("\u00B6", '')|truncate(160) }}">
 
+<!-- Zendesk -->
+<meta name="zd-site-verification" content="ocz0liuu2tgqzafi4d9mp">
+
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@aiven_io">


### PR DESCRIPTION
# What changed, and why it matters
Add verification tag to allow Zendesk to crawl the docs site for its federated search.


