### PR TITLE
Added info about SSL certificate renewal timelines

### DIFF
--- a/docs/products/kafka/howto/renew-ssl-certs.rst
+++ b/docs/products/kafka/howto/renew-ssl-certs.rst
@@ -1,13 +1,16 @@
-Renew and Acknowledge service user SSL certificates
+Renew and acknowledge service user SSL certificates
 ===================================================
 In every Aiven for Apache Kafka® service, when the existing service user SSL certificate is close to expiration (approximately 3 months before the expiration date), a new certificate is automatically generated, including the renewal of the private key. 
 
-During the renewal process, both the SSL certificate and its corresponding private key are regenerated. This approach is implemented to enhance overall security and maintain the certificate's integrity.
 
-The project admins, operators, and tech email addresses associated with the service are notified about this certificate renewal.
+SSL certificate renewal schedule
+---------------------------------------------
 
-The old certificate remains functional until its expiration date, allowing for a seamless transition to the new certificate.
+SSL certificates for Aiven for Apache Kafka® services remain valid for 820 days (approximately 2 years and 3 months). To ensure uninterrupted service and enhance security, these certificates are renewed every 2 years as a proactive measure.
 
+Each renewal process involves regenerating both the SSL certificate and its private key, reinforcing security and preserving integrity. Notifications about certificate renewals are sent to project admins, operators, and technical contacts associated with the service.
+
+The existing certificate stays operational until its expiration date, allowing for a seamless transition to the new certificate.
 
 
 Download the new SSL certificates
@@ -15,16 +18,18 @@ Download the new SSL certificates
 
 The renewed SSL certificate is immediately available for download in the `Aiven Console <https://console.aiven.io/>`_, `API <https://api.aiven.io/doc/>`_, and :doc:`Aiven CLI </docs/tools/cli>` after the notification.
 
-When accessing the `Aiven Console <https://console.aiven.io/>`_ service page for the Aiven for Apache Kafka service with expiring certificates, you'll be notified with the following message:
+When accessing the `Aiven Console <https://console.aiven.io/>`_ service page for the Aiven for Apache Kafka service with expiring certificates, you will be notified with the following message:
 
 .. image:: /images/products/kafka/ssl-cert-renewal.png
    :alt: Apache Kafka service user SSL certificate expiring message
 
-You can download the new certificate from the `Aiven Console <https://console.aiven.io/>`_ by: 
 
-* Accessing the Aiven for Apache Kafka service for which you want to download the new certificate.
-* Selecting **Users** from the left sidebar. 
-* Selecting **Show access key** and **Show access cert** for the required user.
+To download the new certificate, 
+
+1. Access the `Aiven Console <https://console.aiven.io/>`_
+2. Select the Aiven for Apache Kafka service for which you want to download the new certificate.
+3. Click on the **Users** from the sidebar.
+4. Select the required user and click **Show access key** and **Show access cert** to download the new certificate.
 
 .. image:: /images/products/kafka/new-ssl-cert-download.png
    :alt: Apache Kafka service user SSL certificate and access key download
@@ -33,10 +38,10 @@ You can download the new certificate from the `Aiven Console <https://console.ai
 
     You can download the renewed SSL certificate and key using the :ref:`dedicated Aiven CLI command <avn_service_user_creds_download>` ``avn service user-creds-download``
 
-Acknowledge the usage of the new SSL certificate
+Acknowledge new SSL certificate usage
 ------------------------------------------------
 
-To stop receiving periodic notifications about certificate expiration, you need to acknowledge that the new certificate has been taken into use.
+To stop receiving notifications about certificate expiration, you must confirm that the new certificate is in use.
 
 To acknowledge the new SSL certificate with the `Aiven Console <https://console.aiven.io/>`_:
 


### PR DESCRIPTION
# What changed, and why it matters

Updated Aiven for Apache Kafka® SSL certificate renewal documentation to clarify the 820-day validity, streamline the download process, and refine acknowledgment instructions. 

Addresses: [DOC-715](https://aiven.atlassian.net/browse/DOC-715)


[DOC-715]: https://aiven.atlassian.net/browse/DOC-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ