### PR TITLE
Clarify Add Kafka producer and consumer Datadog metrics

### DIFF
--- a/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
+++ b/docs/products/kafka/howto/add-missing-producer-consumer-metrics.rst
@@ -1,8 +1,6 @@
-Add ``kafka.producer.`` and ``kafka.consumer`` Datadog metrics
-==============================================================
+Add client-side Apache Kafka® producer and consumer Datadog metrics
+===================================================================
 
 When you enable the :doc:`Datadog integration </docs/integrations/datadog/datadog-metrics>` in Aiven for Apache Kafka®, the service supports all of the broker-side metrics listed in the `Datadog Kafka integration documentation <https://docs.datadoghq.com/integrations/kafka/?tab=host#data-collected>`_ and allows you to send additional :doc:`custom metrics <datadog-customised-metrics>`.
 
-However, all metrics that have a prefix like ``kafka.producer.*`` or ``kafka.consumer.*`` are client-side metrics that should be collected from the producer or consumer, and sent to Datadog.
-
-The dedicated `Datadog documentation <https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka>`_ (see "Missing producer and consumer metrics" chapter) provides a way to include the missing metrics natively for Java based producers and consumers or via `DogStatsD <https://docs.datadoghq.com/developers/dogstatsd/>`_ for clients in other languages.
+Additionally, you can collect client-side metrics directly from the producer or consumer and send them to Datadog. For guidance, refer to the *Missing producer and consumer metrics* section in the `Datadog documentation <https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka>`_, which outlines the process for integrating missing metrics natively for Java-based producers and consumers. For clients using languages other than Java, incorporating these metrics can be achieved through `DogStatsD <https://docs.datadoghq.com/developers/dogstatsd/>`_.


### PR DESCRIPTION
# What

First, remove the false claim that kafka.producer.* and kafka.consumer.* metrics are client side. Some broker-side metrics also have the prefix.

Change the topic to clearly state the page is about client-side metrics.

# Why

It was unclear this page is only about client side metrics and the claim of those metrics prefixes being client-side only is not correct.