### PR TITLE
Updated with info to enable feature preview

### DIFF
--- a/docs/products/kafka/concepts/kafka-tiered-storage.rst
+++ b/docs/products/kafka/concepts/kafka-tiered-storage.rst
@@ -5,8 +5,9 @@ Tiered storage in Aiven for Apache Kafka® enables more effective data managemen
 
 .. important:: 
 
-    Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
-
+    Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+    After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
+    
 
 .. note:: 
 

--- a/docs/products/kafka/concepts/tiered-storage-how-it-works.rst
+++ b/docs/products/kafka/concepts/tiered-storage-how-it-works.rst
@@ -3,7 +3,8 @@ How tiered storage works in Aiven for Apache Kafka®
 
 .. important:: 
   
-  Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
+  Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+  After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
 
 Aiven for Apache Kafka® tiered storage is a feature that optimizes data management across two distinct storage tiers:
 

--- a/docs/products/kafka/howto/configure-topic-tiered-storage.rst
+++ b/docs/products/kafka/howto/configure-topic-tiered-storage.rst
@@ -3,7 +3,8 @@ Enable and configure tiered storage for topics
 
 .. important:: 
     
-    Aiven for Apache Kafka® tiered storage is a :doc:`early availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
+    Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+    After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
 
 
 Aiven for Apache Kafka® allows you to easily configure tiered storage and set retention policies for individual topics. Learn how to configure tiered storage for individual topics and set local retention policies step by step.

--- a/docs/products/kafka/howto/enable-kafka-tiered-storage.rst
+++ b/docs/products/kafka/howto/enable-kafka-tiered-storage.rst
@@ -3,7 +3,8 @@ Enable tiered storage for Aiven for Apache Kafka®
 
 .. important:: 
     
-   Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
+   Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+   After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
 
 Tiered storage significantly improves the storage efficiency of your Aiven for Apache Kafka® service. You can enable this feature for your service using either the `Aiven console <https://console.aiven.io/>`_ or the :doc:`Aiven CLI </docs/tools/cli>`. 
 

--- a/docs/products/kafka/howto/kafka-tiered-storage-get-started.rst
+++ b/docs/products/kafka/howto/kafka-tiered-storage-get-started.rst
@@ -4,7 +4,8 @@ Get started with tiered storage for Aiven for Apache Kafka®
 
 .. important:: 
     
-    Aiven for Apache Kafka® tiered storage is a :doc:`limited availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
+    Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+    After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
 
 Aiven for Apache Kafka®'s tiered storage optimizes resources by keeping recent data—typically the most accessed—on faster local disks. As data becomes less active, it's transferred to more economical, slower storage, balancing performance with cost efficiency.
 

--- a/docs/products/kafka/howto/tiered-storage-overview-page.rst
+++ b/docs/products/kafka/howto/tiered-storage-overview-page.rst
@@ -5,7 +5,8 @@ Aiven for Apache Kafka® offers a comprehensive overview of tiered storage, allo
 
 .. important:: 
    
-   Aiven for Apache Kafka® tiered storage is a :doc:`early availability feature </docs/platform/concepts/beta_services>`. If you're interested in trying out this feature, contact the sales team at sales@Aiven.io.
+   Aiven for Apache Kafka® tiered storage is an :doc:`early availability feature </docs/platform/concepts/beta_services>`. To use this feature, contact our sales team at `sales@Aiven.io <mailto:sales@Aiven.io>`_ to activate tiered storage for your account.
+   After activation, you must enable the feature from the :doc:`feature preview page </docs/platform/howto/feature-preview>` in your user profile to start using tiered storage.
 
 
 Access tiered storage overview


### PR DESCRIPTION
# What changed, and why it matters

To use tiered storage in Aiven for Apache Kafka as an early access feature, it must be enabled in the user's profile under the 'feature preview' section to start using it.