### PR TITLE
Update managed users and domains articles for GA release

### DIFF
--- a/docs/platform/concepts/managed-users.rst
+++ b/docs/platform/concepts/managed-users.rst
@@ -1,13 +1,10 @@
 Managed users 
 ==============
 
-.. important:: 
-    Managed users is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use it, :doc:`enable the feature preview </docs/platform/howto/feature-preview>` in your user profile.
-
 The managed users feature provides a centralized way of managing all of your organization's users, including editing their profiles, resetting passwords, and :doc:`setting authentication policies </docs/platform/howto/set-authentication-policies>`.
 
 When you :doc:`verify a domain </docs/platform/howto/manage-domains>`, existing organization users automatically become managed users. 
 
-A managed user cannot create new organizations unless they are a super admin of the organization that they are managed by. 
+A managed user cannot create new organizations unless they are a :doc:`super admin </docs/platform/howto/make-super-admin>` of the organization that they are managed by. 
 
 To see a list of all users in your organization go to **Admin** and select **Users**.

--- a/docs/platform/howto/manage-domains.rst
+++ b/docs/platform/howto/manage-domains.rst
@@ -1,9 +1,6 @@
 Manage domains
 ===============
 
-.. important:: 
-    The domains feature is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use it, enable the managed users :doc:`feature preview </docs/platform/howto/feature-preview>` in your user profile.
-
 Verified domains let you manage users in your organization.
 
 There are two ways you can verify a domain:
@@ -11,8 +8,8 @@ There are two ways you can verify a domain:
 * by adding a DNS TXT record to the domain (recommended)
 * by uploading an HTML file to your website
 
-.. note::
-    After adding a domain, your organization users will automatically become managed users. 
+After adding a domain, organization users automatically become :doc:`managed users </docs/platform/concepts/managed-users>`. 
+
 
 Add a domain using a DNS TXT record
 -------------------------------------


### PR DESCRIPTION
# What changed, and why it matters
Removed the EA note from the managed users and domains articles for the upcoming GA release.

