### PR TITLE
Added missing service type config for DF adv parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ service-type-config-redis:
 service-type-config-influxdb:
 	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "influxdb" "includes/config-influxdb.rst"
 
+service_type_config-dragonfly:
+	python "$(SOURCEDIR)/scripts/aiven/service_type_config.py" "dragonfly" "includes/config-dragonfly.rst"
+
 # TODO: add automation for "pg". See https://github.com/aiven/devportal/issues/1026
 
 # (Re)Generate cloud listing


### PR DESCRIPTION
# What changed, and why it matters

In order to generate the advanced parameter documentation for Dragonfly, the configurations in the makefile and `includes` folder were missing. Dragonfly was added to `service_type_config`, and a new `config-dragonfly.rst` file was created in the /includes folder to store the advanced parameters.

ref: [Dragonfly - Create PR to Update Advanced parameters](https://github.com/aiven/devportal/actions/workflows/advanced-params-dragonfly.yaml)