### PR TITLE
Updated audit log content for OS Security

### DIFF
--- a/docs/products/opensearch/howto/audit-logs.rst
+++ b/docs/products/opensearch/howto/audit-logs.rst
@@ -1,4 +1,4 @@
-Enable, configure, and visualize OpenSearch® Audit logs
+Enable and manage OpenSearch® Audit logs
 ===============================================================
 
 Aiven for OpenSearch® enables audit logging functionality via the OpenSearch Security dashboard, which allows OpenSearch Security administrators to track system events, security-related events, and user activity. These audit logs contain information about user actions, such as login attempts, API calls, index operations, and other security-related events. 
@@ -10,9 +10,23 @@ Prerequisites
 * Aiven for OpenSearch® service
 * :doc:`OpenSearch Security management enabled </docs/products/opensearch/howto/enable-opensearch-security>` for the Aiven for OpenSearch service 
 
+After enabling audit logs in the service's advanced configuration, proceed to enable them in the OpenSearch® Security dashboard.
 
-Enable audit logs
----------------------
+Enabling audit logs in Aiven for OpenSearch
+----------------------------------------------
+By default, audit logs are disabled in Aiven for OpenSearch. To enable them:
+
+1. Access your Aiven for OpenSearch service in the Aiven Console. 
+2. From the left sidebar, click **Service settings**
+3. Scroll to the **Advanced configuration** and click **Configure**. 
+4. In the **Advanced configuration** dialog, click **Add configuration to options**. 
+5. Use the search function to locate the ``enable_security_audit`` configuration and switch it to the **Enabled** position.
+6. Click **Save configuration** to save your changes and enable audit logging. 
+
+After enabling audit logs in the service's advanced configuration, proceed to enable them in the OpenSearch® Security dashboard.
+
+Enable audit logs in OpenSearch® Security dashboard
+-----------------------------------------------------
 To enable audit logs in OpenSearch® Security dashboard, follow these steps: 
 
 1. Log in to the OpenSearch® Dashboard using OpenSearch® Security admin credentials.
@@ -41,36 +55,25 @@ The following are the types of audit events recorded by OpenSearch:
 Configure audit logging 
 ------------------------
 
-The audit logging settings in OpenSearch® Security can be tailored to meet your organization's requirements by customizing the *General* and *Compliance* settings sections. The following are the available settings for each section:
+Customize the audit logging settings in OpenSearch® Security to align with your organization's specific requirements. The configuration process involves two primary sections: General and Compliance settings, each offering distinct options:
 
-General settings
-```````````````````
-* **Layer settings**: This section allows you to enable or disable logging for the REST and Transport layers. You can also exclude specific categories of events from being logged, such as events related to user authentication, to reduce noise in the logs.
-* **Attribute settings**: This section allows customization of log data for each event, including options to log the request body, resolved indices, and sensitive headers. Additionally, there is an option to enable or disable logging for bulk requests.
-* **Ignore settings**: This section allows you to exclude specific users or requests from being logged. This is useful for excluding internal users or automated processes that generate a lot of noise in the logs.
+* **General settings:** Adjust logging for REST and Transport layers, tailor log data for each event, and set preferences to selectively exclude specific users or requests, ensuring log relevance and operational efficiency.
+* **Compliance settings:** Enable compliance mode to meet regulatory standards and activate tamper-evident logging. You can also enable logging for internal and external configuration changes as well as metadata logging options for a robust security posture.
 
-Compliance settings 
-`````````````````````
-* **Compliance mode**: This enables logging of all events in a tamper-evident manner, which prevents deletion or modification of logs, ensuring compliance with specific regulations or standards.
-* **Config**: This enables logging of changes to OpenSearch Security configuration files, allowing you to monitor security policies and settings changes.
-* **Internal config logging**: This enables logging of events on the internal security index, allowing you to monitor changes to the OpenSearch Security configuration made by internal users or processes.
-* **External config logging**: This enables logging of external configuration changes, allowing you to monitor changes to external authentication providers or other systems integrated with OpenSearch Security.
-* **Read metadata and write metadata options**: This enables metadata logging for read and write operations. You can also exclude specific users or watched fields from being logged.
-
-..note: 
+.. note:: 
    
    * You cannot modify the name of the audit log index for your Aiven for OpenSearch service as it is set to the default name ``auditlog-YYYY.MM.dd``. 
    * You cannot change the size of the thread pool using ``OpenSearch.yml``. 
 
 Optimize audit log configuration
 `````````````````````````````````
-Optimizing the configuration of audit logs in OpenSearch Security can ensure that your OpenSearch Security system is logging only the necessary information and protecting sensitive data from unauthorized access.
+Optimize audit log configuration in OpenSearch Security to protect sensitive data from unauthorized access.
 
-* **Exclude categories**: To make it easier to identify important events and reduce the amount of data stored, consider excluding categories of events irrelevant to your security policies. For example, you may not need to log every successful login event, but may want to log all failed login attempts.
-* **Disable Rest and transport layers**: By disabling logging for Rest and Transport layers, you can prevent sensitive information such as passwords and usernames from being logged. These layers are used to communicate with OpenSearch cluster nodes and may contain sensitive data.
-* **Disable request body logging**: To prevent the logging of sensitive information such as credit card numbers and personal information, consider disabling request body logging. This can help prevent unauthorized access to sensitive data.
-* **Additional configuration options**: Depending on your specific security requirements and policies, you may want to configure additional options such as disabling logging of all affected index names from an alias or wildcard, configuring bulk request handling, excluding specific requests or users from logs, configuring the audit log index name, and tuning the thread pool.
-* **Regular review and maintenance**: It is essential to periodically review and maintain your audit log configuration to ensure that it is up-to-date with your security policies and requirements. This can help you identify potential security threats and take action to prevent them.
+* Exclude irrelevant event categories.
+* Consider disabling logging for Rest and Transport layers.
+* Disable request body logging for sensitive information.
+* Regularly review and maintain audit log configuration.
+
 
 Visualize audit log 
 --------------------
@@ -78,27 +81,11 @@ Visualizing audit logs is an effective way to understand the extensive data gene
 
 To access and visualize audit logs in OpenSearch, follow the steps below:
 
-1. **Create an index pattern**: 
-   
-   a. Go to the OpenSearch Dashboards left side menu and select **Stack Management**. 
-   b. Select on **Index Patterns** and select **Create index pattern**. 
-   c. Enter the name of the index that contains the audit logs and follow the prompts to complete the index pattern creation process.
+1. **Create an index pattern**: In the **Stack Management** section, establish an index pattern to organize your log data.
 
-2. **Create a visualization**: 
-   
-   a. Select **Visualize** in the OpenSearch Dashboards left side menu, and then select **Create new visualization** or **Create visualization** if there are already saved visualizations.
-   b. Choose the type of visualization you want to create and select the index pattern you created in the previous step.
-   c. Choose the specific fields you want to display in your visualization.
+2. **Create a visualization**: Navigate to the **Visualize** section, where you can design and tailor visualizations to suit your analysis needs.
 
-3. **Save visualization**:
-   
-   a. Select **Save** in the top right corner of the dashboard.
-   b. In the **Save visualization** screen, enter a title and description for the visualization.
-   c. Click Save.
-
-4. **Modify visualization**: 
-   
-   To make changes to a visualization, in the **Visualization** screen, select the pencil icon next to the visualization you want to modify, make the desired changes, and save them.
+3. **Save and modify visualization**: Once you've created a visualization, save it for future reference. You can always return to modify and update it as your requirements evolve
 
 
 Related reading


### PR DESCRIPTION
# What changed, and why it matters


Audit log in Aiven for OpenSearch is disabled by default for all services. Users need to enable it via the advanced configuration (``enable_security_audit``) and then enable it on the OSS dashboard. 

ref: https://github.com/aiven/aiven-core/pull/41854