### PR TITLE
Added Adv config file for Dragonfly

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -910,6 +910,12 @@ entries:
           - file: docs/products/dragonfly/howto/migrate-ext-redis-df-console
             title: Migrate external Redis
 
+      - file: docs/products/dragonfly/reference
+        title: Reference
+        entries:
+        - file: docs/products/dragonfly/reference/advanced-params
+          title: Advanced parameters
+
 
 
 

--- a/docs/products/dragonfly/reference.rst
+++ b/docs/products/dragonfly/reference.rst
@@ -1,0 +1,6 @@
+Aiven for Dragonfly® reference
+=====================================
+
+Additional reference information for Aiven for Dragonfly®:
+
+.. tableofcontents::

--- a/docs/products/dragonfly/reference/advanced-params.rst
+++ b/docs/products/dragonfly/reference/advanced-params.rst
@@ -1,0 +1,6 @@
+Advanced parameters for Aiven for Dragonfly®
+===============================================
+
+Below you can find a summary of every configuration option available for Aiven for Dragonfly® service:
+
+.. include:: /includes/config-dragonfly.rst


### PR DESCRIPTION
# What changed, and why it matters

Added advanced-params.rst file, previously absent, to facilitate the automatic update of Advanced parameters. This addition is anticipated to resolve the ongoing build failure issues, as detailed here: [Build Failure Report](https://github.com/aiven/devportal/actions/runs/7537643150).