### PR TITLE
Fix cloud list GitHub Action

### DIFF
--- a/.github/workflows/cloud-list.yaml
+++ b/.github/workflows/cloud-list.yaml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# What changed, and why it matters

Switch to Python 3.11 and latest version of setup-python action.

