### PR TITLE
Update kafka lag predictor prometheus metric names

### DIFF
--- a/docs/products/kafka/howto/enabled-consumer-lag-predictor.rst
+++ b/docs/products/kafka/howto/enabled-consumer-lag-predictor.rst
@@ -102,10 +102,10 @@ After enabling the consumer lag predictor, you can use Prometheus to access and 
    * - Metric
      - Type
      - Description
-   * - ``kafka_lag_predictor_topic_produced_records``
+   * - ``kafka_lag_predictor_topic_produced_records_total``
      - Counter
      - Represents the total count of records produced.
-   * - ``kafka_lag_predictor_group_consumed_records``
+   * - ``kafka_lag_predictor_group_consumed_records_total``
      - Counter
      - Represents the total count of records consumed.
    * - ``kafka_lag_predictor_group_lag_predicted_seconds``


### PR DESCRIPTION
These metric names were incorrect as the suffix _total gets added to Counter type metrics

[SRE-7935]

# What changed, and why it matters




[SRE-7935]: https://aiven.atlassian.net/browse/SRE-7935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ