### PR TITLE
Add Pro Platform docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -270,3 +270,14 @@ For features that are in the early availability stage and can be enabled in the 
 
     .. important:: 
         {feature name} is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use it, :doc:`enable the feature preview </docs/platform/howto/feature-preview.html>` in your user profile.
+
+
+Pro Platform feature note template
+'''''''''''''''''''''''''''''''''''
+
+For features that are only available on the Pro Platform, add the following admonition directly under the article title:
+
+.. code::
+
+    .. important:: 
+        {feature name} is available on the :doc:`Pro Platform </docs/platform/concepts/pro-platform>`.

--- a/_toc.yml
+++ b/_toc.yml
@@ -18,13 +18,13 @@ entries:
       - file: docs/platform/howto/billing-google-cloud-platform-marketplace-subscription
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
-    - file: docs/platform/howto/pro-platform
     - file: docs/platform/concepts/beta_services
     - file: docs/platform/howto/feature-preview
 
   # -------- ORGANIZATIONS, UNITS, PROJECTS --------
   - file: docs/platform/howto/list-account
     entries:
+    - file: docs/platform/howto/pro-platform
     - file: docs/platform/concepts/projects_accounts_access
     - file: docs/tools/aiven-console/howto/create-accounts
     - file: docs/platform/howto/manage-organizations

--- a/_toc.yml
+++ b/_toc.yml
@@ -18,13 +18,13 @@ entries:
       - file: docs/platform/howto/billing-google-cloud-platform-marketplace-subscription
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
+    - file: docs/platform/howto/pro-platform
     - file: docs/platform/concepts/beta_services
     - file: docs/platform/howto/feature-preview
 
   # -------- ORGANIZATIONS, UNITS, PROJECTS --------
   - file: docs/platform/howto/list-account
     entries:
-    - file: docs/platform/howto/pro-platform
     - file: docs/platform/concepts/projects_accounts_access
     - file: docs/tools/aiven-console/howto/create-accounts
     - file: docs/platform/howto/manage-organizations

--- a/_toc.yml
+++ b/_toc.yml
@@ -18,6 +18,7 @@ entries:
       - file: docs/platform/howto/billing-google-cloud-platform-marketplace-subscription
         title: Set up Google Cloud Marketplace subscriptions
     - file: docs/tools/aiven-console
+    - file: docs/platform/howto/pro-platform
     - file: docs/platform/concepts/beta_services
     - file: docs/platform/howto/feature-preview
 

--- a/docs/platform/howto/pro-platform.rst
+++ b/docs/platform/howto/pro-platform.rst
@@ -1,0 +1,34 @@
+Pro Platform
+=============
+
+Pro Platform gives enterprise organizations added capabilities for implementing security, resilience, reliability, and cost-efficiency strategies for their data infrastructure. Pro Platform features are available across disaster recovery, security and compliance, advanced networking, and user lifecycle management.
+
+To use Pro features, enable Pro Platform for your organization.  
+
+
+Enable Pro Platform for an organization
+----------------------------------------
+
+#. Click the user information icon and select **Admin**.
+
+#. Click **Pro Platform**.
+
+#. Select a billing group for the Pro Platform charges. 
+
+#. Click **Enable Pro Platform**.
+
+
+Disable Pro Platform
+---------------------
+
+To disable Pro Platform for an organization, you should first disable any Pro features being used in your services.
+
+#. Click the user information icon and select **Admin**.
+
+#. Click **Pro Platform**.
+
+#. Click **Disable Pro Platform**.
+
+#. To confirm, click **Disable Pro Platform**. 
+
+You can enable Pro Platform again at any time.

--- a/docs/platform/howto/pro-platform.rst
+++ b/docs/platform/howto/pro-platform.rst
@@ -6,10 +6,12 @@ Pro Platform gives enterprise organizations added capabilities for implementing 
 To use Pro features, enable Pro Platform for your organization.  
 
 
-Enable Pro Platform for an organization
-----------------------------------------
+Enable Pro Platform 
+--------------------
 
-#. Click the user information icon and select **Admin**.
+To enable Pro Platform for an organization:
+
+#. In the organization, click **Admin**.
 
 #. Click **Pro Platform**.
 
@@ -23,11 +25,11 @@ Disable Pro Platform
 
 To disable Pro Platform for an organization, you should first disable any Pro features being used in your services.
 
-#. Click the user information icon and select **Admin**.
+#. In the organization, click **Admin**.
 
 #. Click **Pro Platform**.
 
-#. Click **Disable Pro Platform**.
+#. Open the actions mentu and select **Disable Pro Platform**.
 
 #. To confirm, click **Disable Pro Platform**. 
 


### PR DESCRIPTION
# What changed, and why it matters
Add instructions for Pro Platform and template annotation to be used on pages about Pro features.

